### PR TITLE
BAVL-14 add gov notify api key environment var. Still need template IDs adding when we know them.

### DIFF
--- a/helm_deploy/hmpps-book-a-video-link-api/values.yaml
+++ b/helm_deploy/hmpps-book-a-video-link-api/values.yaml
@@ -22,6 +22,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     DB_SSL_MODE: "verify-full"
+    # Add the gov-notify template IDs here when we know what they are.
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
@@ -36,6 +37,8 @@ generic-service:
       DB_NAME: "database_name"
       DB_USER: "database_username"
       DB_PASS: "database_password"
+    gov-notify:
+      NOTIFY_API_KEY: "notify_api_key"
 
   allowlist:
     groups:


### PR DESCRIPTION
This secret for the API key has been added to the dev k8s namespace.  I would suggest verifying this prior to approving the PR.