### PR TITLE
BAVL-67 adding config for HMPPS auth integration.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,14 @@ configurations {
 }
 
 dependencies {
+  // Spring boot dependencies
   implementation("org.springframework.boot:spring-boot-starter-webflux")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:0.2.4")
+
+  // Test dependencies
+  testImplementation("io.jsonwebtoken:jjwt-impl:0.12.5")
+  testImplementation("io.jsonwebtoken:jjwt-jackson:0.12.5")
+  testImplementation("org.wiremock:wiremock-standalone:3.5.3")
 }
 
 kotlin {

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -9,6 +9,7 @@ generic-service:
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
+    API_BASE_URL_HMPPS_AUTH: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -9,6 +9,7 @@ generic-service:
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
+    API_BASE_URL_HMPPS_AUTH: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -5,6 +5,9 @@ generic-service:
   ingress:
     host: hmpps-book-a-video-link-api.hmpps.service.justice.gov.uk
 
+  env:
+    API_BASE_URL_HMPPS_AUTH: "https://sign-in.hmpps.service.justice.gov.uk/auth"
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,19 +13,14 @@ spring:
   jpa:
     show-sql: true
 
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          public-key-location: classpath:local-public-key.pub
-
 system:
   client:
     id: ${SYSTEM_CLIENT_ID}
     secret: ${SYSTEM_CLIENT_SECRET}
 
 # Container-provider local auth server
-hmpps:
-  auth:
-    url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+api:
+  base:
+    url:
+      hmpps-auth: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,17 @@ spring:
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false
 
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${api.base.url.hmpps-auth}/.well-known/jwks.json
+
+    client:
+      provider:
+        hmpps-auth:
+          token-uri: ${api.base.url.hmpps-auth}/oauth/token
+
 server:
   port: 8080
   servlet:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
@@ -1,16 +1,32 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration
 
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.HmppsAuthApiExtension
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
+@ExtendWith(HmppsAuthApiExtension::class)
 abstract class IntegrationTestBase {
 
-  @Suppress("SpringJavaInjectionPointsAutowiringInspection")
   @Autowired
   lateinit var webTestClient: WebTestClient
+
+  @Autowired
+  protected lateinit var jwtAuthHelper: JwtAuthHelper
+
+  internal fun setAuthorisation(
+    user: String = "AUTH_ADM",
+    roles: List<String> = listOf(),
+    scopes: List<String> = listOf("read"),
+  ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisation(user, roles, scopes)
+
+  protected fun stubPingWithResponse(status: Int) {
+    HmppsAuthApiExtension.hmppsAuth.stubHealthPing(status)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/JwtAuthHelper.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration
+
+import io.jsonwebtoken.Jwts
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.http.HttpHeaders
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.stereotype.Component
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPublicKey
+import java.time.Duration
+import java.util.Date
+import java.util.UUID
+
+@Component
+class JwtAuthHelper {
+  private val keyPair: KeyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+
+  @Bean
+  @Primary
+  fun jwtDecoder(): JwtDecoder = NimbusJwtDecoder.withPublicKey(keyPair.public as RSAPublicKey).build()
+
+  fun setAuthorisation(
+    user: String = "AUTH_ADM",
+    roles: List<String> = listOf(),
+    scopes: List<String> = listOf(),
+  ): (HttpHeaders) -> Unit {
+    val token = createJwt(
+      subject = user,
+      scope = scopes,
+      expiryTime = Duration.ofHours(1L),
+      roles = roles,
+    )
+    return { it.set(HttpHeaders.AUTHORIZATION, "Bearer $token") }
+  }
+
+  internal fun createJwt(
+    subject: String?,
+    scope: List<String>? = listOf(),
+    roles: List<String>? = listOf(),
+    expiryTime: Duration = Duration.ofHours(1),
+    jwtId: String = UUID.randomUUID().toString(),
+  ): String =
+    mutableMapOf<String, Any>()
+      .also { subject?.let { subject -> it["user_name"] = subject } }
+      .also { it["client_id"] = "test-app" }
+      .also { roles?.let { roles -> it["authorities"] = roles } }
+      .also { scope?.let { scope -> it["scope"] = scope } }
+      .let {
+        Jwts.builder()
+          .id(jwtId)
+          .subject(subject)
+          .claims(it.toMap())
+          .expiration(Date(System.currentTimeMillis() + expiryTime.toMillis()))
+          .signWith(keyPair.private, Jwts.SIG.RS256)
+          .compact()
+      }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/NotFoundTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/NotFoundTest.kt
@@ -7,6 +7,7 @@ class NotFoundTest : IntegrationTestBase() {
   @Test
   fun `Resources that aren't found should return 404 - test of the exception handler`() {
     webTestClient.get().uri("/some-url-not-found")
+      .headers(setAuthorisation())
       .exchange()
       .expectStatus().isNotFound
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/HmppsAuthMockServer.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.http.HttpHeader
+import com.github.tomakehurst.wiremock.http.HttpHeaders
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class HmppsAuthMockServer : WireMockServer(8090) {
+  fun stubHealthPing(status: Int) {
+    stubFor(
+      get("/auth/health/ping").willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody(if (status == 200) """{"status":"UP"}""" else """{"status":"DOWN"}""")
+          .withStatus(status),
+      ),
+    )
+  }
+
+  fun stubGrantToken() {
+    stubFor(
+      post(urlEqualTo("/auth/oauth/token"))
+        .willReturn(
+          aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(
+              """
+              {
+                 "access_token": "ABCDE", 
+                 "token_type": "bearer"
+              }
+              """.trimIndent(),
+            ),
+        ),
+    )
+  }
+}
+
+class HmppsAuthApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
+  companion object {
+    @JvmField
+    val hmppsAuth = HmppsAuthMockServer()
+  }
+
+  override fun beforeAll(context: ExtensionContext) {
+    hmppsAuth.start()
+    hmppsAuth.stubGrantToken()
+  }
+
+  override fun beforeEach(context: ExtensionContext) {
+    hmppsAuth.resetAll()
+    hmppsAuth.stubGrantToken()
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    hmppsAuth.stop()
+  }
+}


### PR DESCRIPTION
This change includes the basics for getting integration with HMPPS auth using a common shared HMPPS Kotlin library.  

This takes away a lot of the boiler plate code we would otherwise have to include.  It also allows for consistency moving forwards should things change i.e. the share component can pick up this responsibility.

If push comes to shove we can use our own instead but it shouldn't come to that if we use the common one.