### PR TITLE
BAVL-142 changes to prevent sumbission of invalid dates which would be otherwise be rounded as a result of default lenient dates.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/HmppsBookAVideoLinkApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/HmppsBookAVideoLinkApiExceptionHandler.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.resource.NoResourceFoundException
@@ -58,7 +59,7 @@ class HmppsBookAVideoLinkApiExceptionHandler {
       ),
     ).also { log.error("Unexpected exception", e) }
 
-  @ExceptionHandler(IllegalArgumentException::class)
+  @ExceptionHandler(IllegalArgumentException::class, HttpMessageNotReadableException::class)
   fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<ErrorResponse> {
     log.info("Exception: {}", e.message)
     return ResponseEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
@@ -137,7 +137,7 @@ data class Appointment(
   @field:NotNull(message = "The date for the appointment is mandatory")
   @field:Future(message = "The date for the appointment must be in the future")
   @Schema(description = "The future date for which the appointment will start", example = "2022-12-23")
-  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "uuuu-MM-dd")
   val date: LocalDate?,
 
   @field:NotNull(message = "The start time for the appointment is mandatory")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,7 @@ spring:
     date-format: "yyyy-MM-dd HH:mm:ss"
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false
+    default-leniency: false
 
   security:
     oauth2:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
@@ -1,0 +1,140 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.resource
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.context.web.WebAppConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.BvlsRequestContext
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingFacade
+import uk.gov.justice.hmpps.kotlin.auth.HmppsResourceServerConfiguration
+import java.time.LocalDateTime
+
+/**
+ * As a general guideline we primarily test controllers in integration tests. This is an exception due to wanting to get
+ * some (early) test coverage in particular around the preventing the API accepting lenient dates.
+ */
+@ExtendWith(SpringExtension::class)
+@AutoConfigureMockMvc
+@Import(HmppsResourceServerConfiguration::class)
+@ActiveProfiles("test")
+@WebAppConfiguration
+@WebMvcTest(controllers = [VideoLinkBookingController::class])
+@ContextConfiguration(classes = [VideoLinkBookingController::class])
+class VideoLinkBookingControllerTest {
+
+  @MockBean
+  private lateinit var bookingFacade: BookingFacade
+
+  @Autowired
+  private lateinit var context: WebApplicationContext
+
+  private val objectMapper = jacksonObjectMapper().registerModules(JavaTimeModule())
+
+  private lateinit var mockMvc: MockMvc
+
+  @BeforeEach
+  fun before() {
+    mockMvc = MockMvcBuilders
+      .webAppContextSetup(context)
+      .build()
+  }
+
+  @WithMockUser(username = "FRED", roles = ["BOOK_A_VIDEO_LINK_ADMIN"])
+  @Test
+  fun `should fail to accept invalid appointment date provided when date leniency is disabled in configuration`() {
+    val json = """
+{
+  "bookingType": "COURT",
+  "prisoners": [
+    {
+      "prisonCode": "BMI",
+      "prisonerNumber": "G5662GI",
+      "appointments": [
+        {
+          "type": "VLB_COURT_MAIN",
+          "locationKey": "BMI-VIDEOLINK-ROOM1",
+          "date": "2200-02-31",
+          "startTime": "10:00",
+          "endTime": "11:00"
+        }
+      ]
+    }
+  ],
+  "courtId": 1,
+  "courtHearingType": "APPEAL",
+  "comments": "Waiting to hear on legal representation",
+  "videoLinkUrl": "https://video.here.com"
+}
+    """.trimIndent()
+
+    mockMvc.post("/video-link-booking") {
+      contentType = MediaType.APPLICATION_JSON
+      content = json
+      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext("FRED", LocalDateTime.now()))
+    }
+      .andExpect {
+        status { isBadRequest() }
+      }
+
+    verifyNoInteractions(bookingFacade)
+  }
+
+  @WithMockUser(username = "FRED", roles = ["BOOK_A_VIDEO_LINK_ADMIN"])
+  @Test
+  fun `should succeed when valid appointment date provided`() {
+    val json = """
+{
+  "bookingType": "COURT",
+  "prisoners": [
+    {
+      "prisonCode": "BMI",
+      "prisonerNumber": "G5662GI",
+      "appointments": [
+        {
+          "type": "VLB_COURT_MAIN",
+          "locationKey": "BMI-VIDEOLINK-ROOM1",
+          "date": "2200-02-28",
+          "startTime": "10:00",
+          "endTime": "11:00"
+        }
+      ]
+    }
+  ],
+  "courtId": 1,
+  "courtHearingType": "APPEAL",
+  "comments": "Waiting to hear on legal representation",
+  "videoLinkUrl": "https://video.here.com"
+}
+    """.trimIndent()
+
+    mockMvc.post("/video-link-booking") {
+      contentType = MediaType.APPLICATION_JSON
+      content = json
+      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext("FRED", LocalDateTime.now()))
+    }
+      .andExpect {
+        status { isCreated() }
+      }
+
+    verify(bookingFacade).create(objectMapper.readValue(json, CreateVideoBookingRequest::class.java), "FRED")
+  }
+}


### PR DESCRIPTION
So I struggled to get a unit or integration test to confirm these changes work, I have tested this manually.

Perhaps have a quick read [here](https://makemeengr.com/uuuu-versus-yyyy-in-datetimeformatter-formatting-pattern-codes-in-java/) and [here](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html).