### PR TITLE
BAVL-133: Controller, service and repository methods to return a list of prisons

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/Prison.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/Prison.kt
@@ -17,7 +17,9 @@ class Prison(
 
   val code: String,
 
-  val description: String,
+  val name: String,
+
+  val description: String?,
 
   // Enabled == Courts/probation cannot self-serve, but we will accept bookings from the prison (via DPS and A&A)
   val enabled: Boolean,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/Prison.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/Prison.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Describes the details of a prison")
+data class Prison(
+
+  @Schema(description = "An internally-generated unique identifier for this prison.", example = "12345")
+  val prisonId: Long,
+
+  @Schema(description = "A short code for this prison.", example = "BMI")
+  val code: String,
+
+  @Schema(description = "A fuller description for this prison", example = "HMP Birmingham")
+  val name: String,
+
+  @Schema(description = "A fuller description for this prison (usually the same as the name)", example = "HMP Birmingham")
+  val description: String?,
+
+  @Schema(description = "A boolean value to show whether the prison is enabled for self-service video link bookings by court/probation.", example = "true")
+  val enabled: Boolean,
+
+  @Schema(description = "Notes relating to this prison, e.g. number of video-enabled rooms, address.", example = "Free form notes")
+  val notes: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/PrisonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/PrisonRepository.kt
@@ -7,4 +7,5 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Prison
 @Repository
 interface PrisonRepository : JpaRepository<Prison, Long> {
   fun findByCode(prisonCode: String): Prison?
+  fun findAllByEnabledIsTrue(): List<Prison>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/PrisonsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/PrisonsController.kt
@@ -1,0 +1,68 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.PrisonsService
+
+@Tag(name = "Prisons Controller")
+@RestController
+@RequestMapping(value = ["prisons"], produces = [MediaType.APPLICATION_JSON_VALUE])
+class PrisonsController(private val prisonsService: PrisonsService) {
+
+  @Operation(summary = "Endpoint to return the list of prisons known to the service")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "List of prisons",
+        content = [
+          Content(
+            mediaType = "application/json",
+            array = ArraySchema(schema = Schema(implementation = Prison::class)),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  @GetMapping(value = ["/list"], produces = [MediaType.APPLICATION_JSON_VALUE])
+  @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN')")
+  fun prisonsList(
+    @Parameter(description = "EnabledOnly true or false. Defaults to false if not supplied.")
+    @RequestParam(name = "enabledOnly", required = false)
+    enabledOnly: Boolean = false,
+  ): List<Prison> = prisonsService.getListOfPrisons(enabledOnly)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/PrisonsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/PrisonsService.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
+
+@Service
+class PrisonsService(private val prisonRepository: PrisonRepository) {
+  fun getListOfPrisons(enabledOnly: Boolean): List<Prison> {
+    return if (!enabledOnly) {
+      prisonRepository.findAll().toModel()
+    } else {
+      prisonRepository.findAllByEnabledIsTrue().toModel()
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/PrisonMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/PrisonMappers.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping
+
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Prison as PrisonEntity
+
+fun PrisonEntity.toModel() = Prison(
+  prisonId = prisonId,
+  code = code,
+  name = name,
+  description = description,
+  enabled = enabled,
+  notes = notes,
+)
+
+fun List<PrisonEntity>.toModel() = map { it.toModel() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -17,6 +17,7 @@ fun court(courtId: Long = 0, enabled: Boolean = true) = Court(
 fun prison(prisonCode: String, enabled: Boolean = true) = Prison(
   prisonId = 0,
   code = prisonCode,
+  name = "prison name",
   description = "prison description",
   enabled = enabled,
   notes = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/PrisonsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/PrisonsResourceIntegrationTest.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
+
+class PrisonsResourceIntegrationTest : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var prisonRepository: PrisonRepository
+
+  @Test
+  fun `should return a list of enabled prisons`() {
+    prisonRepository.findAllByEnabledIsTrue() hasSize 14
+
+    val listOfEnabledPrisons = webTestClient.getPrisons(true)
+
+    assertThat(listOfEnabledPrisons).hasSize(14)
+    assertThat(listOfEnabledPrisons).extracting("code").contains("WWI")
+    assertThat(listOfEnabledPrisons).extracting("code").doesNotContain("LEI")
+  }
+
+  @Test
+  fun `should return a list of all prisons`() {
+    prisonRepository.findAll() hasSize 112
+
+    val listOfAllPrisons = webTestClient.getPrisons(false)
+
+    assertThat(listOfAllPrisons).hasSize(112)
+    assertThat(listOfAllPrisons).extracting("code").containsAll(listOf("LEI", "BMI", "WWI"))
+  }
+
+  private fun WebTestClient.getPrisons(enabledOnly: Boolean = false) =
+    get()
+      .uri {
+        it.path("/prisons/list")
+          .queryParam("enabledOnly", enabledOnly)
+          .build()
+      }
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation("user", roles = listOf("ROLE_BOOK_A_VIDEO_LINK_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBodyList(Prison::class.java)
+      .returnResult().responseBody
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/PrisonsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/PrisonsServiceTest.kt
@@ -1,0 +1,66 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations.openMocks
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Prison as PrisonEntity
+
+class PrisonsServiceTest {
+  private val prisonRepository: PrisonRepository = mock()
+  private val service = PrisonsService(prisonRepository)
+
+  private fun prisonEntity(id: Long, code: String, name: String, enabled: Boolean = true, notes: String? = "notes") =
+    PrisonEntity(id, code, name, name, enabled, notes, "name")
+
+  @BeforeEach
+  fun setUp() {
+    openMocks(this)
+  }
+
+  @Test
+  fun `Should return a list of enabled prisons`() {
+    val listOfEnabledPrisons = listOf(
+      prisonEntity(1L, "BMI", "Birmingham"),
+      prisonEntity(2L, "LEI", "Leeds"),
+      prisonEntity(3L, "PVI", "Pentonville"),
+    )
+
+    whenever(prisonRepository.findAllByEnabledIsTrue()).thenReturn(listOfEnabledPrisons)
+
+    assertThat(service.getListOfPrisons(true)).isEqualTo(
+      listOfEnabledPrisons.toModel(),
+    )
+
+    verify(prisonRepository).findAllByEnabledIsTrue()
+  }
+
+  @Test
+  fun `Should return a list of all prisons`() {
+    val listOfAllPrisons = listOf(
+      prisonEntity(1L, "BMI", "Birmingham"),
+      prisonEntity(2L, "LEI", "Leeds"),
+      prisonEntity(3L, "PVI", "Pentonville"),
+    )
+
+    whenever(prisonRepository.findAll()).thenReturn(listOfAllPrisons)
+
+    assertThat(service.getListOfPrisons(false)).isEqualTo(
+      listOfAllPrisons.toModel(),
+    )
+
+    verify(prisonRepository).findAll()
+  }
+
+  @Test
+  fun `Should return an empty list when no prisons are enabled`() {
+    whenever(prisonRepository.findAllByEnabledIsTrue()).thenReturn(emptyList())
+    assertThat(service.getListOfPrisons(true)).isEmpty()
+    verify(prisonRepository).findAllByEnabledIsTrue()
+  }
+}


### PR DESCRIPTION
Supply request parameter `enabledOnly=true` to limit just to those enabled for self-service video bookings.
The default is to return all prisons.