### PR TITLE
BAVL-98 changes to persist the appointments for a court hearing booking. Still requires further validation checks.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
@@ -151,7 +151,7 @@ data class Appointment(
   private fun isInvalidTime() = (startTime == null || endTime == null) || startTime.isBefore(endTime)
 }
 
-enum class AppointmentType(val isProbation: Boolean, isCourt: Boolean) {
+enum class AppointmentType(val isProbation: Boolean, val isCourt: Boolean) {
   // Probation types
   RECALL_REPORT(true, false),
   PRE_SENTENCE_REPORT(true, false),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
@@ -7,6 +7,8 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Appointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.PrisonerDetails
@@ -49,11 +51,55 @@ class CreateVideoBookingService(
   }
 
   private fun createAppointmentsForCourt(videoBooking: VideoBooking, prisoner: PrisonerDetails) {
-    // TODO to be implemented
+    // TODO consider what validation may be needed e.g. duplicate, room in already in use etc.
+    // TODO need to check locations against locations API
+
+    prisoner.appointments.checkCourtAppointmentTypesOnly()
+    prisoner.appointments.checkCourtAppointmentDateAndTimesDoNotOverlap()
+
+    prisoner.appointments.map {
+      PrisonAppointment.newAppointment(
+        videoBooking = videoBooking,
+        prisonCode = prisoner.prisonCode!!,
+        prisonerNumber = prisoner.prisonerNumber!!,
+        appointmentType = it.type!!.name,
+        appointmentDate = it.date!!,
+        startTime = it.startTime!!,
+        endTime = it.endTime!!,
+        locationKey = it.locationKey!!,
+        createdBy = "TBD",
+      )
+    }.forEach { prisonAppointmentRepository.saveAndFlush(it) }
   }
+
+  private fun List<Appointment>.checkCourtAppointmentTypesOnly() {
+    require(
+      size <= 3 &&
+        count { it.type == AppointmentType.PRE_CONFERENCE } <= 1 &&
+        count { it.type == AppointmentType.POST_CONFERENCE } <= 1 &&
+        count { it.type == AppointmentType.HEARING } == 1 &&
+        all { it.type!!.isCourt },
+    ) {
+      "Court bookings can only have one pre-conference, one hearing and one post-conference."
+    }
+  }
+
+  private fun List<Appointment>.checkCourtAppointmentDateAndTimesDoNotOverlap() {
+    val pre = singleOrNull { it.type == AppointmentType.PRE_CONFERENCE }
+    val hearing = single { it.type == AppointmentType.HEARING }
+    val post = singleOrNull { it.type == AppointmentType.POST_CONFERENCE }
+
+    require((pre == null || pre.isBefore(hearing)) && (post == null || hearing.isBefore(post))) {
+      "Court booking appointments must not overlap."
+    }
+  }
+
+  private fun Appointment.isBefore(other: Appointment): Boolean =
+    this.date!! <= other.date && this.endTime!! <= other.startTime
 
   private fun createProbation(request: CreateVideoBookingRequest): VideoBooking {
     // TODO consider what validation may be needed e.g. duplicate, room in already in use etc.
+    // TODO need to check locations against locations API
 
     val probationTeam = probationTeamRepository.findById(request.probationTeamId!!).orElseThrow { EntityNotFoundException("Probation team with ID ${request.probationTeamId} not found") }
     request.prisoner().let { prisonerSearchClient.getPrisonerAtPrison(it.prisonerNumber!!, it.prisonCode!!) }
@@ -67,8 +113,6 @@ class CreateVideoBookingService(
   }
 
   private fun createAppointmentForProbation(videoBooking: VideoBooking, prisoner: PrisonerDetails) {
-    // TODO check location key against the locations API
-
     val appointment = with(prisoner.appointments.single()) {
       require(type!!.isProbation) {
         "Appointment type $type is not valid for probation appointments"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -14,19 +14,25 @@ fun courtBookingRequest(
   courtId: Long = 1,
   prisonCode: String = "MDI",
   prisonerNumber: String = "123456",
+  locationSuffix: String = "A-1-001",
+  startTime: LocalTime = LocalTime.now(),
+  endTime: LocalTime = LocalTime.now().plusHours(1),
+  appointments: List<Appointment> = emptyList(),
 ): CreateVideoBookingRequest {
-  val appointment = Appointment(
-    type = AppointmentType.HEARING,
-    locationKey = "$prisonCode-A-1-001",
-    date = LocalDate.now().plusDays(1),
-    startTime = LocalTime.now(),
-    endTime = LocalTime.now().plusHours(1),
-  )
-
   val prisoner = PrisonerDetails(
     prisonCode = prisonCode,
     prisonerNumber = prisonerNumber,
-    appointments = listOf(appointment),
+    appointments = appointments.ifEmpty {
+      listOf(
+        Appointment(
+          type = AppointmentType.HEARING,
+          locationKey = "$prisonCode-$locationSuffix",
+          date = LocalDate.now().plusDays(1),
+          startTime = startTime,
+          endTime = endTime,
+        ),
+      )
+    },
   )
 
   return CreateVideoBookingRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingServiceTest.kt
@@ -7,6 +7,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -21,12 +22,15 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Appointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.CourtRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.util.*
 
 class CreateVideoBookingServiceTest {
@@ -54,7 +58,34 @@ class CreateVideoBookingServiceTest {
   fun `should create a court video booking`() {
     val prisonCode = "MDI"
     val prisonerNumber = "123456"
-    val courtBookingRequest = courtBookingRequest(prisonCode = prisonCode, prisonerNumber = prisonerNumber)
+    val courtBookingRequest = courtBookingRequest(
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      appointments = listOf(
+        Appointment(
+          type = AppointmentType.PRE_CONFERENCE,
+          locationKey = "$prisonCode-ABCEDFG",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(9, 0),
+          endTime = LocalTime.of(9, 30),
+        ),
+        Appointment(
+          type = AppointmentType.HEARING,
+          locationKey = "$prisonCode-ABCEDFG",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(9, 30),
+          endTime = LocalTime.of(10, 0),
+        ),
+        Appointment(
+          type = AppointmentType.POST_CONFERENCE,
+          locationKey = "$prisonCode-ABCEDFG",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(10, 0),
+          endTime = LocalTime.of(10, 30),
+        ),
+      ),
+    )
+
     val requestedCourt = court(courtBookingRequest.courtId!!)
 
     whenever(courtRepository.findById(courtBookingRequest.courtId!!)) doReturn Optional.of(requestedCourt)
@@ -72,6 +103,326 @@ class CreateVideoBookingServiceTest {
       hearingType isEqualTo courtBookingRequest.courtHearingType?.name
       videoUrl isEqualTo courtBookingRequest.videoLinkUrl
     }
+
+    verify(prisonAppointmentRepository, times(3)).saveAndFlush(appointmentsCaptor.capture())
+
+    appointmentsCaptor.allValues.size isEqualTo 3
+
+    with(appointmentsCaptor.firstValue) {
+      videoBooking isEqualTo persistedVideoBooking
+      this.prisonCode isEqualTo prisonCode
+      this.prisonerNumber isEqualTo prisonerNumber
+      appointmentType isEqualTo AppointmentType.PRE_CONFERENCE.name
+      appointmentDate isEqualTo LocalDate.now().plusDays(1)
+      startTime isEqualTo LocalTime.of(9, 0).toMinutePrecision()
+      endTime isEqualTo LocalTime.of(9, 30).toMinutePrecision()
+      prisonLocKey isEqualTo "MDI-ABCEDFG"
+      createdBy isEqualTo "TBD"
+    }
+
+    with(appointmentsCaptor.secondValue) {
+      videoBooking isEqualTo persistedVideoBooking
+      this.prisonCode isEqualTo prisonCode
+      this.prisonerNumber isEqualTo prisonerNumber
+      appointmentType isEqualTo AppointmentType.HEARING.name
+      appointmentDate isEqualTo LocalDate.now().plusDays(1)
+      startTime isEqualTo LocalTime.of(9, 30).toMinutePrecision()
+      endTime isEqualTo LocalTime.of(10, 0).toMinutePrecision()
+      prisonLocKey isEqualTo "MDI-ABCEDFG"
+      createdBy isEqualTo "TBD"
+    }
+
+    with(appointmentsCaptor.thirdValue) {
+      videoBooking isEqualTo persistedVideoBooking
+      this.prisonCode isEqualTo prisonCode
+      this.prisonerNumber isEqualTo prisonerNumber
+      appointmentType isEqualTo AppointmentType.POST_CONFERENCE.name
+      appointmentDate isEqualTo LocalDate.now().plusDays(1)
+      startTime isEqualTo LocalTime.of(10, 0).toMinutePrecision()
+      endTime isEqualTo LocalTime.of(10, 30).toMinutePrecision()
+      prisonLocKey isEqualTo "MDI-ABCEDFG"
+      createdBy isEqualTo "TBD"
+    }
+  }
+
+  @Test
+  fun `should fail to create a court video booking when too many appointments`() {
+    val prisonCode = "MDI"
+    val prisonerNumber = "123456"
+    val courtBookingRequest = courtBookingRequest(
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      appointments = listOf(
+        Appointment(
+          type = AppointmentType.PRE_CONFERENCE,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(9, 0),
+          endTime = LocalTime.of(9, 30),
+        ),
+        Appointment(
+          type = AppointmentType.HEARING,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(9, 30),
+          endTime = LocalTime.of(10, 0),
+        ),
+        Appointment(
+          type = AppointmentType.POST_CONFERENCE,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(10, 0),
+          endTime = LocalTime.of(10, 30),
+        ),
+        Appointment(
+          type = AppointmentType.POST_CONFERENCE,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(10, 30),
+          endTime = LocalTime.of(11, 0),
+        ),
+      ),
+    )
+    val requestedCourt = court(courtBookingRequest.courtId!!)
+
+    whenever(courtRepository.findById(courtBookingRequest.courtId!!)) doReturn Optional.of(requestedCourt)
+    whenever(prisonerSearchClient.getPrisonerAtPrison(prisonCode = prisonCode, prisonerNumber = prisonerNumber)) doReturn Prisoner(prisonerNumber = prisonerNumber, prisonId = prisonCode)
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest) }
+
+    error.message isEqualTo "Court bookings can only have one pre-conference, one hearing and one post-conference."
+  }
+
+  @Test
+  fun `should fail to create a court video booking when pre-hearing overlaps hearing`() {
+    val prisonCode = "MDI"
+    val prisonerNumber = "123456"
+    val courtBookingRequest = courtBookingRequest(
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      appointments = listOf(
+        Appointment(
+          type = AppointmentType.PRE_CONFERENCE,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(9, 0),
+          endTime = LocalTime.of(9, 31),
+        ),
+        Appointment(
+          type = AppointmentType.HEARING,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(9, 30),
+          endTime = LocalTime.of(10, 0),
+        ),
+      ),
+    )
+    val requestedCourt = court(courtBookingRequest.courtId!!)
+
+    whenever(courtRepository.findById(courtBookingRequest.courtId!!)) doReturn Optional.of(requestedCourt)
+    whenever(prisonerSearchClient.getPrisonerAtPrison(prisonCode = prisonCode, prisonerNumber = prisonerNumber)) doReturn Prisoner(prisonerNumber = prisonerNumber, prisonId = prisonCode)
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest) }
+
+    error.message isEqualTo "Court booking appointments must not overlap."
+  }
+
+  @Test
+  fun `should fail to create a court video booking when post-hearing overlaps hearing`() {
+    val prisonCode = "MDI"
+    val prisonerNumber = "123456"
+    val courtBookingRequest = courtBookingRequest(
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      appointments = listOf(
+        Appointment(
+          type = AppointmentType.HEARING,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(9, 0),
+          endTime = LocalTime.of(9, 31),
+        ),
+        Appointment(
+          type = AppointmentType.POST_CONFERENCE,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(9, 30),
+          endTime = LocalTime.of(10, 0),
+        ),
+      ),
+    )
+    val requestedCourt = court(courtBookingRequest.courtId!!)
+
+    whenever(courtRepository.findById(courtBookingRequest.courtId!!)) doReturn Optional.of(requestedCourt)
+    whenever(prisonerSearchClient.getPrisonerAtPrison(prisonCode = prisonCode, prisonerNumber = prisonerNumber)) doReturn Prisoner(prisonerNumber = prisonerNumber, prisonId = prisonCode)
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest) }
+
+    error.message isEqualTo "Court booking appointments must not overlap."
+  }
+
+  @Test
+  fun `should fail to create a court video booking when no hearing appointment`() {
+    val prisonCode = "MDI"
+    val prisonerNumber = "123456"
+    val courtBookingRequest = courtBookingRequest(
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      appointments = listOf(
+        Appointment(
+          type = AppointmentType.PRE_CONFERENCE,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(9, 0),
+          endTime = LocalTime.of(9, 30),
+        ),
+        Appointment(
+          type = AppointmentType.POST_CONFERENCE,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(10, 0),
+          endTime = LocalTime.of(10, 30),
+        ),
+      ),
+    )
+    val requestedCourt = court(courtBookingRequest.courtId!!)
+
+    whenever(courtRepository.findById(courtBookingRequest.courtId!!)) doReturn Optional.of(requestedCourt)
+    whenever(prisonerSearchClient.getPrisonerAtPrison(prisonCode = prisonCode, prisonerNumber = prisonerNumber)) doReturn Prisoner(prisonerNumber = prisonerNumber, prisonId = prisonCode)
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest) }
+
+    error.message isEqualTo "Court bookings can only have one pre-conference, one hearing and one post-conference."
+  }
+
+  @Test
+  fun `should fail to create a court video booking when too many pre-hearing appointments`() {
+    val prisonCode = "MDI"
+    val prisonerNumber = "123456"
+    val courtBookingRequest = courtBookingRequest(
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      appointments = listOf(
+        Appointment(
+          type = AppointmentType.PRE_CONFERENCE,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(9, 0),
+          endTime = LocalTime.of(9, 30),
+        ),
+        Appointment(
+          type = AppointmentType.PRE_CONFERENCE,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(9, 0),
+          endTime = LocalTime.of(9, 30),
+        ),
+        Appointment(
+          type = AppointmentType.HEARING,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(9, 30),
+          endTime = LocalTime.of(10, 0),
+        ),
+      ),
+    )
+    val requestedCourt = court(courtBookingRequest.courtId!!)
+
+    whenever(courtRepository.findById(courtBookingRequest.courtId!!)) doReturn Optional.of(requestedCourt)
+    whenever(prisonerSearchClient.getPrisonerAtPrison(prisonCode = prisonCode, prisonerNumber = prisonerNumber)) doReturn Prisoner(prisonerNumber = prisonerNumber, prisonId = prisonCode)
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest) }
+
+    error.message isEqualTo "Court bookings can only have one pre-conference, one hearing and one post-conference."
+  }
+
+  @Test
+  fun `should fail to create a court video booking when too many post-hearing appointments`() {
+    val prisonCode = "MDI"
+    val prisonerNumber = "123456"
+    val courtBookingRequest = courtBookingRequest(
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      appointments = listOf(
+        Appointment(
+          type = AppointmentType.HEARING,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(9, 30),
+          endTime = LocalTime.of(10, 0),
+        ),
+        Appointment(
+          type = AppointmentType.POST_CONFERENCE,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(10, 0),
+          endTime = LocalTime.of(10, 30),
+        ),
+        Appointment(
+          type = AppointmentType.POST_CONFERENCE,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(10, 30),
+          endTime = LocalTime.of(11, 0),
+        ),
+      ),
+    )
+    val requestedCourt = court(courtBookingRequest.courtId!!)
+
+    whenever(courtRepository.findById(courtBookingRequest.courtId!!)) doReturn Optional.of(requestedCourt)
+    whenever(prisonerSearchClient.getPrisonerAtPrison(prisonCode = prisonCode, prisonerNumber = prisonerNumber)) doReturn Prisoner(prisonerNumber = prisonerNumber, prisonId = prisonCode)
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest) }
+
+    error.message isEqualTo "Court bookings can only have one pre-conference, one hearing and one post-conference."
+  }
+
+  @Test
+  fun `should fail to create a court video booking when wrong appointment type`() {
+    val prisonCode = "MDI"
+    val prisonerNumber = "123456"
+    val courtBookingRequest = courtBookingRequest(
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      appointments = listOf(
+        Appointment(
+          type = AppointmentType.HEARING,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(9, 30),
+          endTime = LocalTime.of(10, 0),
+        ),
+        Appointment(
+          type = AppointmentType.POST_CONFERENCE,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(10, 0),
+          endTime = LocalTime.of(10, 30),
+        ),
+        Appointment(
+          type = AppointmentType.PRE_SENTENCE_REPORT,
+          locationKey = "$prisonCode-A-1-001",
+          date = LocalDate.now().plusDays(1),
+          startTime = LocalTime.of(10, 30),
+          endTime = LocalTime.of(11, 0),
+        ),
+      ),
+    )
+    val requestedCourt = court(courtBookingRequest.courtId!!)
+
+    whenever(courtRepository.findById(courtBookingRequest.courtId!!)) doReturn Optional.of(requestedCourt)
+    whenever(prisonerSearchClient.getPrisonerAtPrison(prisonCode = prisonCode, prisonerNumber = prisonerNumber)) doReturn Prisoner(prisonerNumber = prisonerNumber, prisonId = prisonCode)
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest) }
+
+    error.message isEqualTo "Court bookings can only have one pre-conference, one hearing and one post-conference."
   }
 
   @Test
@@ -118,8 +469,8 @@ class CreateVideoBookingServiceTest {
       val prisoner = probationBookingRequest.prisoners.single()
 
       videoBooking isEqualTo persistedVideoBooking
-      prisonCode isEqualTo prisoner.prisonCode!!
-      prisonerNumber isEqualTo prisoner.prisonerNumber!!
+      this.prisonCode isEqualTo prisoner.prisonCode!!
+      this.prisonerNumber isEqualTo prisoner.prisonerNumber!!
       appointmentType isEqualTo prisoner.appointments.single().type?.name
       appointmentDate isEqualTo prisoner.appointments.single().date!!
       startTime isEqualTo prisoner.appointments.single().startTime!!.toMinutePrecision()


### PR DESCRIPTION
This change now adds the creation of appointments for a court bookings.

There are further validation steps required but this gets the end to end flow in place.