### PR TITLE
BAVL-98 changes introduces and persists the appointment for a probation team appointment. Still requires further validation checks.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/LocalTimeExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/LocalTimeExt.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common
+
+import java.time.LocalTime
+import java.time.temporal.ChronoUnit
+
+fun LocalTime.toMinutePrecision() = this.truncatedTo(ChronoUnit.MINUTES)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/PrisonAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/PrisonAppointment.kt
@@ -1,0 +1,90 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.Hibernate
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toMinutePrecision
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@Entity
+@Table(name = "prison_appointment")
+class PrisonAppointment private constructor(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val prisonAppointmentId: Long = 0,
+
+  @ManyToOne
+  @JoinColumn(name = "video_booking_id")
+  val videoBooking: VideoBooking,
+
+  val prisonCode: String,
+
+  val prisonerNumber: String,
+
+  val appointmentType: String,
+
+  val comments: String? = null,
+
+  val prisonLocKey: String,
+
+  val appointmentDate: LocalDate,
+
+  val startTime: LocalTime,
+
+  val endTime: LocalTime,
+
+  val createdBy: String,
+
+  val createdTime: LocalDateTime = LocalDateTime.now(),
+) {
+
+  var amendedBy: String? = null
+    private set
+
+  var amendedTime: LocalDateTime? = null
+    private set
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+
+    other as PrisonAppointment
+
+    return prisonAppointmentId == other.prisonAppointmentId
+  }
+
+  override fun hashCode(): Int {
+    return prisonAppointmentId.hashCode()
+  }
+
+  companion object {
+    fun newAppointment(
+      videoBooking: VideoBooking,
+      prisonCode: String,
+      prisonerNumber: String,
+      appointmentType: String,
+      appointmentDate: LocalDate,
+      startTime: LocalTime,
+      endTime: LocalTime,
+      locationKey: String,
+      createdBy: String,
+    ) = PrisonAppointment(
+      videoBooking = videoBooking,
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      appointmentType = appointmentType,
+      appointmentDate = appointmentDate,
+      startTime = startTime.toMinutePrecision(),
+      endTime = endTime.toMinutePrecision(),
+      prisonLocKey = locationKey,
+      createdBy = createdBy,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
@@ -60,12 +60,13 @@ class VideoBooking private constructor(
   }
 
   companion object {
-    fun court(
+    fun newCourtBooking(
       court: Court,
       hearingType: String,
       videoUrl: String?,
       createdBy: String,
     ): VideoBooking =
+      // TODO check court is enabled?
       VideoBooking(
         bookingType = "COURT",
         court = court,
@@ -76,12 +77,13 @@ class VideoBooking private constructor(
         createdBy = createdBy,
       )
 
-    fun probation(
+    fun newProbationBooking(
       probationTeam: ProbationTeam,
       probationMeetingType: String,
       videoUrl: String?,
       createdBy: String,
     ): VideoBooking =
+      // TODO check probation team is enabled?
       VideoBooking(
         bookingType = "PROBATION",
         court = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
@@ -106,7 +106,18 @@ data class PrisonerDetails(
 
   @field:Valid
   @field:NotEmpty(message = "At least one appointment must be supplied for the prisoner")
-  @Schema(description = "The appointments associated with the prisoner")
+  @Schema(
+    description =
+    """
+      The appointment or appointments associated with the prisoner.
+  
+      There should only ever be one appointment for a probation meeting.
+  
+      Court meetings can have up to 3 meetings, a pre, main hearing and post meeting. They must always have a main meeting.
+  
+      Appointment dates and times must not overlap.
+    """,
+  )
   val appointments: List<Appointment>,
 )
 
@@ -140,13 +151,13 @@ data class Appointment(
   private fun isInvalidTime() = (startTime == null || endTime == null) || startTime.isBefore(endTime)
 }
 
-enum class AppointmentType {
+enum class AppointmentType(val isProbation: Boolean, isCourt: Boolean) {
   // Probation types
-  RECALL_REPORT,
-  PRE_SENTENCE_REPORT,
+  RECALL_REPORT(true, false),
+  PRE_SENTENCE_REPORT(true, false),
 
   // Court types
-  PRE_CONFERENCE,
-  HEARING,
-  POST_CONFERENCE,
+  PRE_CONFERENCE(false, true),
+  HEARING(false, true),
+  POST_CONFERENCE(false, true),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/PrisonAppointmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/PrisonAppointmentRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+
+interface PrisonAppointmentRepository : JpaRepository<PrisonAppointment, Long> {
+  fun findByVideoBooking(booking: VideoBooking): List<PrisonAppointment>
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -41,15 +41,22 @@ fun courtBookingRequest(
 
 fun probationBookingRequest(
   probationTeamId: Long = 1,
+  probationMeetingType: ProbationMeetingType = ProbationMeetingType.PSR,
+  videoLinkUrl: String = "https://video.link.com",
   prisonCode: String = "MDI",
   prisonerNumber: String = "123456",
+  locationSuffix: String = "A-1-001",
+  appointmentType: AppointmentType = AppointmentType.PRE_SENTENCE_REPORT,
+  appointmentDate: LocalDate = LocalDate.now().plusDays(1),
+  startTime: LocalTime = LocalTime.now(),
+  endTime: LocalTime = LocalTime.now().plusHours(1),
 ): CreateVideoBookingRequest {
   val appointment = Appointment(
-    type = AppointmentType.PRE_SENTENCE_REPORT,
-    locationKey = "$prisonCode-A-1-001",
-    date = LocalDate.now().plusDays(1),
-    startTime = LocalTime.now(),
-    endTime = LocalTime.now().plusHours(1),
+    type = appointmentType,
+    locationKey = "$prisonCode-$locationSuffix",
+    date = appointmentDate,
+    startTime = startTime,
+    endTime = endTime,
   )
 
   val prisoner = PrisonerDetails(
@@ -61,9 +68,9 @@ fun probationBookingRequest(
   return CreateVideoBookingRequest(
     bookingType = BookingType.PROBATION,
     probationTeamId = probationTeamId,
-    probationMeetingType = ProbationMeetingType.PSR,
+    probationMeetingType = probationMeetingType,
     prisoners = listOf(prisoner),
     comments = "Blah de blah",
-    videoLinkUrl = "https://video.link.com",
+    videoLinkUrl = videoLinkUrl,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.LocationsInsidePrisonApiExtension
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.PrisonerSearchApiExtension
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.PrisonerSearchApiMockServer
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
@@ -25,8 +24,6 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var webTestClient: WebTestClient
-
-  lateinit var prisonerSearchApiMockServer: PrisonerSearchApiMockServer
 
   @Autowired
   protected lateinit var jwtAuthHelper: JwtAuthHelper

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingServiceTest.kt
@@ -1,14 +1,19 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
+import jakarta.persistence.EntityNotFoundException
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toMinutePrecision
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBookingRequest
@@ -16,7 +21,9 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.CourtRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
 import java.time.LocalDateTime
@@ -29,15 +36,19 @@ class CreateVideoBookingServiceTest {
   private val probationTeamRepository: ProbationTeamRepository = mock()
   private val videoBookingRepository: VideoBookingRepository = mock()
   private val persistedVideoBooking: VideoBooking = mock()
+  private val prisonAppointmentRepository: PrisonAppointmentRepository = mock()
 
   private val service = CreateVideoBookingService(
     courtRepository,
     prisonerSearchClient,
     probationTeamRepository,
     videoBookingRepository,
+    prisonAppointmentRepository,
   )
 
   private var newBookingCaptor = argumentCaptor<VideoBooking>()
+
+  private var appointmentsCaptor = argumentCaptor<PrisonAppointment>()
 
   @Test
   fun `should create a court video booking`() {
@@ -48,11 +59,11 @@ class CreateVideoBookingServiceTest {
 
     whenever(courtRepository.findById(courtBookingRequest.courtId!!)) doReturn Optional.of(requestedCourt)
     whenever(prisonerSearchClient.getPrisonerAtPrison(prisonCode = prisonCode, prisonerNumber = prisonerNumber)) doReturn Prisoner(prisonerNumber = prisonerNumber, prisonId = prisonCode)
-    whenever(videoBookingRepository.save(any())) doReturn persistedVideoBooking
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
 
     service.create(courtBookingRequest)
 
-    verify(videoBookingRepository).save(newBookingCaptor.capture())
+    verify(videoBookingRepository).saveAndFlush(newBookingCaptor.capture())
 
     with(newBookingCaptor.firstValue) {
       bookingType isEqualTo "COURT"
@@ -64,6 +75,19 @@ class CreateVideoBookingServiceTest {
   }
 
   @Test
+  fun `should fail to create a court video booking when court not found`() {
+    val courtBookingRequest = courtBookingRequest()
+
+    whenever(courtRepository.findById(courtBookingRequest.courtId!!)) doReturn Optional.empty()
+
+    val error = assertThrows<EntityNotFoundException> { service.create(courtBookingRequest) }
+
+    error.message isEqualTo "Court with ID ${courtBookingRequest.courtId} not found"
+
+    verifyNoInteractions(videoBookingRepository)
+  }
+
+  @Test
   fun `should create a probation video booking`() {
     val prisonCode = "MDI"
     val prisonerNumber = "123456"
@@ -72,11 +96,11 @@ class CreateVideoBookingServiceTest {
 
     whenever(probationTeamRepository.findById(probationBookingRequest.probationTeamId!!)) doReturn Optional.of(requestedProbationTeam)
     whenever(prisonerSearchClient.getPrisonerAtPrison(prisonCode = prisonCode, prisonerNumber = prisonerNumber)) doReturn Prisoner(prisonerNumber = prisonerNumber, prisonId = prisonCode)
-    whenever(videoBookingRepository.save(any())) doReturn persistedVideoBooking
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
 
     service.create(probationBookingRequest)
 
-    verify(videoBookingRepository).save(newBookingCaptor.capture())
+    verify(videoBookingRepository).saveAndFlush(newBookingCaptor.capture())
 
     with(newBookingCaptor.firstValue) {
       bookingType isEqualTo "PROBATION"
@@ -85,5 +109,52 @@ class CreateVideoBookingServiceTest {
       probationMeetingType isEqualTo probationBookingRequest.probationMeetingType?.name
       videoUrl isEqualTo probationBookingRequest.videoLinkUrl
     }
+
+    verify(prisonAppointmentRepository).saveAndFlush(appointmentsCaptor.capture())
+
+    appointmentsCaptor.allValues.size isEqualTo 1
+
+    with(appointmentsCaptor.firstValue) {
+      val prisoner = probationBookingRequest.prisoners.single()
+
+      videoBooking isEqualTo persistedVideoBooking
+      prisonCode isEqualTo prisoner.prisonCode!!
+      prisonerNumber isEqualTo prisoner.prisonerNumber!!
+      appointmentType isEqualTo prisoner.appointments.single().type?.name
+      appointmentDate isEqualTo prisoner.appointments.single().date!!
+      startTime isEqualTo prisoner.appointments.single().startTime!!.toMinutePrecision()
+      endTime isEqualTo prisoner.appointments.single().endTime!!.toMinutePrecision()
+      prisonLocKey isEqualTo prisoner.appointments.single().locationKey!!
+      createdBy isEqualTo "TBD"
+    }
+  }
+
+  @Test
+  fun `should fail to create a probation video booking when team not found`() {
+    val probationBookingRequest = probationBookingRequest()
+
+    whenever(probationTeamRepository.findById(probationBookingRequest.probationTeamId!!)) doReturn Optional.empty()
+
+    val error = assertThrows<EntityNotFoundException> { service.create(probationBookingRequest) }
+
+    error.message isEqualTo "Probation team with ID ${probationBookingRequest.probationTeamId} not found"
+
+    verifyNoInteractions(videoBookingRepository)
+  }
+
+  @Test
+  fun `should fail to create a probation video booking when appointment type not probation specific`() {
+    val prisonCode = "MDI"
+    val prisonerNumber = "123456"
+    val probationBookingRequest = probationBookingRequest(prisonCode = prisonCode, prisonerNumber = prisonerNumber, appointmentType = AppointmentType.HEARING)
+    val requestedProbationTeam = probationTeam(probationBookingRequest.probationTeamId!!)
+
+    whenever(probationTeamRepository.findById(probationBookingRequest.probationTeamId!!)) doReturn Optional.of(requestedProbationTeam)
+    whenever(prisonerSearchClient.getPrisonerAtPrison(prisonCode = prisonCode, prisonerNumber = prisonerNumber)) doReturn Prisoner(prisonerNumber = prisonerNumber, prisonId = prisonCode)
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+
+    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest) }
+
+    error.message isEqualTo "Appointment type HEARING is not valid for probation appointments"
   }
 }


### PR DESCRIPTION
This change introduces the PrisonAppointment entity and also creates one as part of the probation booking/appointment creation journey.  There are still validation needs in this area, e.g. checking of location keys.

Court appointments are not created in these changes.