### PR TITLE
BAVL-98 first simple integration test for the creation journey.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/Assertions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/Assertions.kt
@@ -13,6 +13,10 @@ internal inline infix fun <reified K, V> Map<K, V>.containsEntriesExactlyInAnyOr
   assertThat(this).containsExactlyInAnyOrderEntriesOf(value)
 }
 
+internal infix fun <T> Collection<T>.hasSize(size: Int) {
+  assertThat(this).hasSize(size)
+}
+
 internal infix fun Boolean.isBool(value: Boolean) {
   assertThat(this).isEqualTo(value)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.LocationsInsidePrisonApiExtension
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.PrisonerSearchApiExtension
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.PrisonerSearchApiMockServer
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
@@ -25,6 +26,8 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var webTestClient: WebTestClient
 
+  lateinit var prisonerSearchApiMockServer: PrisonerSearchApiMockServer
+
   @Autowired
   protected lateinit var jwtAuthHelper: JwtAuthHelper
 
@@ -38,6 +41,8 @@ abstract class IntegrationTestBase {
     ActivitiesAppointmentsApiExtension.server.stubHealthPing(status)
     HmppsAuthApiExtension.server.stubHealthPing(status)
     LocationsInsidePrisonApiExtension.server.stubHealthPing(status)
-    PrisonerSearchApiExtension.server.stubHealthPing(status)
+    prisonSearchApi().stubHealthPing(status)
   }
+
+  protected fun prisonSearchApi() = PrisonerSearchApiExtension.server
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.resource
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
+
+class VideoLinkBookingIntegrationTest : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var videoBookingRepository: VideoBookingRepository
+
+  @Test
+  fun `should create a court booking`() {
+    videoBookingRepository.findAll().filter { it.bookingType == "COURT" } hasSize 0
+
+    prisonSearchApi().stubGetPrisoner("123456", "MDI")
+
+    val courtBookingRequest = courtBookingRequest()
+
+    val bookingId = webTestClient.createBooking(courtBookingRequest)
+
+    with(videoBookingRepository.findById(bookingId).orElseThrow()) {
+      videoBookingId isEqualTo bookingId
+      bookingType isEqualTo "COURT"
+      court?.courtId isEqualTo courtBookingRequest.courtId
+      hearingType isEqualTo courtBookingRequest.courtHearingType?.name
+      videoUrl isEqualTo courtBookingRequest.videoLinkUrl
+    }
+  }
+
+  @Test
+  fun `should create a probation booking`() {
+    videoBookingRepository.findAll().filter { it.bookingType == "PROBATION" } hasSize 0
+
+    prisonSearchApi().stubGetPrisoner("123456", "MDI")
+
+    val probationBookingRequest = probationBookingRequest()
+
+    val bookingId = webTestClient.createBooking(probationBookingRequest)
+
+    with(videoBookingRepository.findById(bookingId).orElseThrow()) {
+      videoBookingId isEqualTo bookingId
+      bookingType isEqualTo "PROBATION"
+      probationTeam?.probationTeamId isEqualTo probationBookingRequest.probationTeamId
+      probationMeetingType isEqualTo probationBookingRequest.probationMeetingType?.name
+      videoUrl isEqualTo probationBookingRequest.videoLinkUrl
+    }
+  }
+
+  private fun WebTestClient.createBooking(request: CreateVideoBookingRequest) =
+    this
+      .post()
+      .uri("/video-link-booking")
+      .bodyValue(request)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_BOOK_A_VIDEO_LINK_ADMIN")))
+      .exchange()
+      .expectStatus().isCreated
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(Long::class.java)
+      .returnResult().responseBody!!
+}


### PR DESCRIPTION
The is the first end to end integration test which exercises the persistence of a court and probation booking to the database.

It does not create any appointments, this is next on the agenda.

I was thinking of not bothering with Controller dedicated tests as we really end up writing almost the same as an integration test anyway.