### PR TITLE
BAVL-14 updates the notification table to include a reference to the associated gov notify notifications.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -8,6 +8,7 @@ generic-service:
     host: book-a-video-link-api-dev.prison.service.justice.gov.uk
 
   env:
+    SPRING_PROFILES_ACTIVE: dev
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_ACTIVITIES_APPOINTMENTS: "https://activities-api-dev.prison.service.justice.gov.uk"
     API_BASE_URL_HMPPS_AUTH: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,5 @@
+spring:
+  flyway:
+    # This should be removed when we think the DB is stable, and we should be moving onto migrations for changes.
+    clean-disabled: false
+    clean-on-validation-error: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,6 +15,9 @@ spring:
 
   flyway:
     locations: classpath:/migrations/common,classpath:/migrations/dev
+    # This should be removed when we think the DB is stable, and we should be moving onto migrations for changes.
+    clean-disabled: false
+    clean-on-validation-error: true
 
 system:
   client:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
       ddl-auto: none
 
   flyway:
-    locations: classpath:/migrations/common,classpath:/migrations/prod\
+    locations: classpath:/migrations/common,classpath:/migrations/prod
 
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
       ddl-auto: none
 
   flyway:
-    locations: classpath:/migrations/common,classpath:/migrations/prod
+    locations: classpath:/migrations/common,classpath:/migrations/prod\
 
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"

--- a/src/main/resources/migrations/common/V2024.04.22__baseline_tables.sql
+++ b/src/main/resources/migrations/common/V2024.04.22__baseline_tables.sql
@@ -291,16 +291,18 @@ CREATE INDEX idx_user_probation_username ON user_probation(username);
 
 CREATE TABLE notification
 (
-    notification_id  bigserial  NOT NULL CONSTRAINT notification_id_pk PRIMARY KEY,
-    video_booking_id bigint NOT NULL REFERENCES video_booking(video_booking_id),
-    template_name    varchar(100),
-    email            varchar(100),
-    reason           varchar(40) NOT NULL,
-    created_time     timestamp NOT NULL
+    notification_id            bigserial  NOT NULL CONSTRAINT notification_id_pk PRIMARY KEY,
+    video_booking_id           bigint NOT NULL REFERENCES video_booking(video_booking_id),
+    template_name              varchar(100),
+    email                      varchar(100),
+    reason                     varchar(40) NOT NULL,
+    gov_notify_notification_id uuid NOT NULL,
+    created_time               timestamp NOT NULL
 );
 
 CREATE INDEX idx_notification_booking_id ON notification(video_booking_id);
 CREATE INDEX idx_notification_email ON notification(email);
+CREATE UNIQUE INDEX idx_gov_notify_notification_id ON notification(gov_notify_notification_id);
 
 ---------------------------------------------------------------------------------------
 -- This is the history of changes to a booking


### PR DESCRIPTION
The changes adds the notification id returned by gov notify to our own notifications table.

This will be useful down the line if we need to investigate any potential issues with notifications.  It also gives us the option to consider implementing a callback endpoint which gov notify can call to say whether some has actually been delivered or not.