### PR TITLE
BAVL-14 this change adds a simple implementation for the Gov Notify email service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,59 @@
 # hmpps-book-a-video-link-api
 [![repo standards badge](https://img.shields.io/badge/dynamic/json?color=blue&style=flat&logo=github&label=MoJ%20Compliant&query=%24.result&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fhmpps-book-a-video-link-api)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-github-repositories.html#hmpps-book-a-video-link-api "Link to report")
-[![CircleCI](https://circleci.com/gh/ministryofjustice/hmpps-book-a-video-link-api/tree/main.svg?style=svg)](https://circleci.com/gh/ministryofjustice/hmpps-book-a-video-link-api)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/ministryofjustice/hmpps-book-a-video-link-api/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/ministryofjustice/hmpps-activities-management-api/tree/main)
 [![Docker Repository on Quay](https://quay.io/repository/hmpps/hmpps-book-a-video-link-api/status "Docker Repository on Quay")](https://quay.io/repository/hmpps/hmpps-book-a-video-link-api)
-[![API docs](https://img.shields.io/badge/API_docs_-view-85EA2D.svg?logo=swagger)](https://hmpps-book-a-video-link-api-dev.hmpps.service.justice.gov.uk/webjars/swagger-ui/index.html?configUrl=/v3/api-docs)
+[![API docs](https://img.shields.io/badge/API_docs-view-85EA2D.svg?logo=swagger)](https://book-a-video-link-dev.prison.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config)
 
 API to support the front end service allowing court and probation users to book and manage video link hearings/appointments with people in prison.
 
-# TODO add details on building and running the project ...
+## Building the project
+
+Tools required:
+
+* JDK v21+
+* Kotlin (Intellij)
+* docker
+* docker-compose
+
+Useful tools but not essential:
+
+* KUBECTL not essential for building the project but will be needed for other tasks. Can be installed with `brew`.
+* [k9s](https://k9scli.io/) a terminal based UI to interact with your Kubernetes clusters. Can be installed with `brew`.
+* [jq](https://jqlang.github.io/jq/) a lightweight and flexible command-line JSON processor. Can be installed with `brew`.
+
+## Install gradle and build the project
+
+```
+./gradlew
+```
+
+```
+./gradlew clean build
+```
+
+## Running the service
+
+There are two key environment variables needed to run the service. The system client id and secret used to retrieve the OAuth 2.0 access token needed for service to service API calls can be set as local environment variables.
+This allows API calls made from this service that do not use the caller's token to successfully authenticate.
+
+Add the following to a local `.env` file in the root folder of this project (_you can extract the credentials from the dev k8s project namespace_).
+
+N.B. you must escape any '$' characters with '\\$'
+
+```
+export SYSTEM_CLIENT_ID="<system.client.id>"
+export SYSTEM_CLIENT_SECRET="<system.client.secret>"
+```
+
+Start up the docker dependencies using the docker-compose file in the `hmpps-activities-management-api` service.
+
+```
+docker-compose up --remove-orphans
+```
+
+There is a script to help, which sets local profiles, port and DB connection properties to the
+values required.
+
+```
+./run-local.sh
+```

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
@@ -16,15 +16,15 @@ import uk.gov.service.notify.NotificationClient
 @Configuration
 class EmailConfiguration(
   @Value("\${notify.api.key:}") private val apiKey: String,
-  @Value("\${notify.templates.prison.transferred:}") private val offenderTransferredPrisonEmailTemplateId: String,
-  @Value("\${notify.templates.court.transferred:}") private val offenderTransferredCourtEmailTemplateId: String,
-  @Value("\${notify.templates.prison.transferred-but-no-court-email:}") private val offenderTransferredPrisonEmailButNoCourtEmailTemplateId: String,
-  @Value("\${notify.templates.prison.released:}") private val offenderReleasedPrisonEmailTemplateId: String,
-  @Value("\${notify.templates.court.released:}") private val offenderReleasedCourtEmailTemplateId: String,
-  @Value("\${notify.templates.prison.released-but-no-court-email:}") private val offenderReleasedPrisonEmailButNoCourtEmailTemplateId: String,
-  @Value("\${notify.templates.appointment-canceled.prison:}") private val appointmentCanceledPrisonEmailTemplateId: String,
-  @Value("\${notify.templates.appointment-canceled.court:}") private val appointmentCanceledCourtEmailTemplateId: String,
-  @Value("\${notify.templates.appointment-canceled.no-court-email:}") private val appointmentCanceledPrisonEmailButNoCourtEmailTemplateId: String,
+  @Value("\${notify.templates.appointment-cancelled-court:}") private val appointmentCancelledCourt: String,
+  @Value("\${notify.templates.appointment-cancelled-no-court:}") private val appointmentCancelledPrisonNoCourt: String,
+  @Value("\${notify.templates.appointment-cancelled-prison:}") private val appointmentCancelledPrison: String,
+  @Value("\${notify.templates.court.released:}") private val offenderReleasedCourt: String,
+  @Value("\${notify.templates.court.transferred:}") private val offenderTransferredCourt: String,
+  @Value("\${notify.templates.prison.released:}") private val offenderReleasedPrison: String,
+  @Value("\${notify.templates.prison.released-no-court:}") private val offenderReleasedPrisonNoCourt: String,
+  @Value("\${notify.templates.prison.transferred:}") private val offenderTransferredPrison: String,
+  @Value("\${notify.templates.prison.transferred-no-court:}") private val offenderTransferredPrisonNoCourt: String,
 ) {
 
   companion object {
@@ -40,31 +40,35 @@ class EmailConfiguration(
     }
 
   private fun emailTemplates() = EmailTemplates(
-    offenderTransferredPrisonEmailTemplateId = offenderTransferredPrisonEmailTemplateId,
-    offenderTransferredCourtEmailTemplateId = offenderTransferredCourtEmailTemplateId,
-    offenderTransferredPrisonEmailButNoCourtEmailTemplateId = offenderTransferredPrisonEmailButNoCourtEmailTemplateId,
-    offenderReleasedPrisonEmailTemplateId = offenderReleasedPrisonEmailTemplateId,
-    offenderReleasedCourtEmailTemplateId = offenderReleasedCourtEmailTemplateId,
-    offenderReleasedPrisonEmailButNoCourtEmailTemplateId = offenderReleasedPrisonEmailButNoCourtEmailTemplateId,
-    appointmentCanceledPrisonEmailTemplateId = appointmentCanceledPrisonEmailTemplateId,
-    appointmentCanceledCourtEmailTemplateId = appointmentCanceledCourtEmailTemplateId,
-    appointmentCanceledPrisonEmailButNoCourtEmailTemplateId = appointmentCanceledPrisonEmailButNoCourtEmailTemplateId,
+    appointmentCancelledCourt = appointmentCancelledCourt,
+    appointmentCancelledPrison = appointmentCancelledPrison,
+    appointmentCancelledPrisonNoCourt = appointmentCancelledPrisonNoCourt,
+    offenderReleasedCourt = offenderReleasedCourt,
+    offenderReleasedPrison = offenderReleasedPrison,
+    offenderReleasedPrisonNoCourt = offenderReleasedPrisonNoCourt,
+    offenderTransferredCourt = offenderTransferredCourt,
+    offenderTransferredPrison = offenderTransferredPrison,
+    offenderTransferredPrisonNoCourt = offenderTransferredPrisonNoCourt,
   )
 }
 
 fun interface EmailService {
-  // TODO: the actual interface for the sendEmail yet to be decided.
-  fun sendEmail()
+  fun send(email: Email)
 }
 
-internal data class EmailTemplates(
-  val offenderTransferredPrisonEmailTemplateId: String,
-  val offenderTransferredCourtEmailTemplateId: String,
-  val offenderTransferredPrisonEmailButNoCourtEmailTemplateId: String,
-  val offenderReleasedPrisonEmailTemplateId: String,
-  val offenderReleasedCourtEmailTemplateId: String,
-  val offenderReleasedPrisonEmailButNoCourtEmailTemplateId: String,
-  val appointmentCanceledPrisonEmailTemplateId: String,
-  val appointmentCanceledCourtEmailTemplateId: String,
-  val appointmentCanceledPrisonEmailButNoCourtEmailTemplateId: String,
+abstract class Email {
+  abstract val address: String
+  abstract val personalisation: Map<String, String?>
+}
+
+data class EmailTemplates(
+  val appointmentCancelledCourt: String,
+  val appointmentCancelledPrison: String,
+  val appointmentCancelledPrisonNoCourt: String,
+  val offenderReleasedCourt: String,
+  val offenderReleasedPrison: String,
+  val offenderReleasedPrisonNoCourt: String,
+  val offenderTransferredCourt: String,
+  val offenderTransferredPrison: String,
+  val offenderTransferredPrisonNoCourt: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailService.kt
@@ -1,11 +1,59 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Email
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.EmailService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.EmailTemplates
 import uk.gov.service.notify.NotificationClient
 
-internal class GovNotifyEmailService(client: NotificationClient, emailTemplates: EmailTemplates) : EmailService {
-  override fun sendEmail() {
-    TODO("Service is not yet implemented")
+class GovNotifyEmailService(
+  private val client: NotificationClient,
+  private val emailTemplates: EmailTemplates,
+) : EmailService {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  override fun send(email: Email) {
+    when (email) {
+      is AppointmentCancelledCourtEmail -> send(email, emailTemplates.appointmentCancelledCourt)
+      is AppointmentCancelledPrisonEmail -> send(email, emailTemplates.appointmentCancelledPrison)
+      is AppointmentCancelledPrisonNoCourtEmail -> send(email, emailTemplates.appointmentCancelledPrisonNoCourt)
+      is OffenderReleasedCourtEmail -> send(email, emailTemplates.offenderReleasedCourt)
+      is OffenderReleasedPrisonEmail -> send(email, emailTemplates.offenderReleasedPrison)
+      is OffenderReleasedPrisonNoCourtEmail -> send(email, emailTemplates.offenderReleasedPrisonNoCourt)
+      is OffenderTransferredCourtEmail -> send(email, emailTemplates.offenderTransferredCourt)
+      is OffenderTransferredPrisonEmail -> send(email, emailTemplates.offenderTransferredPrison)
+      is OffenderTransferredPrisonNoCourtEmail -> send(email, emailTemplates.offenderTransferredPrisonNoCourt)
+      else -> throw RuntimeException("Unsupported email type ${email.javaClass.simpleName}.")
+    }
+  }
+
+  private fun send(email: Email, templateId: String) {
+    runCatching {
+      client.sendEmail(templateId, email.address, email.personalisation, null)
+    }
+      .onSuccess { log.info("EMAIL: sent ${email.javaClass.simpleName} email.") }
+      .onFailure { log.info("EMAIL: failed to send ${email.javaClass.simpleName} email.") }
+      .getOrThrow()
   }
 }
+
+class AppointmentCancelledCourtEmail(override val address: String, override val personalisation: Map<String, String?>) : Email()
+
+class AppointmentCancelledPrisonEmail(override val address: String, override val personalisation: Map<String, String?>) : Email()
+
+class AppointmentCancelledPrisonNoCourtEmail(override val address: String, override val personalisation: Map<String, String?>) : Email()
+
+class OffenderReleasedCourtEmail(override val address: String, override val personalisation: Map<String, String?>) : Email()
+
+class OffenderReleasedPrisonEmail(override val address: String, override val personalisation: Map<String, String?>) : Email()
+
+class OffenderReleasedPrisonNoCourtEmail(override val address: String, override val personalisation: Map<String, String?>) : Email()
+
+class OffenderTransferredCourtEmail(override val address: String, override val personalisation: Map<String, String?>) : Email()
+
+class OffenderTransferredPrisonEmail(override val address: String, override val personalisation: Map<String, String?>) : Email()
+
+class OffenderTransferredPrisonNoCourtEmail(override val address: String, override val personalisation: Map<String, String?>) : Email()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailServiceTest.kt
@@ -1,0 +1,117 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.any
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Email
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.EmailTemplates
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.health.isEqualTo
+import uk.gov.service.notify.NotificationClient
+import uk.gov.service.notify.NotificationClientException
+
+class GovNotifyEmailServiceTest {
+  private val client: NotificationClient = mock()
+
+  private val emailTemplates = EmailTemplates(
+    appointmentCancelledCourt = "template 1",
+    appointmentCancelledPrison = "template 2",
+    appointmentCancelledPrisonNoCourt = "template 3",
+    offenderReleasedCourt = "template 4",
+    offenderReleasedPrison = "template 5",
+    offenderReleasedPrisonNoCourt = "template 6",
+    offenderTransferredCourt = "template 7",
+    offenderTransferredPrison = "template 8",
+    offenderTransferredPrisonNoCourt = "template 9",
+  )
+
+  private val service = GovNotifyEmailService(client, emailTemplates)
+
+  @Test
+  fun `should send appointment cancelled court email`() {
+    service.send(AppointmentCancelledCourtEmail("address 1", mapOf("a" to "b")))
+
+    verify(client).sendEmail("template 1", "address 1", mapOf("a" to "b"), null)
+  }
+
+  @Test
+  fun `should send appointment cancelled prison email`() {
+    service.send(AppointmentCancelledPrisonEmail("address 2", mapOf("b" to "c")))
+
+    verify(client).sendEmail("template 2", "address 2", mapOf("b" to "c"), null)
+  }
+
+  @Test
+  fun `should send appointment cancelled prison no court email`() {
+    service.send(AppointmentCancelledPrisonNoCourtEmail("address 3", mapOf("c" to "d")))
+
+    verify(client).sendEmail("template 3", "address 3", mapOf("c" to "d"), null)
+  }
+
+  @Test
+  fun `should send offender released court email`() {
+    service.send(OffenderReleasedCourtEmail("address 4", mapOf("d" to "e")))
+
+    verify(client).sendEmail("template 4", "address 4", mapOf("d" to "e"), null)
+  }
+
+  @Test
+  fun `should send offender released prison email`() {
+    service.send(OffenderReleasedPrisonEmail("address 5", mapOf("e" to "f")))
+
+    verify(client).sendEmail("template 5", "address 5", mapOf("e" to "f"), null)
+  }
+
+  @Test
+  fun `should send offender released prison no court email`() {
+    service.send(OffenderReleasedPrisonNoCourtEmail("address 6", mapOf("f" to "g")))
+
+    verify(client).sendEmail("template 6", "address 6", mapOf("f" to "g"), null)
+  }
+
+  @Test
+  fun `should send offender transferred court email`() {
+    service.send(OffenderTransferredCourtEmail("address 7", mapOf("g" to "h")))
+
+    verify(client).sendEmail("template 7", "address 7", mapOf("g" to "h"), null)
+  }
+
+  @Test
+  fun `should send offender transferred prison email`() {
+    service.send(OffenderTransferredPrisonEmail("address 8", mapOf("h" to "i")))
+
+    verify(client).sendEmail("template 8", "address 8", mapOf("h" to "i"), null)
+  }
+
+  @Test
+  fun `should send offender transferred prison no court email`() {
+    service.send(OffenderTransferredPrisonNoCourtEmail("address 9", mapOf("i" to "j")))
+
+    verify(client).sendEmail("template 9", "address 9", mapOf("i" to "j"), null)
+  }
+
+  @Test
+  fun `should throw error for unsupported email type`() {
+    val error = assertThrows<RuntimeException> { service.send(UnsupportedEmail) }
+
+    error.message isEqualTo "Unsupported email type UnsupportedEmail."
+  }
+
+  private object UnsupportedEmail : Email() {
+    override val address: String get() = ""
+    override val personalisation: Map<String, String?> get() = mapOf()
+  }
+
+  @Test
+  fun `should propagate client error when client fails to send email`() {
+    whenever(client.sendEmail(any(), any(), any(), anyOrNull())) doThrow NotificationClientException("Failed to send email.")
+
+    val error = assertThrows<NotificationClientException> { service.send(OffenderTransferredPrisonNoCourtEmail("address 9", mapOf("i" to "j"))) }
+
+    error.message isEqualTo "Failed to send email."
+  }
+}


### PR DESCRIPTION
This change provides a simple implementation for sending emails via Gov Notify.

The service will likely need further changes but hopefully this gives us a good initial footing.