### PR TITLE
BAVL-134 added checks to ensure we only send owner emails to verified email addresses only.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/manageusers/ManageUsersClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/manageusers/ManageUsersClient.kt
@@ -20,11 +20,11 @@ class ManageUsersClient(private val manageUsersApiWebClient: WebClient) {
   fun getUsersEmail(username: String): EmailAddressDto? =
     manageUsersApiWebClient
       .get()
-      .uri("/users/{username}/email", username)
+      .uri("/users/{username}/email?unverified=false", username)
       .retrieve()
       .bodyToMono(EmailAddressDto::class.java)
       .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
-      .block()
+      .block()?.takeIf(EmailAddressDto::verified)
 }
 
 data class UserDetailsDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/manageusers/ManageUsersClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/manageusers/ManageUsersClientTest.kt
@@ -21,10 +21,17 @@ class ManageUsersClientTest {
   }
 
   @Test
-  fun `should get users email`() {
-    server.stubGetUserEmail("username", "email")
+  fun `should return a verified users email`() {
+    server.stubGetUserEmail("username", "verified@email.com", true)
 
-    client.getUsersEmail("username") isEqualTo userEmail("username", "email")
+    client.getUsersEmail("username") isEqualTo userEmail("username", "verified@email.com")
+  }
+
+  @Test
+  fun `should not return an unverified users email`() {
+    server.stubGetUserEmail("username", "unverified@email.com", false)
+
+    client.getUsersEmail("username") isEqualTo null
   }
 
   @AfterEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -49,7 +49,7 @@ fun prisonerSearchPrisoner(
   lastName = lastName,
 )
 
-fun userEmail(username: String, email: String) = EmailAddressDto(username, email, true)
+fun userEmail(username: String, email: String, verified: Boolean = true) = EmailAddressDto(username, email, verified)
 
 fun userDetails(username: String, name: String) = UserDetailsDto(
   username = username,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ManageUsersApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ManageUsersApiMockServer.kt
@@ -23,13 +23,13 @@ class ManageUsersApiMockServer : MockServer(8093) {
     )
   }
 
-  fun stubGetUserEmail(username: String = TEST_USERNAME, email: String = TEST_USER_EMAIL) {
+  fun stubGetUserEmail(username: String = TEST_USERNAME, email: String = TEST_USER_EMAIL, verified: Boolean = true) {
     stubFor(
-      get("/users/$username/email")
+      get("/users/$username/email?unverified=false")
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
-            .withBody(mapper.writeValueAsString(userEmail(username, email)))
+            .withBody(mapper.writeValueAsString(userEmail(username, email, verified)))
             .withStatus(200),
         ),
     )


### PR DESCRIPTION
Strictly speaking we should not need this (default call to users API should only return verified) but I have added as a precautionary measure given the change/impact is very small.