### PR TITLE
BAVL-128 correct email contact to owner for new court email and update locations api to use new endpoint.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationsInsidePrisonClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationsInsidePrisonClient.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison
 
 import jakarta.validation.ValidationException
+import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
@@ -9,18 +10,18 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsid
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.extensions.isAtPrison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location
 
+inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>() {}
+
 @Component
 class LocationsInsidePrisonClient(private val locationsInsidePrisonApiWebClient: WebClient) {
 
-  fun getLocationsByKeys(keys: Set<String>): List<Location> = keys.mapNotNull(::getLocationByKey)
-
-  @Deprecated(message = "We are waiting on a post endpoint to avoid multiple location API calls")
-  private fun getLocationByKey(key: String): Location? = locationsInsidePrisonApiWebClient.get()
-    .uri("/locations/key/{key}", key)
+  fun getLocationsByKeys(keys: Set<String>): List<Location> = locationsInsidePrisonApiWebClient.post()
+    .uri("/locations/keys")
+    .bodyValue(keys)
     .retrieve()
-    .bodyToMono(Location::class.java)
+    .bodyToMono(typeReference<List<Location>>())
     .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
-    .block()
+    .block() ?: emptyList()
 }
 
 @Component

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
@@ -52,7 +52,7 @@ class BookingFacade(
       .mapNotNull { contact ->
         // TODO need to look at different contact types as this will dictate which emails/templates to use/send
         when (contact.contactType) {
-          ContactType.COURT -> CourtNewBookingEmail(
+          ContactType.OWNER -> CourtNewBookingEmail(
             address = contact.email!!,
             userName = contact.name ?: "Book Video",
             prisonerFirstName = prisoner.firstName,
@@ -66,7 +66,7 @@ class BookingFacade(
             postAppointmentInfo = post?.let { "${it.startTime.toIsoTime()} to ${it.endTime.toIsoTime()}" },
             comments = booking.comments,
           )
-          else -> null
+          else -> log.info("No contacts found for video booking ID ${booking.videoBookingId}").let { null }
         }
       }.forEach { email ->
         emailService.send(email).onSuccess { (govNotifyId, templateId) ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -1,31 +1,41 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.resource
 
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.bookingContact
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.moorlandLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.ContactType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.NotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingContactsService
 import java.time.LocalDate
 import java.time.LocalTime
 
 class VideoLinkBookingIntegrationTest : IntegrationTestBase() {
+
+  // This is temporary until we can stub the call to the manage users api for establishing the owners email address.
+  @MockBean
+  private lateinit var contactsService: BookingContactsService
 
   @Autowired
   private lateinit var videoBookingRepository: VideoBookingRepository
@@ -43,6 +53,7 @@ class VideoLinkBookingIntegrationTest : IntegrationTestBase() {
 
     prisonSearchApi().stubGetPrisoner("123456", BIRMINGHAM)
     locationsInsidePrisonApi().stubPostLocationByKeys(setOf(birminghamLocation.key), BIRMINGHAM)
+    whenever(contactsService.getBookingContacts(any())) doReturn listOf(bookingContact(contactType = ContactType.OWNER, email = "jon@somewhere.com", name = "Jon"))
 
     val courtBookingRequest = courtBookingRequest(
       prisonerNumber = "123456",
@@ -80,14 +91,11 @@ class VideoLinkBookingIntegrationTest : IntegrationTestBase() {
       comments isEqualTo "integration test court booking comments"
     }
 
-    // There should be three notifications for 3 court contacts
-    with(notificationRepository.findAll()) {
-      this hasSize 3
-      all { it.templateName == "fake template id" } isBool true
-      all { it.videoBooking == persistedBooking } isBool true
-      single { it.email == "t@t.com" }
-      single { it.email == "m@m.com" }
-      single { it.email == "s@s.com" }
+    // There should be one owner notification email
+    with(notificationRepository.findAll().single()) {
+      templateName isEqualTo "fake template id"
+      videoBooking isEqualTo persistedBooking
+      email isEqualTo "jon@somewhere.com"
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/LocationsInsidePrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/LocationsInsidePrisonApiMockServer.kt
@@ -1,7 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock
 
+import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
-import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.post
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
@@ -12,35 +13,33 @@ import java.util.UUID
 class LocationsInsidePrisonApiMockServer : MockServer(8091) {
 
   fun stubPostLocationByKeys(keys: Set<String>, prisonId: String = "MDI") {
-    keys.forEach { k -> stubGetLocationByKey(k, prisonId) }
-  }
-
-  private fun stubGetLocationByKey(key: String, prisonId: String = "MDI") {
-    val id = UUID.randomUUID()
-
     stubFor(
-      get("/locations/key/$key").willReturn(
-        aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withBody(
-            mapper.writeValueAsString(
-              Location(
-                id = id,
-                prisonId = prisonId,
-                code = "001",
-                pathHierarchy = "A-1-001",
-                locationType = Location.LocationType.VIDEO_LINK,
-                permanentlyInactive = false,
-                active = true,
-                deactivatedByParent = false,
-                topLevelId = id,
-                key = key,
-                isResidential = true,
+      post("/locations/keys")
+        .withRequestBody(WireMock.equalToJson(mapper.writeValueAsString(keys)))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              mapper.writeValueAsString(
+                keys.map { key ->
+                  Location(
+                    id = UUID.randomUUID(),
+                    prisonId = prisonId,
+                    code = "001",
+                    pathHierarchy = "A-1-001",
+                    locationType = Location.LocationType.VIDEO_LINK,
+                    permanentlyInactive = false,
+                    active = true,
+                    deactivatedByParent = false,
+                    topLevelId = UUID.randomUUID(),
+                    key = key,
+                    isResidential = true,
+                  )
+                },
               ),
-            ),
-          )
-          .withStatus(200),
-      ),
+            )
+            .withStatus(200),
+        ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
@@ -61,7 +61,7 @@ class BookingFacadeTest {
     whenever(bookingService.create(bookingRequest, "facade court user")) doReturn Pair(booking, prisoner(prisonerNumber = "123456", prisonCode = MOORLAND))
     whenever(prisonAppointmentRepository.findByVideoBooking(booking)) doReturn listOf(appointment)
     whenever(prisonRepository.findByCode(MOORLAND)) doReturn prison(MOORLAND)
-    whenever(bookingContactsService.getBookingContacts(any())) doReturn listOf(bookingContact(contactType = ContactType.COURT, email = "jon@somewhere.com", name = "Jon"))
+    whenever(bookingContactsService.getBookingContacts(any())) doReturn listOf(bookingContact(contactType = ContactType.OWNER, email = "jon@somewhere.com", name = "Jon"))
 
     val notificationId = UUID.randomUUID()
 


### PR DESCRIPTION
This changes a call to the locations api to use a new post endpoint for locations so we can make one call instead of many calls for locations.

It also corrects the (initial) email contact type.  There are still more emails to be sent on creation of a booking.