### PR TITLE
BAVL-128 updates to support sending emails to prisons on creation of booking.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
@@ -19,7 +19,9 @@ import java.util.UUID
 @Configuration
 class EmailConfiguration(
   @Value("\${notify.api.key:}") private val apiKey: String,
-  @Value("\${notify.templates.court.new-booking:}") private val courtNewBooking: String,
+  @Value("\${notify.templates.new-court-booking.owner:}") private val newCourtBookingOwner: String,
+  @Value("\${notify.templates.new-court-booking.prison-court-email:}") private val newCourtBookingPrisonCourtEmail: String,
+  @Value("\${notify.templates.new-court-booking.prison-no-court-email:}") private val newCourtBookingPrisonNoCourtEmail: String,
 ) {
 
   companion object {
@@ -35,7 +37,9 @@ class EmailConfiguration(
     }
 
   private fun emailTemplates() = EmailTemplates(
-    courtNewBooking = courtNewBooking,
+    newCourtBookingOwner = newCourtBookingOwner,
+    newCourtBookingPrisonCourtEmail = newCourtBookingPrisonCourtEmail,
+    newCourtBookingPrisonNoCourtEmail = newCourtBookingPrisonNoCourtEmail,
   )
 }
 
@@ -54,13 +58,13 @@ abstract class Email(
   prisonerLastName: String,
   prisonerNumber: String,
   date: LocalDate = LocalDate.now(),
-  comments: String? = "",
+  comments: String? = null,
 ) {
   private val common = mapOf(
     "date" to date.toMediumFormatStyle(),
     "prisonerName" to prisonerFirstName.plus(" $prisonerLastName"),
     "offenderNo" to prisonerNumber,
-    "comments" to comments,
+    "comments" to (comments ?: "None entered"),
   )
   private val personalisation: MutableMap<String, String?> = mutableMapOf()
 
@@ -72,5 +76,7 @@ abstract class Email(
 }
 
 data class EmailTemplates(
-  val courtNewBooking: String,
+  val newCourtBookingOwner: String,
+  val newCourtBookingPrisonCourtEmail: String,
+  val newCourtBookingPrisonNoCourtEmail: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/BookingContact.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/BookingContact.kt
@@ -25,6 +25,8 @@ data class BookingContact(
   val email: String?,
 
   val telephone: String?,
+
+  val primaryContact: Boolean,
 )
 
 data class UniquePropertyId(val contactType: String, val email: String?) : Serializable {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/BookingContact.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/BookingContact.kt
@@ -13,7 +13,10 @@ data class BookingContact(
   @Schema(description = "Describes the contact name (optional)", example = "Mr. Person-contact")
   val name: String?,
 
-  @Schema(description = "Describes the position or role of the contact person (optional)", example = "BVLS Administrator")
+  @Schema(
+    description = "Describes the position or role of the contact person (optional)",
+    example = "BVLS Administrator",
+  )
   val position: String? = null,
 
   @Schema(description = "Describes the email address of this contact (optional)", example = "example@example.com")
@@ -21,6 +24,16 @@ data class BookingContact(
 
   @Schema(description = "Describes the telephone number of this contact (optional)", example = "00902 0909779")
   val telephone: String? = null,
+
+  @Schema(
+    description = """
+    Describes the whether the contact is a primary contact or not, true if yes otherwise false.
+    
+    There will only ever be one primary contact for each contact type e.g. a court will only have one primary contact.
+  """,
+    example = "true",
+  )
+  val primaryContact: Boolean,
 )
 
 enum class ContactType {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingContactsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingContactsService.kt
@@ -39,6 +39,7 @@ class BookingContactsService(
           contactType = ContactType.OWNER,
           name = mayBeCreatedByContactDetails.name,
           email = mayBeCreatedByContactDetails.email,
+          primaryContact = true,
         ),
       )
     }
@@ -54,6 +55,7 @@ class BookingContactsService(
             contactType = ContactType.OWNER,
             name = mayBeAmendedByContactDetails.name,
             email = mayBeAmendedByContactDetails.email,
+            primaryContact = true,
           ),
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/BookingContactMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/BookingContactMappers.kt
@@ -11,6 +11,7 @@ fun BookingContactEntity.toModel() = BookingContact(
   position = position,
   email = email,
   telephone = telephone,
+  primaryContact = primaryContact,
 )
 
 fun List<BookingContactEntity>.toModel() = map { it.toModel() }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,8 +101,11 @@ management:
 
 notify:
   templates:
-    court:
-      new-booking: "c8d61c0f-1fa0-4281-9597-a45780e345d4"
+    new-court-booking:
+      owner: "c8d61c0f-1fa0-4281-9597-a45780e345d4"
+      prison-court-email: "bf2c340e-31a4-45db-bc70-e902ee499ec5"
+      prison-no-court-email: "d555929e-c8a5-4771-911b-4538ba259eba"
+
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/migrations/common/R__v_booking_contacts.sql
+++ b/src/main/resources/migrations/common/R__v_booking_contacts.sql
@@ -1,21 +1,21 @@
 CREATE OR REPLACE VIEW v_booking_contacts
     AS
-    select vlb.video_booking_id, 'COURT' as contact_type, cc.name, cc.position, cc.email, cc.telephone
+    select vlb.video_booking_id, 'COURT' as contact_type, cc.name, cc.position, cc.email, cc.telephone, cc.primary_contact
     from video_booking vlb, court c, court_contact cc
     where vlb.court_id = c.court_id
     and cc.court_id = c.court_id
   UNION
-    select vlb.video_booking_id, 'PROBATION' as contact_type, ptc.name, ptc.position, ptc.email, ptc.telephone
+    select vlb.video_booking_id, 'PROBATION' as contact_type, ptc.name, ptc.position, ptc.email, ptc.telephone, ptc.primary_contact
     from video_booking vlb, probation_team pt, probation_team_contact ptc
     where vlb.probation_team_id = pt.probation_team_id
     and ptc.probation_team_id = pt.probation_team_id
   UNION
-    select vlb.video_booking_id, 'PRISON' as contact_type, pc.name, pc.position, pc.email, pc.telephone
+    select vlb.video_booking_id, 'PRISON' as contact_type, pc.name, pc.position, pc.email, pc.telephone, pc.primary_contact
     from video_booking vlb, prison_appointment pa, prison p, prison_contact pc
     where pa.video_booking_id = vlb.video_booking_id
     and pa.prison_code = p.code
     and pc.prison_id = p.prison_id
   UNION
-    select vlb.video_booking_id, 'THIRD_PARTY' as contact_type, tp.name, tp.organisation as position, tp.email, tp.telephone
+    select vlb.video_booking_id, 'THIRD_PARTY' as contact_type, tp.name, tp.organisation as position, tp.email, tp.telephone, tp.primary_contact
     from video_booking vlb, third_party tp
     where tp.video_booking_id = vlb.video_booking_id;

--- a/src/main/resources/migrations/common/V2024.04.22__baseline_tables.sql
+++ b/src/main/resources/migrations/common/V2024.04.22__baseline_tables.sql
@@ -59,6 +59,7 @@ CREATE TABLE court_contact
     position            varchar(100),
     enabled             boolean NOT NULL,
     notes               varchar(200),
+    primary_contact     boolean NOT NULL,
     created_by          varchar(100) NOT NULL,
     created_time        timestamp NOT NULL,
     amended_by          varchar(100),
@@ -108,6 +109,7 @@ CREATE TABLE probation_team_contact
     position             varchar(100),
     enabled              boolean NOT NULL,
     notes                varchar(200),
+    primary_contact      boolean NOT NULL,
     created_by           varchar(100) NOT NULL,
     created_time         timestamp NOT NULL,
     amended_by           varchar(100),
@@ -143,18 +145,19 @@ CREATE UNIQUE INDEX idx_prison_code ON prison(code);
 
 CREATE TABLE prison_contact
 (
-    prison_contact_id  bigserial NOT NULL CONSTRAINT prison_contact_id_pk PRIMARY KEY,
-    prison_id bigint NOT NULL REFERENCES prison(prison_id),
-    name varchar(100) NOT NULL,
-    email varchar(100),
-    telephone varchar(20),
-    position varchar(100),
-    enabled boolean NOT NULL,
-    notes varchar(200),
-    created_by   varchar(100) NOT NULL,
-    created_time timestamp NOT NULL,
-    amended_by   varchar(100),
-    amended_time timestamp
+    prison_contact_id bigserial NOT NULL CONSTRAINT prison_contact_id_pk PRIMARY KEY,
+    prison_id         bigint NOT NULL REFERENCES prison(prison_id),
+    name              varchar(100) NOT NULL,
+    email             varchar(100),
+    telephone         varchar(20),
+    position          varchar(100),
+    enabled boolean   NOT NULL,
+    notes             varchar(200),
+    primary_contact   boolean NOT NULL,
+    created_by        varchar(100) NOT NULL,
+    created_time      timestamp NOT NULL,
+    amended_by        varchar(100),
+    amended_time      timestamp
 );
 
 CREATE INDEX idx_prison_prison_id ON prison_contact(prison_id);
@@ -240,7 +243,8 @@ CREATE TABLE third_party
     organisation       varchar(100),
     email              varchar(100),
     telephone          varchar(20),
-    created_by         varchar(100) NOT NULL, 
+    primary_contact    boolean NOT NULL,
+    created_by         varchar(100) NOT NULL,
     created_time       timestamp NOT NULL,
     amended_by         varchar(100), 
     amended_time       timestamp

--- a/src/main/resources/migrations/common/V2024.04.23__baseline_data.sql
+++ b/src/main/resources/migrations/common/V2024.04.23__baseline_data.sql
@@ -390,10 +390,10 @@ alter sequence if exists court_court_id_seq restart with 327;
 
 ---
 
-insert into court_contact (court_contact_id, court_id, name, email, telephone, position, enabled, notes, created_by, created_time)
-values (1, 1, 'Tim Hipkins', 't@t.com', '0117 282442', 'Court Clerk', true, '', 'TIM', current_timestamp),
-       (2, 1, 'Matt Hipkins', 'm@m.com', '0117 282443', 'Court Clerk', true, '', 'TIM', current_timestamp),
-       (3, 1, 'Steve Hipkins', 's@s.com', '0117 282444', 'Court Clerk', true, '', 'TIM', current_timestamp);
+insert into court_contact (court_contact_id, court_id, name, email, telephone, position, enabled, notes, primary_contact, created_by, created_time)
+values (1, 1, 'Tim Hipkins', 't@t.com', '0117 282442', 'Court Clerk', true, '', true, 'TIM', current_timestamp),
+       (2, 1, 'Matt Hipkins', 'm@m.com', '0117 282443', 'Court Clerk', true, '', false, 'TIM', current_timestamp),
+       (3, 1, 'Steve Hipkins', 's@s.com', '0117 282444', 'Court Clerk', true, '', false, 'TIM', current_timestamp);
 
 alter sequence if exists court_contact_court_contact_id_seq restart with 4;
 
@@ -433,10 +433,10 @@ alter sequence if exists probation_team_probation_team_id_seq restart with 29;
 
 ---
 
-insert into probation_team_contact (probation_team_contact_id, probation_team_id, name, email, telephone, position, enabled, notes, created_by, created_time)
-values (1, 1, 'Tim Hipkins', 't@t.com', '0117 282442', 'Court Clerk', true, '', 'TIM', current_timestamp),
-       (2, 1, 'Matt Hipkins', 'm@m.com', '0117 282443', 'Court Clerk', true, '', 'TIM', current_timestamp),
-       (3, 1, 'Steve Hipkins', 's@s.com', '0117 282444', 'Court Clerk', true, '', 'TIM', current_timestamp);
+insert into probation_team_contact (probation_team_contact_id, probation_team_id, name, email, telephone, position, enabled, notes, primary_contact, created_by, created_time)
+values (1, 1, 'Tim Hipkins', 't@t.com', '0117 282442', 'Court Clerk', true, '', true, 'TIM', current_timestamp),
+       (2, 1, 'Matt Hipkins', 'm@m.com', '0117 282443', 'Court Clerk', true, '', false, 'TIM', current_timestamp),
+       (3, 1, 'Steve Hipkins', 's@s.com', '0117 282444', 'Court Clerk', true, '', false, 'TIM', current_timestamp);
 
 alter sequence if exists probation_team_contact_probation_team_contact_id_seq restart with 4;
 
@@ -562,9 +562,10 @@ alter sequence if exists prison_prison_id_seq restart with 113;
 
 ---
 
-insert into prison_contact (prison_contact_id, prison_id, name, email, telephone, position, enabled, notes, created_by, created_time)
-values (1, 1, 'Tim Hopkins', 't@t.com', '0117 282442', 'Video Admin', true, '', 'TIM', current_timestamp),
-       (2, 1, 'Matt Hopkins', 'm@m.com', '0117 282443', 'Video Admin', true, '', 'TIM', current_timestamp),
-       (3, 1, 'Steve Hopkins', 's@s.com', '0117 282444', 'Video Admin', true, '', 'TIM', current_timestamp);
+insert into prison_contact (prison_contact_id, prison_id, name, email, telephone, position, enabled, notes, primary_contact, created_by, created_time)
+values (1, 1, 'Tim Hopkins', 't@t.com', '0117 282442', 'Video Admin', true, '', true, 'TIM', current_timestamp),
+       (2, 1, 'Matt Hopkins', 'm@m.com', '0117 282443', 'Video Admin', true, '', false, 'TIM', current_timestamp),
+       (3, 1, 'Steve Hopkins', 's@s.com', '0117 282444', 'Video Admin', true, '', false, 'TIM', current_timestamp),
+       (4, 33, 'Jane Hopkins', 'j@j.com', '0117 282445', 'Video Admin', true, '', true, 'TIM', current_timestamp);
 
-alter sequence if exists prison_contact_prison_contact_id_seq restart with 4;
+alter sequence if exists prison_contact_prison_contact_id_seq restart with 5;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/Courts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/Courts.kt
@@ -1,0 +1,4 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper
+
+const val CHESTERFIELD_JUSTICE_CENTRE = "CHSTMC"
+const val DERBY_JUSTICE_CENTRE = "DRBYMC"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -153,4 +153,5 @@ fun bookingContact(contactType: ContactType, email: String?, name: String? = nul
   position = null,
   email = email,
   telephone = null,
+  primaryContact = true,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ProbationTeams.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ProbationTeams.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper
+
+const val BLACKPOOL_MC_PPOC = "BLKPPP"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/BookingContactsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/BookingContactsResourceIntegrationTest.kt
@@ -7,10 +7,12 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WERRINGTON
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.moorlandLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.werringtonLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
@@ -103,14 +105,14 @@ class BookingContactsResourceIntegrationTest : IntegrationTestBase() {
     val bookingCreator = "BOOKING_CREATOR"
     videoBookingRepository.findAll() hasSize 0
 
-    prisonSearchApi().stubGetPrisoner("A1111AA", BIRMINGHAM)
-    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(birminghamLocation.key), BIRMINGHAM)
+    prisonSearchApi().stubGetPrisoner("A1111AA", MOORLAND)
+    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(moorlandLocation.key), MOORLAND)
 
     val courtBookingRequest = courtBookingRequest(
       courtCode = "NWPIAC",
       prisonerNumber = "A1111AA",
-      prisonCode = BIRMINGHAM,
-      location = birminghamLocation,
+      prisonCode = MOORLAND,
+      location = moorlandLocation,
       startTime = LocalTime.of(12, 0),
       endTime = LocalTime.of(12, 30),
       comments = "integration test court booking comments",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
@@ -40,7 +40,7 @@ class BookingFacadeTest {
 
   private val facade = BookingFacade(bookingService, bookingContactsService, prisonAppointmentRepository, prisonRepository, emailService, notificationRepository)
 
-  private val emailCaptor = argumentCaptor<CourtNewBookingEmail>()
+  private val emailCaptor = argumentCaptor<NewCourtBookingEmail>()
   private val notificationCaptor = argumentCaptor<Notification>()
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailServiceTest.kt
@@ -27,16 +27,18 @@ class GovNotifyEmailServiceTest {
   private val client: NotificationClient =
     mock { on { sendEmail(any(), any(), any(), anyOrNull()) } doReturn sendEmailResponse }
   private val emailTemplates = EmailTemplates(
-    courtNewBooking = "template 1",
+    newCourtBookingOwner = "template 1",
+    newCourtBookingPrisonCourtEmail = "template 2",
+    newCourtBookingPrisonNoCourtEmail = "template 3",
   )
 
   private val service = GovNotifyEmailService(client, emailTemplates)
 
   @Test
-  fun `should send booking by court email and return a notification ID`() {
+  fun `should send court new booking email and return a notification ID`() {
     val result = service.send(
-      CourtNewBookingEmail(
-        address = "address 1",
+      NewCourtBookingEmail(
+        address = "recipient@emailaddress.com",
         prisonerFirstName = "builder",
         prisonerLastName = "bob",
         prisonerNumber = "123456",
@@ -55,13 +57,131 @@ class GovNotifyEmailServiceTest {
 
     verify(client).sendEmail(
       "template 1",
-      "address 1",
+      "recipient@emailaddress.com",
       mapOf(
         "date" to today.toMediumFormatStyle(),
         "prisonerName" to "builder bob",
         "offenderNo" to "123456",
         "comments" to "comments for bob",
         "userName" to "username",
+        "court" to "the court",
+        "prison" to "the prison",
+        "preAppointmentInfo" to "bobs pre-appointment info",
+        "mainAppointmentInfo" to "bobs main appointment info",
+        "postAppointmentInfo" to "bob post appointment info",
+      ),
+      null,
+    )
+  }
+
+  @Test
+  fun `should send court new booking email with no pre and post appoint or no comments, and return a notification ID`() {
+    val result = service.send(
+      NewCourtBookingEmail(
+        address = "recipient@emailaddress.com",
+        prisonerFirstName = "builder",
+        prisonerLastName = "bob",
+        prisonerNumber = "123456",
+        date = today,
+        userName = "username",
+        comments = null,
+        preAppointmentInfo = null,
+        mainAppointmentInfo = "bobs main appointment info",
+        postAppointmentInfo = null,
+        court = "the court",
+        prison = "the prison",
+      ),
+    )
+
+    result.getOrThrow() isEqualTo Pair(notificationId, "template 1")
+
+    verify(client).sendEmail(
+      "template 1",
+      "recipient@emailaddress.com",
+      mapOf(
+        "date" to today.toMediumFormatStyle(),
+        "prisonerName" to "builder bob",
+        "offenderNo" to "123456",
+        "comments" to "None entered",
+        "userName" to "username",
+        "court" to "the court",
+        "prison" to "the prison",
+        "preAppointmentInfo" to "Not required",
+        "mainAppointmentInfo" to "bobs main appointment info",
+        "postAppointmentInfo" to "Not required",
+      ),
+      null,
+    )
+  }
+
+  @Test
+  fun `should send prison new booking with court email and return a notification ID`() {
+    val result = service.send(
+      NewCourtBookingPrisonCourtEmail(
+        address = "recipient@emailaddress.com",
+        prisonerFirstName = "builder",
+        prisonerLastName = "bob",
+        prisonerNumber = "123456",
+        date = today,
+        comments = "comments for bob",
+        preAppointmentInfo = "bobs pre-appointment info",
+        mainAppointmentInfo = "bobs main appointment info",
+        postAppointmentInfo = "bob post appointment info",
+        court = "the court",
+        courtEmailAddress = "court@emailaddress.com",
+        prison = "the prison",
+      ),
+    )
+
+    result.getOrThrow() isEqualTo Pair(notificationId, "template 2")
+
+    verify(client).sendEmail(
+      "template 2",
+      "recipient@emailaddress.com",
+      mapOf(
+        "date" to today.toMediumFormatStyle(),
+        "prisonerName" to "builder bob",
+        "offenderNo" to "123456",
+        "comments" to "comments for bob",
+        "court" to "the court",
+        "courtEmailAddress" to "court@emailaddress.com",
+        "prison" to "the prison",
+        "preAppointmentInfo" to "bobs pre-appointment info",
+        "mainAppointmentInfo" to "bobs main appointment info",
+        "postAppointmentInfo" to "bob post appointment info",
+      ),
+      null,
+    )
+  }
+
+  @Test
+  fun `should send prison new booking with no court email and return a notification ID`() {
+    val result = service.send(
+      NewCourtBookingPrisonNoCourtEmail(
+        address = "recipient@emailaddress.com",
+        prisonerFirstName = "builder",
+        prisonerLastName = "bob",
+        prisonerNumber = "123456",
+        date = today,
+        comments = "comments for bob",
+        preAppointmentInfo = "bobs pre-appointment info",
+        mainAppointmentInfo = "bobs main appointment info",
+        postAppointmentInfo = "bob post appointment info",
+        court = "the court",
+        prison = "the prison",
+      ),
+    )
+
+    result.getOrThrow() isEqualTo Pair(notificationId, "template 3")
+
+    verify(client).sendEmail(
+      "template 3",
+      "recipient@emailaddress.com",
+      mapOf(
+        "date" to today.toMediumFormatStyle(),
+        "prisonerName" to "builder bob",
+        "offenderNo" to "123456",
+        "comments" to "comments for bob",
         "court" to "the court",
         "prison" to "the prison",
         "preAppointmentInfo" to "bobs pre-appointment info",
@@ -88,7 +208,7 @@ class GovNotifyEmailServiceTest {
     whenever(client.sendEmail(any(), any(), any(), anyOrNull())) doThrow exception
 
     val result = service.send(
-      CourtNewBookingEmail(
+      NewCourtBookingEmail(
         address = "address 1",
         prisonerFirstName = "builder",
         prisonerLastName = "bob",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/NewCourtBookingEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/NewCourtBookingEmailTest.kt
@@ -4,11 +4,11 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntriesExactlyInAnyOrder
 import java.time.LocalDate
 
-class CourtNewBookingEmailTest {
+class NewCourtBookingEmailTest {
 
   @Test
   fun `should personalise court new booking email`() {
-    val email = CourtNewBookingEmail(
+    val email = NewCourtBookingEmail(
       address = "address 1",
       prisonerFirstName = "builder",
       prisonerLastName = "bob",

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,5 +1,8 @@
 spring:
 
+  main:
+    allow-bean-definition-overriding: true
+
   jpa:
     show-sql: true
 


### PR DESCRIPTION
These changes add in additional emails on the creation journey for prisons.

Two new prison emails have been added, one where we have a contact for a court and one where we don't have a court contact.