### PR TITLE
BAVL-14 handle the sending of email errors gracefully, do not just throw error if send fails, let the caller decided on course of action.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.GovNotifyEmailService
 import uk.gov.service.notify.NotificationClient
+import java.util.UUID
 
 /**
  * Email configuration for the service. The sending of all emails is handled by the Gov Notify service.
@@ -34,7 +35,7 @@ class EmailConfiguration(
   @Bean
   fun emailService() =
     if (apiKey.isBlank()) {
-      EmailService { log.info("Email will not be sent.") }.also { log.info("Gov Notify emails are disabled") }
+      EmailService { email -> Result.success(UUID.randomUUID()).also { log.info("Email ${email.javaClass.simpleName} not sent.") } }.also { log.info("Gov Notify emails are disabled") }
     } else {
       GovNotifyEmailService(NotificationClient(apiKey), emailTemplates()).also { log.info("Gov Notify emails are enabled") }
     }
@@ -53,7 +54,10 @@ class EmailConfiguration(
 }
 
 fun interface EmailService {
-  fun send(email: Email)
+  /**
+   * On success returns a unique reference for each email sent.
+   */
+  fun send(email: Email): Result<UUID>
 }
 
 abstract class Email {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/health/Assertions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/health/Assertions.kt
@@ -2,6 +2,10 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.health
 
 import org.assertj.core.api.Assertions.assertThat
 
+internal infix fun Boolean.isBool(value: Boolean) {
+  assertThat(this).isEqualTo(value)
+}
+
 internal infix fun <T> T.isEqualTo(value: T) {
   assertThat(this).isEqualTo(value)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailServiceTest.kt
@@ -3,20 +3,25 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.any
-import org.mockito.Mockito.mock
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Email
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.EmailTemplates
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.health.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.health.isEqualTo
 import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.NotificationClientException
+import uk.gov.service.notify.SendEmailResponse
+import java.util.UUID
 
 class GovNotifyEmailServiceTest {
-  private val client: NotificationClient = mock()
-
+  private val notificationId = UUID.randomUUID()
+  private val sendEmailResponse: SendEmailResponse = mock { on { notificationId } doReturn notificationId }
+  private val client: NotificationClient = mock { on { sendEmail(any(), any(), any(), anyOrNull()) } doReturn sendEmailResponse }
   private val emailTemplates = EmailTemplates(
     appointmentCancelledCourt = "template 1",
     appointmentCancelledPrison = "template 2",
@@ -32,64 +37,82 @@ class GovNotifyEmailServiceTest {
   private val service = GovNotifyEmailService(client, emailTemplates)
 
   @Test
-  fun `should send appointment cancelled court email`() {
-    service.send(AppointmentCancelledCourtEmail("address 1", mapOf("a" to "b")))
+  fun `should send appointment cancelled court email and return a notification ID`() {
+    val result = service.send(AppointmentCancelledCourtEmail("address 1", mapOf("a" to "b")))
+
+    result.getOrThrow() isEqualTo notificationId
 
     verify(client).sendEmail("template 1", "address 1", mapOf("a" to "b"), null)
   }
 
   @Test
-  fun `should send appointment cancelled prison email`() {
-    service.send(AppointmentCancelledPrisonEmail("address 2", mapOf("b" to "c")))
+  fun `should send appointment cancelled prison email and return a notification ID`() {
+    val result = service.send(AppointmentCancelledPrisonEmail("address 2", mapOf("b" to "c")))
+
+    result.getOrThrow() isEqualTo notificationId
 
     verify(client).sendEmail("template 2", "address 2", mapOf("b" to "c"), null)
   }
 
   @Test
-  fun `should send appointment cancelled prison no court email`() {
-    service.send(AppointmentCancelledPrisonNoCourtEmail("address 3", mapOf("c" to "d")))
+  fun `should send appointment cancelled prison no court email and return a notification ID`() {
+    val result = service.send(AppointmentCancelledPrisonNoCourtEmail("address 3", mapOf("c" to "d")))
+
+    result.getOrThrow() isEqualTo notificationId
 
     verify(client).sendEmail("template 3", "address 3", mapOf("c" to "d"), null)
   }
 
   @Test
-  fun `should send offender released court email`() {
-    service.send(OffenderReleasedCourtEmail("address 4", mapOf("d" to "e")))
+  fun `should send offender released court email and return a notification ID`() {
+    val result = service.send(OffenderReleasedCourtEmail("address 4", mapOf("d" to "e")))
+
+    result.getOrThrow() isEqualTo notificationId
 
     verify(client).sendEmail("template 4", "address 4", mapOf("d" to "e"), null)
   }
 
   @Test
-  fun `should send offender released prison email`() {
-    service.send(OffenderReleasedPrisonEmail("address 5", mapOf("e" to "f")))
+  fun `should send offender released prison email and return a notification ID`() {
+    val result = service.send(OffenderReleasedPrisonEmail("address 5", mapOf("e" to "f")))
+
+    result.getOrThrow() isEqualTo notificationId
 
     verify(client).sendEmail("template 5", "address 5", mapOf("e" to "f"), null)
   }
 
   @Test
-  fun `should send offender released prison no court email`() {
-    service.send(OffenderReleasedPrisonNoCourtEmail("address 6", mapOf("f" to "g")))
+  fun `should send offender released prison no court email and return a notification ID`() {
+    val result = service.send(OffenderReleasedPrisonNoCourtEmail("address 6", mapOf("f" to "g")))
+
+    result.getOrThrow() isEqualTo notificationId
 
     verify(client).sendEmail("template 6", "address 6", mapOf("f" to "g"), null)
   }
 
   @Test
-  fun `should send offender transferred court email`() {
-    service.send(OffenderTransferredCourtEmail("address 7", mapOf("g" to "h")))
+  fun `should send offender transferred court email and return a notification ID`() {
+    val result = service.send(OffenderTransferredCourtEmail("address 7", mapOf("g" to "h")))
+
+    result.getOrThrow() isEqualTo notificationId
 
     verify(client).sendEmail("template 7", "address 7", mapOf("g" to "h"), null)
   }
 
   @Test
-  fun `should send offender transferred prison email`() {
-    service.send(OffenderTransferredPrisonEmail("address 8", mapOf("h" to "i")))
+  fun `should send offender transferred prison email and return a notification ID`() {
+    val result = service.send(OffenderTransferredPrisonEmail("address 8", mapOf("h" to "i")))
+
+    result.getOrThrow() isEqualTo notificationId
 
     verify(client).sendEmail("template 8", "address 8", mapOf("h" to "i"), null)
   }
 
   @Test
-  fun `should send offender transferred prison no court email`() {
-    service.send(OffenderTransferredPrisonNoCourtEmail("address 9", mapOf("i" to "j")))
+  fun `should send offender transferred prison no court email and return a notification ID`() {
+    val result = service.send(OffenderTransferredPrisonNoCourtEmail("address 9", mapOf("i" to "j")))
+
+    result.getOrThrow() isEqualTo notificationId
 
     verify(client).sendEmail("template 9", "address 9", mapOf("i" to "j"), null)
   }
@@ -108,10 +131,14 @@ class GovNotifyEmailServiceTest {
 
   @Test
   fun `should propagate client error when client fails to send email`() {
-    whenever(client.sendEmail(any(), any(), any(), anyOrNull())) doThrow NotificationClientException("Failed to send email.")
+    val exception = NotificationClientException("Failed to send email.")
 
-    val error = assertThrows<NotificationClientException> { service.send(OffenderTransferredPrisonNoCourtEmail("address 9", mapOf("i" to "j"))) }
+    whenever(client.sendEmail(any(), any(), any(), anyOrNull())) doThrow exception
 
-    error.message isEqualTo "Failed to send email."
+    val result = service.send(OffenderTransferredPrisonNoCourtEmail("address 9", mapOf("i" to "j")))
+
+    result.isSuccess isBool false
+    result.isFailure isBool true
+    result.exceptionOrNull() isEqualTo exception
   }
 }


### PR DESCRIPTION
Handle email failures gracefully so the caller can decide on course of action if/when it happens.

The change also now returns the unique reference associated with an email send from gov notify so we can record it against the email notification in the notifications table.