### PR TITLE
BAVL-124: Storing probation teams preferences (similar to courts)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/UserProbation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/UserProbation.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.Hibernate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "user_probation")
+class UserProbation(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val userProbationId: Long = 0,
+
+  @JoinColumn(name = "probation_team_id")
+  @ManyToOne(fetch = FetchType.LAZY)
+  val probationTeam: ProbationTeam,
+
+  val username: String,
+
+  val createdBy: String,
+
+  val createdTime: LocalDateTime = LocalDateTime.now(),
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+
+    other as UserProbation
+
+    return userProbationId == other.userProbationId
+  }
+
+  override fun hashCode(): Int {
+    return userProbationId.hashCode()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/SetProbationTeamPreferencesRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/SetProbationTeamPreferencesRequest.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotEmpty
+
+@Schema(description = "Describes the list of probation teams to set as preferences for a user")
+data class SetProbationTeamPreferencesRequest(
+  @field:Valid
+  @field:NotEmpty(message = "At least one probation team code is required")
+  @Schema(description = "The list of probation team codes to set as the preferences for this username.")
+  val probationTeamCodes: List<String>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/SetProbationTeamPreferencesResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/SetProbationTeamPreferencesResponse.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Describes the response from setting the user probation team preferences")
+data class SetProbationTeamPreferencesResponse(
+  @Schema(description = "The count of probation teams saved as preferences for this user")
+  val probationTeamsSaved: Int = 0,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/ProbationTeamRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/ProbationTeamRepository.kt
@@ -19,4 +19,5 @@ interface ProbationTeamRepository : JpaRepository<ProbationTeam, Long> {
     nativeQuery = true,
   )
   fun findProbationTeamsByUsername(username: String): List<ProbationTeam>
+  fun findAllByCodeIn(codes: List<String>): List<ProbationTeam>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/UserProbationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/UserProbationRepository.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.UserProbation
+
+@Repository
+interface UserProbationRepository : JpaRepository<UserProbation, Long> {
+  @Query(value = "from UserProbation up where up.username = :username")
+  fun findAllByUsername(@Param("username") username: String): List<UserProbation>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/ProbationTeamsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/ProbationTeamsController.kt
@@ -1,20 +1,30 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.getBvlsRequestContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.ProbationTeam
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.SetProbationTeamPreferencesRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.SetProbationTeamPreferencesResponse
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationTeamsService
 
 @Tag(name = "Probation Teams Controller")
@@ -101,4 +111,64 @@ class ProbationTeamsController(private val probationTeamsService: ProbationTeams
   fun probationTeamsUserPreferences(
     @PathVariable("username") username: String,
   ) = probationTeamsService.getUserProbationTeamPreferences(username)
+
+  @Operation(summary = "Endpoint to set the probation team preferences for a user")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Count of the number of probation teams saved in this request",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = SetProbationTeamPreferencesResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid request provided",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  @PostMapping(
+    value = ["/user-preferences/set"],
+    consumes = [MediaType.APPLICATION_JSON_VALUE],
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+  )
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN')")
+  fun setUserProbationTeamPreferences(
+    @Valid
+    @RequestBody
+    @Parameter(description = "The request body containing the user probation team preferences", required = true)
+    request: SetProbationTeamPreferencesRequest,
+    httpRequest: HttpServletRequest,
+  ) = probationTeamsService.setUserProbationTeamPreferences(request, httpRequest.getBvlsRequestContext().username)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ProbationTeamsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ProbationTeamsService.kt
@@ -1,16 +1,39 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.UserProbation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.SetProbationTeamPreferencesRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.SetProbationTeamPreferencesResponse
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.UserProbationRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
 
 @Service
 class ProbationTeamsService(
   private val probationTeamRepository: ProbationTeamRepository,
+  private val userProbationRepository: UserProbationRepository,
 ) {
   fun getEnabledProbationTeams() =
     probationTeamRepository.findAllByEnabledIsTrue().toModel()
 
   fun getUserProbationTeamPreferences(username: String) =
     probationTeamRepository.findProbationTeamsByUsername(username).toModel()
+
+  @Transactional
+  fun setUserProbationTeamPreferences(
+    request: SetProbationTeamPreferencesRequest,
+    username: String,
+  ): SetProbationTeamPreferencesResponse {
+    userProbationRepository.findAllByUsername(username).forEach(userProbationRepository::delete)
+
+    val newTeams = probationTeamRepository.findAllByCodeIn(request.probationTeamCodes).filter { it.enabled }
+
+    // Recreate the UserCourt entities for these courts including the primary key of the related court
+    newTeams.map { probationTeam ->
+      UserProbation(probationTeam = probationTeam, username = username, createdBy = username)
+    }.forEach(userProbationRepository::saveAndFlush)
+
+    return SetProbationTeamPreferencesResponse(probationTeamsSaved = newTeams.size)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CourtsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CourtsResourceIntegrationTest.kt
@@ -93,7 +93,7 @@ class CourtsResourceIntegrationTest : IntegrationTestBase() {
     val courts2 = listOf("SWINCC", "SWINMC", "AMERCC")
     val request2 = SetCourtPreferencesRequest(courtCodes = courts2)
 
-    val response2 = webTestClient.setUserPreferenceCourts(request2, username)
+    webTestClient.setUserPreferenceCourts(request2, username)
 
     val newPreferredCourts = webTestClient.getUserPreferenceCourts(username)
     assertThat(newPreferredCourts).extracting("code").containsAll(courts2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationTeamsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationTeamsResourceIntegrationTest.kt
@@ -10,12 +10,18 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.ProbationTeam
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.SetProbationTeamPreferencesRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.SetProbationTeamPreferencesResponse
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.UserProbationRepository
 
 class ProbationTeamsResourceIntegrationTest : IntegrationTestBase() {
 
   @Autowired
   private lateinit var probationTeamRepository: ProbationTeamRepository
+
+  @Autowired
+  private lateinit var userProbationRepository: UserProbationRepository
 
   @Sql(
     "classpath:integration-test-data/clean-enabled-probation-team-data.sql",
@@ -50,6 +56,52 @@ class ProbationTeamsResourceIntegrationTest : IntegrationTestBase() {
     assertThat(listOfPreferredTeams).extracting("code").doesNotContain("PPOCFD")
   }
 
+  @Test
+  fun `should set a list of preferred probation teams for a specified user`() {
+    val newTeams = listOf("BLKPPP", "BARSPP", "PPOCFD")
+    val username = "test-user@mymail.com"
+    val request = SetProbationTeamPreferencesRequest(probationTeamCodes = newTeams)
+
+    userProbationRepository.findAll() hasSize 0
+
+    val response = webTestClient.setUserPreferenceTeams(request, username)
+
+    assertThat(response?.probationTeamsSaved).isEqualTo(3)
+    userProbationRepository.findAll() hasSize 3
+
+    val listOfPreferredTeams = webTestClient.getUserPreferenceTeams(username)
+    assertThat(listOfPreferredTeams).extracting("code").containsAll(newTeams)
+
+    userProbationRepository.deleteAll()
+  }
+
+  @Test
+  fun `should replace the preferred teams for a specified user`() {
+    val teams1 = listOf("BLKPPP", "BARSPP", "PPOCFD")
+    val username = "test-user@mymail.com"
+    val request1 = SetProbationTeamPreferencesRequest(probationTeamCodes = teams1)
+
+    val response = webTestClient.setUserPreferenceTeams(request1, username)
+    assertThat(response?.probationTeamsSaved).isEqualTo(3)
+
+    userProbationRepository.findAll() hasSize 3
+
+    val listOfPreferredTeams = webTestClient.getUserPreferenceTeams(username)
+    assertThat(listOfPreferredTeams).extracting("code").containsAll(teams1)
+
+    // Replace originals with this set of different teams
+    val teams2 = listOf("PRESPC", "PRESPM", "BURNPC")
+    val request2 = SetProbationTeamPreferencesRequest(probationTeamCodes = teams2)
+
+    webTestClient.setUserPreferenceTeams(request2, username)
+
+    val newPreferredTeams = webTestClient.getUserPreferenceTeams(username)
+    assertThat(newPreferredTeams).extracting("code").containsAll(teams2)
+
+    userProbationRepository.findAll() hasSize 3
+    userProbationRepository.deleteAll()
+  }
+
   private fun WebTestClient.getEnabledProbationTeams() =
     get()
       .uri("/probation-teams/enabled")
@@ -70,5 +122,20 @@ class ProbationTeamsResourceIntegrationTest : IntegrationTestBase() {
       .expectStatus().isOk
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
       .expectBodyList(ProbationTeam::class.java)
+      .returnResult().responseBody
+
+  private fun WebTestClient.setUserPreferenceTeams(
+    request: SetProbationTeamPreferencesRequest,
+    username: String,
+  ) =
+    post()
+      .uri("/probation-teams/user-preferences/set")
+      .bodyValue(request)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(username, roles = listOf("ROLE_BOOK_A_VIDEO_LINK_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SetProbationTeamPreferencesResponse::class.java)
       .returnResult().responseBody
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ProbationTeamsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ProbationTeamsServiceTest.kt
@@ -8,12 +8,14 @@ import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations.openMocks
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.UserProbationRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ProbationTeam as ProbationTeamEntity
 
 class ProbationTeamsServiceTest {
   private val probationTeamRepository: ProbationTeamRepository = mock()
-  private val service = ProbationTeamsService(probationTeamRepository)
+  private val userProbationRepository: UserProbationRepository = mock()
+  private val service = ProbationTeamsService(probationTeamRepository, userProbationRepository)
   private fun generateEntity(id: Long, code: String, desc: String, enabled: Boolean = true, notes: String? = "notes") =
     ProbationTeamEntity(id, code, desc, enabled, notes, "name")
 


### PR DESCRIPTION
This PR adds support for a similar endpoint (as courts) to save the user-selected preferences for probation teams.