### PR TITLE
BAVL-67 adding health check for HMPPS auth.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/WebClientConfiguration.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.hmpps.kotlin.auth.healthWebClient
+import java.time.Duration
+
+@Configuration
+class WebClientConfiguration(
+  @Value("\${api.base.url.hmpps-auth}") val hmppsAuthBaseUri: String,
+  @Value("\${api.health-timeout:2s}") val healthTimeout: Duration,
+) {
+  @Bean
+  fun hmppsAuthHealthWebClient(builder: WebClient.Builder) = builder.healthWebClient(hmppsAuthBaseUri, healthTimeout)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/health/HmppsAuthHealthPingCheck.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/health/HmppsAuthHealthPingCheck.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.health
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.hmpps.kotlin.health.HealthPingCheck
+
+@Component("hmppsAuth")
+class HmppsAuthHealthPingCheck(@Qualifier("hmppsAuthHealthWebClient") webClient: WebClient) : HealthPingCheck(webClient)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,3 +4,8 @@ server:
 management.endpoint:
   health.cache.time-to-live: 0
   info.cache.time-to-live: 0
+
+api:
+  base:
+    url:
+      hmpps-auth: http://localhost:8090/auth


### PR DESCRIPTION
Adds health check for recently added HMPPS auth integration.

Any services we rely on should be added as health checks going forwards.