### PR TITLE
BAVL-98 these changes fix the missing comments field and checks courts and probation teams are enabled.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
@@ -33,7 +33,9 @@ class VideoBooking private constructor(
 
   val probationMeetingType: String?,
 
-  var videoUrl: String?,
+  var comments: String? = null,
+
+  var videoUrl: String? = null,
 
   val createdBy: String,
 
@@ -63,6 +65,7 @@ class VideoBooking private constructor(
     fun newCourtBooking(
       court: Court,
       hearingType: String,
+      comments: String?,
       videoUrl: String?,
       createdBy: String,
     ): VideoBooking =
@@ -73,6 +76,7 @@ class VideoBooking private constructor(
         hearingType = hearingType,
         probationTeam = null,
         probationMeetingType = null,
+        comments = comments,
         videoUrl = videoUrl,
         createdBy = createdBy,
       )
@@ -80,6 +84,7 @@ class VideoBooking private constructor(
     fun newProbationBooking(
       probationTeam: ProbationTeam,
       probationMeetingType: String,
+      comments: String?,
       videoUrl: String?,
       createdBy: String,
     ): VideoBooking =
@@ -90,6 +95,7 @@ class VideoBooking private constructor(
         hearingType = null,
         probationTeam = probationTeam,
         probationMeetingType = probationMeetingType,
+        comments = comments,
         videoUrl = videoUrl,
         createdBy = createdBy,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -3,20 +3,20 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ProbationTeam
 
-fun court(courtId: Long = 0) = Court(
+fun court(courtId: Long = 0, enabled: Boolean = true) = Court(
   courtId = courtId,
   code = "code",
   description = "description",
-  enabled = true,
+  enabled = enabled,
   notes = null,
   createdBy = "Test",
 )
 
-fun probationTeam(probationTeamId: Long = 0) = ProbationTeam(
+fun probationTeam(probationTeamId: Long = 0, enabled: Boolean = true) = ProbationTeam(
   probationTeamId = probationTeamId,
   code = "code",
   description = "description",
-  enabled = true,
+  enabled = enabled,
   notes = null,
   createdBy = "Test",
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -17,6 +17,7 @@ fun courtBookingRequest(
   locationSuffix: String = "A-1-001",
   startTime: LocalTime = LocalTime.now(),
   endTime: LocalTime = LocalTime.now().plusHours(1),
+  comments: String = "court booking comments",
   appointments: List<Appointment> = emptyList(),
 ): CreateVideoBookingRequest {
   val prisoner = PrisonerDetails(
@@ -40,7 +41,7 @@ fun courtBookingRequest(
     courtId = courtId,
     courtHearingType = CourtHearingType.TRIBUNAL,
     prisoners = listOf(prisoner),
-    comments = "Blah de blah",
+    comments = comments,
     videoLinkUrl = "https://video.link.com",
   )
 }
@@ -56,6 +57,7 @@ fun probationBookingRequest(
   appointmentDate: LocalDate = tomorrow(),
   startTime: LocalTime = LocalTime.now(),
   endTime: LocalTime = LocalTime.now().plusHours(1),
+  comments: String = "probation booking comments",
 ): CreateVideoBookingRequest {
   val appointment = Appointment(
     type = appointmentType,
@@ -76,7 +78,7 @@ fun probationBookingRequest(
     probationTeamId = probationTeamId,
     probationMeetingType = probationMeetingType,
     prisoners = listOf(prisoner),
-    comments = "Blah de blah",
+    comments = comments,
     videoLinkUrl = videoLinkUrl,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -40,6 +40,7 @@ class VideoLinkBookingIntegrationTest : IntegrationTestBase() {
       locationSuffix = "ABCDEDFG",
       startTime = LocalTime.of(12, 0),
       endTime = LocalTime.of(12, 30),
+      comments = "integration test court booking comments",
     )
 
     val bookingId = webTestClient.createBooking(courtBookingRequest)
@@ -51,6 +52,7 @@ class VideoLinkBookingIntegrationTest : IntegrationTestBase() {
       bookingType isEqualTo "COURT"
       court?.courtId isEqualTo courtBookingRequest.courtId
       hearingType isEqualTo courtBookingRequest.courtHearingType?.name
+      comments isEqualTo "integration test court booking comments"
       videoUrl isEqualTo courtBookingRequest.videoLinkUrl
     }
 
@@ -125,6 +127,7 @@ class VideoLinkBookingIntegrationTest : IntegrationTestBase() {
       endTime = LocalTime.of(9, 30),
       appointmentType = AppointmentType.VLB_PROBATION,
       locationSuffix = "ABCDEDFG",
+      comments = "integration test probation booking comments",
     )
 
     val bookingId = webTestClient.createBooking(probationBookingRequest)
@@ -136,6 +139,7 @@ class VideoLinkBookingIntegrationTest : IntegrationTestBase() {
       bookingType isEqualTo "PROBATION"
       probationTeam?.probationTeamId isEqualTo 1
       probationMeetingType isEqualTo ProbationMeetingType.PSR.name
+      comments isEqualTo "integration test probation booking comments"
       videoUrl isEqualTo "https://probation.videolink.com"
       createdBy isEqualTo "TBD"
     }


### PR DESCRIPTION
This change adds the missing comments field for the VideoBooking entity and also now checks the selected court or probation team are enabled prior to creating a booking.