### PR TITLE
BAVL-71 adding the necessary client for making calls to the prisoner search API.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,8 +65,8 @@ tasks {
 val configValues = mapOf(
   "dateLibrary" to "java8-localdatetime",
   "serializationLibrary" to "jackson",
-  "useBeanValidation" to "false",
-  "enumPropertyNaming" to "UPPERCASE",
+  "enumPropertyNaming" to "original",
+  "useSpringBoot3" to "true",
 )
 
 val buildDirectory: Directory = layout.buildDirectory.get()

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,6 +11,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_HMPPS_AUTH: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     API_BASE_URL_LOCATIONS_INSIDE_PRISON: "https://locations-inside-prison-api-dev.hmpps.service.justice.gov.uk"
+    API_BASE_URL_PRISONER_SEARCH: https://prisoner-search-dev.prison.service.justice.gov.uk
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -11,6 +11,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_HMPPS_AUTH: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     API_BASE_URL_LOCATIONS_INSIDE_PRISON: "https://locations-inside-prison-api-preprod.hmpps.service.justice.gov.uk"
+    API_BASE_URL_PRISONER_SEARCH: https://prisoner-search-preprod.prison.service.justice.gov.uk
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -8,6 +8,7 @@ generic-service:
   env:
     API_BASE_URL_HMPPS_AUTH: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     API_BASE_URL_LOCATIONS_INSIDE_PRISON: "https://locations-inside-prison-api.hmpps.service.justice.gov.uk"
+    API_BASE_URL_PRISONER_SEARCH: https://prisoner-search.prison.service.justice.gov.uk
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonersearch/PrisonerSearchClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonersearch/PrisonerSearchClient.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch
+
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Mono
+
+class PrisonerSearchClient(private val prisonerSearchApiWebClient: WebClient) {
+
+  fun getPrisoner(prisonerNumber: String): Prisoner? =
+    prisonerSearchApiWebClient
+      .get()
+      .uri("/prisoner/{prisonerNumber}", prisonerNumber)
+      .retrieve()
+      .bodyToMono(Prisoner::class.java)
+      .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
+      .block()
+}
+
+// TODO add additional fields as and when needed e.g. ACTIVE/NOT ACTIVE in prison
+data class Prisoner(
+  val prisonerNumber: String,
+  val prisonId: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/WebClientConfiguration.kt
@@ -13,6 +13,7 @@ import java.time.Duration
 class WebClientConfiguration(
   @Value("\${api.base.url.locations-inside-prison}") val locationsInsidePrisonApiBaseUri: String,
   @Value("\${api.base.url.hmpps-auth}") val hmppsAuthBaseUri: String,
+  @Value("\${api.base.url.prisoner-search}") val prisonerSearchBaseUri: String,
   @Value("\${api.health-timeout:2s}") val healthTimeout: Duration,
   @Value("\${api.timeout:30s}") val timeout: Duration,
   private val builder: WebClient.Builder,
@@ -26,4 +27,11 @@ class WebClientConfiguration(
   @Bean
   fun locationsInsidePrisonApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager) =
     builder.authorisedWebClient(authorizedClientManager, "locations-inside-prison", locationsInsidePrisonApiBaseUri, timeout)
+
+  @Bean
+  fun prisonerSearchApiHealthWebClient() = builder.healthWebClient(prisonerSearchBaseUri, healthTimeout)
+
+  @Bean
+  fun prisonerSearchApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager) =
+    builder.authorisedWebClient(authorizedClientManager, "prisoner-search", prisonerSearchBaseUri, timeout)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/health/HealthPingCheck.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/health/HealthPingCheck.kt
@@ -12,3 +12,6 @@ class HmppsAuthHealthPingCheck(@Qualifier("hmppsAuthHealthWebClient") webClient:
 class LocationsInsidePrisonApiHealthPingCheck(
   @Qualifier("locationsInsidePrisonApiHealthWebClient") webClient: WebClient,
 ) : HealthPingCheck(webClient)
+
+@Component("prisonerSearchApi")
+class PrisonerSearchApiHealthPingCheck(@Qualifier("prisonerSearchApiHealthWebClient") webClient: WebClient) : HealthPingCheck(webClient)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -27,3 +27,4 @@ api:
     url:
       hmpps-auth: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
       locations-inside-prison: https://locations-inside-prison-api-dev.hmpps.service.justice.gov.uk
+      prisoner-search: https://prisoner-search-dev.prison.service.justice.gov.uk

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,12 @@ spring:
             client-secret: ${system.client.secret}
             authorization-grant-type: client_credentials
             scope: read
+          prisoner-search:
+            provider: hmpps-auth
+            client-id: ${system.client.id}
+            client-secret: ${system.client.secret}
+            authorization-grant-type: client_credentials
+            scope: read
         provider:
           hmpps-auth:
             token-uri: ${api.base.url.hmpps-auth}/oauth/token

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonersearch/PrisonerSearchClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonersearch/PrisonerSearchClientTest.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.health.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.PrisonerSearchApiMockServer
+
+class PrisonerSearchClientTest {
+
+  private val server = PrisonerSearchApiMockServer().also { it.start() }
+  private val client = PrisonerSearchClient(WebClient.create("http://localhost:${server.port()}"))
+
+  @Test
+  fun `should get matching prisoner`() {
+    server.stubGetPrisoner("123456", "RSI")
+
+    client.getPrisoner("123456") isEqualTo Prisoner("123456", "RSI")
+  }
+
+  @AfterEach
+  fun after() {
+    server.stop()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/health/HealthCheckTest.kt
@@ -21,6 +21,10 @@ class HealthCheckTest : IntegrationTestBase() {
       .jsonPath("status").isEqualTo("UP")
       .jsonPath("components.hmppsAuth.status").isEqualTo("UP")
       .jsonPath("components.locationsInsidePrisonApi.status").isEqualTo("UP")
+      .jsonPath("components.prisonerSearchApi.status").isEqualTo("UP")
+      .jsonPath("components.db.status").isEqualTo("UP")
+      // If we were using postgres test container this would say PostgreSQL
+      .jsonPath("components.db.details.database").isEqualTo("H2")
   }
 
   @Test
@@ -35,6 +39,7 @@ class HealthCheckTest : IntegrationTestBase() {
       .jsonPath("status").isEqualTo("DOWN")
       .jsonPath("components.hmppsAuth.status").isEqualTo("DOWN")
       .jsonPath("components.locationsInsidePrisonApi.status").isEqualTo("DOWN")
+      .jsonPath("components.prisonerSearchApi.status").isEqualTo("DOWN")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
@@ -9,10 +9,11 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.LocationsInsidePrisonApiExtension
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.PrisonerSearchApiExtension
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
-@ExtendWith(LocationsInsidePrisonApiExtension::class, HmppsAuthApiExtension::class)
+@ExtendWith(LocationsInsidePrisonApiExtension::class, HmppsAuthApiExtension::class, PrisonerSearchApiExtension::class)
 abstract class IntegrationTestBase {
 
   @Autowired
@@ -30,5 +31,6 @@ abstract class IntegrationTestBase {
   protected fun stubPingWithResponse(status: Int) {
     HmppsAuthApiExtension.server.stubHealthPing(status)
     LocationsInsidePrisonApiExtension.server.stubHealthPing(status)
+    PrisonerSearchApiExtension.server.stubHealthPing(status)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/HmppsAuthMockServer.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock
 
-import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
-import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.http.HttpHeader
@@ -12,17 +10,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 
-class HmppsAuthMockServer : WireMockServer(8090) {
-  fun stubHealthPing(status: Int) {
-    stubFor(
-      get("/auth/health/ping").willReturn(
-        aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withBody(if (status == 200) """{"status":"UP"}""" else """{"status":"DOWN"}""")
-          .withStatus(status),
-      ),
-    )
-  }
+class HmppsAuthMockServer : MockServer(8090, "/auth") {
 
   fun stubGrantToken() {
     stubFor(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/LocationsInsidePrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/LocationsInsidePrisonApiMockServer.kt
@@ -1,9 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import org.junit.jupiter.api.extension.AfterAllCallback
@@ -13,20 +9,7 @@ import org.junit.jupiter.api.extension.ExtensionContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location
 import java.util.UUID
 
-class LocationsInsidePrisonApiMockServer : WireMockServer(8091) {
-
-  val mapper: ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
-
-  fun stubHealthPing(status: Int) {
-    stubFor(
-      get("/health/ping").willReturn(
-        aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withBody(if (status == 200) """{"status":"UP"}""" else """{"status":"DOWN"}""")
-          .withStatus(status),
-      ),
-    )
-  }
+class LocationsInsidePrisonApiMockServer : MockServer(8091) {
 
   fun stubGetLocation(locationId: UUID = UUID.randomUUID(), prisonId: String = "MDI") {
     stubFor(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/MockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/MockServer.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+
+/**
+ * It is important you match the servers port number with that of the port number in the application-test.yml file.
+ */
+abstract class MockServer(port: Int, private val urlPrefix: String = "") : WireMockServer(port) {
+
+  protected val mapper: ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+  fun stubHealthPing(status: Int) {
+    stubFor(
+      WireMock.get("$urlPrefix/health/ping").willReturn(
+        WireMock.aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody(if (status == 200) """{"status":"UP"}""" else """{"status":"DOWN"}""")
+          .withStatus(status),
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonerSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonerSearchApiMockServer.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.Prisoner
+
+class PrisonerSearchApiMockServer : MockServer(8092) {
+
+  fun stubGetPrisoner(prisonNumber: String, prisonId: String = "MDI") {
+    stubFor(
+      get("/prisoner/$prisonNumber")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              mapper.writeValueAsString(
+                Prisoner(
+                  prisonerNumber = prisonNumber,
+                  prisonId = prisonId,
+                ),
+              ),
+            )
+            .withStatus(200),
+        ),
+    )
+  }
+}
+
+class PrisonerSearchApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
+  companion object {
+    @JvmField
+    val server = PrisonerSearchApiMockServer()
+  }
+
+  override fun beforeAll(context: ExtensionContext) {
+    server.start()
+  }
+
+  override fun beforeEach(context: ExtensionContext) {
+    server.resetAll()
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    server.stop()
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -27,3 +27,4 @@ api:
     url:
       hmpps-auth: http://localhost:8090/auth
       locations-inside-prison: http://localhost:8091
+      prisoner-search: http://localhost:8092


### PR DESCRIPTION
This change will allow our service to make calls to the external prisoner search API for checking the details of a prisoner related to video link bookings.

Note the original intention of this change was to generate the types for the prisoner search API.  However open API seemed to have an issue (bug) with generating it and I don't want to spend too long trying to see if there is a solution at this point in time.