### PR TITLE
BAV-170 availability check and suggestions for free rooms at the prison

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoAppointment.kt
@@ -7,6 +7,10 @@ import org.springframework.data.annotation.Immutable
 import java.time.LocalDate
 import java.time.LocalTime
 
+/**
+ * This entity represents a view projection for v_video_appointments, and contains the prison appointments
+ * for the criteria specified in the repository methods (different purposes). It is read-only (immutable).
+ */
 @Entity
 @Immutable
 @Table(name = "v_video_appointments")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoAppointment.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.Immutable
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Entity
+@Immutable
+@Table(name = "v_video_appointments")
+data class VideoAppointment(
+  @Id
+  val prisonAppointmentId: Long,
+
+  val videoBookingId: Long,
+
+  val bookingType: String,
+
+  val statusCode: String,
+
+  val courtCode: String?,
+
+  val probationTeamCode: String?,
+
+  val prisonCode: String,
+
+  val prisonerNumber: String,
+
+  val appointmentType: String,
+
+  val prisonLocKey: String,
+
+  val appointmentDate: LocalDate,
+
+  val startTime: LocalTime,
+
+  val endTime: LocalTime,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode
 import jakarta.validation.Constraint
 import jakarta.validation.ConstraintValidator
 import jakarta.validation.ConstraintValidatorContext
@@ -13,27 +14,52 @@ import kotlin.reflect.KClass
 
 @Schema(description = "The request object sent to the availability check endpoint")
 data class AvailabilityRequest(
-  @Schema(description = "The booking type", example = "COURT")
+  @Schema(
+    description = "The booking type",
+    example = "COURT",
+    requiredMode = RequiredMode.REQUIRED,
+  )
   val bookingType: BookingType,
 
   @field:NotEmpty(message = "Court or probation team code is mandatory")
-  @Schema(description = "The court code or probation team code", example = "DRBYMC")
+  @Schema(
+    description = "The court code or probation team code",
+    example = "DRBYMC",
+    requiredMode = RequiredMode.REQUIRED,
+  )
   val courtOrProbationCode: String,
 
   @field:NotEmpty(message = "The prison code must be present")
-  @Schema(description = "The prison code where these appointment will take place", example = "MDI")
+  @Schema(
+    description = "The prison code where these appointment will take place",
+    example = "MDI",
+    requiredMode = RequiredMode.REQUIRED,
+  )
   val prisonCode: String,
 
-  @Schema(description = "The date for the appointments related to this booking (must be on the same day)", example = "2024-04-05")
+  @Schema(
+    description = "The date for the appointments on this booking (must all be on the same day)",
+    example = "2024-04-05",
+    requiredMode = RequiredMode.REQUIRED,
+  )
   val date: LocalDate,
 
-  @Schema(description = "If present, the prison location and start/end time of the requested pre-conference, else null")
+  @Schema(
+    description = "If present, the prison location and start/end time of the requested pre-conference, else null",
+    requiredMode = RequiredMode.NOT_REQUIRED,
+  )
   val preAppointment: LocationAndInterval? = null,
 
-  @Schema(description = "The date of these appointments", example = "2024-04-05", required = true)
+  @Schema(
+    description = "The main appointment which is always present",
+    requiredMode = RequiredMode.REQUIRED,
+  )
   val mainAppointment: LocationAndInterval,
 
-  @Schema(description = "If present, the prison location and start/end time of the post-conference, else null")
+  @Schema(
+    description = "If present, the prison location and start/end time of the post-conference, else null",
+    requiredMode = RequiredMode.NOT_REQUIRED,
+  )
   val postAppointment: LocationAndInterval? = null,
 )
 
@@ -41,10 +67,17 @@ data class AvailabilityRequest(
 data class LocationAndInterval(
 
   @field:NotEmpty(message = "The prison location key must be present")
-  @Schema(description = "The location of the appointment at the prison", example = "VCC-ROOM-1", required = true)
+  @Schema(
+    description = "The location of the appointment at the prison",
+    example = "VCC-ROOM-1",
+    requiredMode = RequiredMode.REQUIRED,
+  )
   val prisonLocKey: String,
 
-  @Schema(description = "", example = "MDI", required = false)
+  @Schema(
+    description = "The start and end time of a prison appointment to define the interval",
+    requiredMode = RequiredMode.NOT_REQUIRED,
+  )
   @field:ValidInterval
   val interval: Interval,
 ) {
@@ -54,10 +87,18 @@ data class LocationAndInterval(
 
 @Schema(description = "A time interval between a start and end time")
 data class Interval(
-  @Schema(description = "The interval start time, inclusive. ISO-8601 format (hh:mm)", example = "09:00")
+  @Schema(
+    description = "The interval start time, inclusive. ISO-8601 format (hh:mm)",
+    example = "09:00",
+    requiredMode = RequiredMode.REQUIRED,
+  )
   val start: LocalTime,
 
-  @Schema(description = "The interval end time (inclusive). ISO-8601 format (hh:mm)", example = "09:30")
+  @Schema(
+    description = "The interval end time (inclusive). ISO-8601 format (hh:mm)",
+    example = "09:30",
+    requiredMode = RequiredMode.REQUIRED,
+  )
   val end: LocalTime,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
@@ -1,0 +1,80 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Constraint
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import jakarta.validation.Payload
+import jakarta.validation.constraints.NotEmpty
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlin.reflect.KClass
+
+@Schema(description = "The request object sent to the availability check endpoint")
+data class AvailabilityRequest(
+  @field:NotEmpty(message = "Booking type is mandatory")
+  @Schema(description = "The booking type", example = "COURT")
+  val bookingType: BookingType,
+
+  @field:NotEmpty(message = "Court or probation team code is mandatory")
+  @Schema(description = "The court code or probation team code", example = "DRBYMC")
+  val courtOrProbationCode: String,
+
+  @field:NotEmpty(message = "The prison code must be present")
+  @Schema(description = "The prison code where these appointment will take place", example = "MDI")
+  val prisonCode: String,
+
+  @Schema(description = "The date for the appointments related to this booking (must be on the same day)", example = "2024-04-05")
+  val date: LocalDate,
+
+  @Schema(description = "If present, the prison location and start/end time of the requested pre-conference, else null")
+  val preAppointment: LocationAndInterval? = null,
+
+  @Schema(description = "The date of these appointments", example = "2024-04-05", required = true)
+  val mainAppointment: LocationAndInterval,
+
+  @Schema(description = "If present, the prison location and start/end time of the post-conference, else null")
+  val postAppointment: LocationAndInterval? = null,
+)
+
+@Schema(description = "The prison location key and start/end interval for an appointment slot")
+data class LocationAndInterval(
+
+  @field:NotEmpty(message = "The prison location key must be present")
+  @Schema(description = "The location of the appointment at the prison", example = "VCC-ROOM-1", required = true)
+  val prisonLocKey: String,
+
+  @Schema(description = "", example = "MDI", required = false)
+  @field:ValidInterval
+  val interval: Interval,
+) {
+  fun shift(duration: Duration): LocationAndInterval =
+    copy(interval = Interval(interval.start.plus(duration), interval.end.plus(duration)))
+}
+
+@Schema(description = "A time interval between a start and end time")
+data class Interval(
+  @Schema(description = "The interval start time, inclusive. ISO-8601 format (hh:mm)", example = "09:00")
+  val start: LocalTime,
+
+  @Schema(description = "The interval end time (inclusive). ISO-8601 format (hh:mm)", example = "09:30")
+  val end: LocalTime,
+)
+
+@Target(AnnotationTarget.TYPE, AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [IntervalValidator::class])
+annotation class ValidInterval(
+  val message: String = "start must precede end",
+  val groups: Array<KClass<out Any>> = [],
+  val payload: Array<KClass<out Payload>> = [],
+)
+
+class IntervalValidator : ConstraintValidator<ValidInterval, Interval> {
+  override fun isValid(interval: Interval?, context: ConstraintValidatorContext?) =
+    when (interval) {
+      null -> true
+      else -> interval.start.isBefore(interval.end)
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
@@ -19,7 +19,7 @@ data class AvailabilityRequest(
     example = "COURT",
     requiredMode = RequiredMode.REQUIRED,
   )
-  val bookingType: BookingType,
+  val bookingType: BookingType?,
 
   @field:NotEmpty(message = "Court or probation team code is mandatory")
   @Schema(
@@ -27,7 +27,7 @@ data class AvailabilityRequest(
     example = "DRBYMC",
     requiredMode = RequiredMode.REQUIRED,
   )
-  val courtOrProbationCode: String,
+  val courtOrProbationCode: String?,
 
   @field:NotEmpty(message = "The prison code must be present")
   @Schema(
@@ -35,7 +35,7 @@ data class AvailabilityRequest(
     example = "MDI",
     requiredMode = RequiredMode.REQUIRED,
   )
-  val prisonCode: String,
+  val prisonCode: String?,
 
   @Schema(
     description = "The date for the appointments on this booking (must all be on the same day)",
@@ -72,7 +72,7 @@ data class LocationAndInterval(
     example = "VCC-ROOM-1",
     requiredMode = RequiredMode.REQUIRED,
   )
-  val prisonLocKey: String,
+  val prisonLocKey: String?,
 
   @Schema(
     description = "The start and end time of a prison appointment to define the interval",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
@@ -13,7 +13,6 @@ import kotlin.reflect.KClass
 
 @Schema(description = "The request object sent to the availability check endpoint")
 data class AvailabilityRequest(
-  @field:NotEmpty(message = "Booking type is mandatory")
   @Schema(description = "The booking type", example = "COURT")
   val bookingType: BookingType,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/AvailabilityResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/AvailabilityResponse.kt
@@ -1,0 +1,62 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AvailabilityRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.LocationAndInterval
+import java.time.Duration
+import java.time.LocalTime
+
+@Schema(description = "Availability check response")
+data class AvailabilityResponse(
+  @Schema(description = "Set to true when all the locations and times for this booking are available, or false when not.", example = "true")
+  val availabilityOk: Boolean = true,
+
+  @Schema(description = "A list of alternative times and locations for the requested appointment on this booking, or empty list")
+  val alternatives: List<BookingOption> = emptyList(),
+)
+
+@Schema(description = "Video link booking option")
+data class BookingOption(
+  @Schema(description = "The pre appointment location and time", required = false)
+  val pre: LocationAndInterval? = null,
+
+  @Schema(description = "The main appointment location and time", required = true)
+  val main: LocationAndInterval,
+
+  @Schema(description = "The post appointment location and time", required = false)
+  val post: LocationAndInterval? = null,
+) {
+
+  fun copyStartingAt(startTime: LocalTime): BookingOption {
+    val offset = Duration.between(earliestStartTime(), startTime)
+    return BookingOption(
+      pre = this.pre?.shift(offset),
+      main = this.main.shift(offset),
+      post = this.post?.shift(offset),
+    )
+  }
+
+  fun toLocationsAndIntervals() = listOfNotNull(pre, main, post)
+
+  fun endsOnOrBefore(endTime: LocalTime): Boolean = latestEndTime().isBefore(endTime) || latestEndTime() == endTime
+
+  private fun earliestStartTime(): LocalTime = pre?.interval?.start ?: main.interval.start
+
+  private fun latestEndTime(): LocalTime = post?.interval?.end ?: main.interval.end
+
+  companion object {
+    // Converts the availability check request into a booking option
+    fun from(request: AvailabilityRequest) =
+      BookingOption(
+        pre = request.preAppointment?.let {
+          LocationAndInterval(prisonLocKey = it.prisonLocKey, interval = it.interval)
+        },
+        main = request.mainAppointment.let {
+          LocationAndInterval(prisonLocKey = it.prisonLocKey, interval = it.interval)
+        },
+        post = request.postAppointment?.let {
+          LocationAndInterval(prisonLocKey = it.prisonLocKey, interval = it.interval)
+        },
+      )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/AvailabilityResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/AvailabilityResponse.kt
@@ -40,9 +40,9 @@ data class BookingOption(
 
   fun endsOnOrBefore(endTime: LocalTime): Boolean = latestEndTime().isBefore(endTime) || latestEndTime() == endTime
 
-  private fun earliestStartTime(): LocalTime = pre?.interval?.start ?: main.interval.start
+  private fun earliestStartTime(): LocalTime = pre?.interval?.start ?: main.interval.start!!
 
-  private fun latestEndTime(): LocalTime = post?.interval?.end ?: main.interval.end
+  private fun latestEndTime(): LocalTime = post?.interval?.end ?: main.interval.end!!
 
   companion object {
     // Converts the availability check request into a booking option
@@ -52,7 +52,7 @@ data class BookingOption(
           LocationAndInterval(prisonLocKey = it.prisonLocKey, interval = it.interval)
         },
         main = request.mainAppointment.let {
-          LocationAndInterval(prisonLocKey = it.prisonLocKey, interval = it.interval)
+          LocationAndInterval(prisonLocKey = it!!.prisonLocKey, interval = it.interval)
         },
         post = request.postAppointment?.let {
           LocationAndInterval(prisonLocKey = it.prisonLocKey, interval = it.interval)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/VideoAppointmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/VideoAppointmentRepository.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoAppointment
+import java.time.LocalDate
+
+@Repository
+interface VideoAppointmentRepository : JpaRepository<VideoAppointment, Long> {
+  @Query(
+    value = """
+      FROM VideoAppointment va 
+      WHERE va.appointmentDate = :forDate
+      AND va.prisonCode  = :forPrison
+      AND va.prisonLocKey in (:forLocationKeys)
+      AND va.statusCode = 'ACTIVE'
+      ORDER BY va.prisonLocKey, va.startTime
+    """,
+  )
+  fun findVideoAppointmentsAtPrison(
+    forDate: LocalDate,
+    forPrison: String,
+    forLocationKeys: List<String>,
+  ): List<VideoAppointment>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/AvailabilityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/AvailabilityController.kt
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
-import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
@@ -16,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.ErrorResponse
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.getBvlsRequestContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AvailabilityRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AvailabilityResponse
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.AvailabilityService
@@ -68,6 +66,5 @@ class AvailabilityController(val availabilityService: AvailabilityService) {
     @RequestBody
     @Parameter(description = "The request containing the times and locations of hearings to check for availability", required = true)
     request: AvailabilityRequest,
-    httpRequest: HttpServletRequest,
-  ) = availabilityService.checkAvailability(request, httpRequest.getBvlsRequestContext().username)
+  ) = availabilityService.checkAvailability(request)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/AvailabilityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/AvailabilityController.kt
@@ -1,0 +1,73 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.Valid
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.getBvlsRequestContext
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AvailabilityRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AvailabilityResponse
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.AvailabilityService
+
+@Tag(name = "Availability Controller")
+@RestController
+@RequestMapping(value = ["availability"], produces = [MediaType.APPLICATION_JSON_VALUE])
+class AvailabilityController(val availabilityService: AvailabilityService) {
+
+  @Operation(summary = "Endpoint to assess booking availability and to suggest alternatives")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Availability response, including any suggested alternative booking options",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = AvailabilityResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
+  @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN')")
+  fun checkAvailability(
+    @Valid
+    @RequestBody
+    @Parameter(description = "The request containing the times and locations of hearings to check for availability", required = true)
+    request: AvailabilityRequest,
+    httpRequest: HttpServletRequest,
+  ) = availabilityService.checkAvailability(request, httpRequest.getBvlsRequestContext().username)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityFinderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityFinderService.kt
@@ -1,0 +1,146 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AvailabilityRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Interval
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AvailabilityResponse
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingOption
+import java.time.LocalTime
+import java.util.*
+
+@Service
+class AvailabilityFinderService(
+  private val availabilityOptionsGenerator: AvailabilityOptionsGenerator,
+
+  @Value("\${video-link-booking.options.max-alternatives}")
+  private val maxAlternatives: Int = 3,
+) {
+
+  fun getOptions(request: AvailabilityRequest, appointments: List<VideoAppointment>): AvailabilityResponse {
+    // Create a Map of <PrisonLocKey, Timeline> from the existing appointments - so we can check and find gaps
+    val timelinesByLocation = timelinesByLocationKey(appointments)
+
+    // Convert the requested times into a booking option object
+    val preferredOption = BookingOption.from(request)
+
+    // If the requested times are available, return ok with no alternatives
+    if (optionIsBookable(preferredOption, timelinesByLocation)) {
+      return AvailabilityResponse(availabilityOk = true, alternatives = emptyList())
+    }
+
+    // Find upto the maximum number of alternative booking times for these rooms
+    val alternatives = availabilityOptionsGenerator
+      .getOptionsInPreferredOrder(preferredOption)
+      .filter { optionIsBookable(it, timelinesByLocation) }
+      .take(maxAlternatives)
+      .sortedBy { it.main.interval.start }
+
+    // Return the alternative booking suggestions
+    return AvailabilityResponse(availabilityOk = false, alternatives = alternatives.toList())
+  }
+
+  companion object {
+
+    fun optionIsBookable(option: BookingOption, timelinesByLocationId: Map<String, Timeline>) =
+      option
+        .toLocationsAndIntervals()
+        .all { timelinesByLocationId[it.prisonLocKey]?.isFreeForInterval(it.interval) ?: true }
+
+    fun timelinesByLocationKey(appointments: List<VideoAppointment>): Map<String, Timeline> =
+      appointments
+        .groupBy { it.prisonLocKey }
+        .mapValues { (_, appointments) -> appointments.flatMap(::toEvents) }
+        .mapValues { Timeline(it.value) }
+
+    private fun toEvents(appointment: VideoAppointment) =
+      listOf(StartEvent(appointment.startTime), EndEvent(appointment.endTime))
+  }
+}
+
+/**
+ * Utility classes for constructing a timeline of existing appointment start/end times, within which to
+ * check and find available slots.
+ */
+
+sealed class Event(val time: LocalTime)
+
+class StartEvent(time: LocalTime) : Event(time)
+
+class EndEvent(time: LocalTime) : Event(time)
+
+/**
+ * The Timeline class is constructed with the list of video appointment start/end times occurring today.
+ * Its init block it will process all events passed in the constructor, and identify the free periods.
+ */
+
+class Timeline(events: List<Event>) {
+  private val emptyPeriods = TreeMap<LocalTime, LocalTime>()
+
+  init {
+    var currentBookings = 0
+
+    var previousEventTime: LocalTime = LocalTime.MIN
+
+    var freePeriodStarted: LocalTime? = LocalTime.MIN
+
+    fun updateStateForPreviousEventTime() {
+      when (currentBookings) {
+        0 -> {
+          // The room became, or continued to be, unoccupied
+          if (freePeriodStarted == null) {
+            // The room became unoccupied
+            freePeriodStarted = previousEventTime
+          }
+        }
+        else -> {
+          // The room became, or continued to be occupied
+          if (freePeriodStarted != null) {
+            // The room became occupied at previousEventTime.
+            emptyPeriods[freePeriodStarted!!] = previousEventTime
+            freePeriodStarted = null
+          }
+        }
+      }
+    }
+
+    events
+      .plus(StartEvent(LocalTime.MAX))
+      .sortedBy { it.time }
+      .forEach {
+        if (it.time > previousEventTime) {
+          updateStateForPreviousEventTime()
+        }
+
+        currentBookings += when (it) {
+          is StartEvent -> 1
+          is EndEvent -> -1
+        }
+
+        previousEventTime = it.time
+      }
+
+    // Handle the end of day
+    updateStateForPreviousEventTime()
+  }
+
+  /**
+   * A List of pairs of start and end times representing the free periods.  Ordered by start time ascending.
+   * Used for testing only.
+   */
+  fun emptyPeriods() = emptyPeriods.navigableKeySet().map {
+    Pair(it, emptyPeriods[it])
+  }
+
+  /**
+   * Answer the question 'is this Timeline free of appointments during the specified interval'.
+   */
+  fun isFreeForInterval(interval: Interval): Boolean {
+    if (interval.end.isBefore(interval.start)) {
+      throw IllegalArgumentException("start must precede end")
+    }
+    val freePeriod = emptyPeriods.floorEntry(interval.start)
+    return interval.end.isBefore(freePeriod.value) || interval.end == freePeriod.value
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityFinderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityFinderService.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Interva
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AvailabilityResponse
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingOption
 import java.time.LocalTime
-import java.util.*
+import java.util.TreeMap
 
 @Service
 class AvailabilityFinderService(
@@ -25,7 +25,7 @@ class AvailabilityFinderService(
     // Convert the requested times into a booking option object
     val preferredOption = BookingOption.from(request)
 
-    // If the requested times are available, return ok with no alternatives
+    // If the preferred option (requested times) is available, return ok with no alternatives
     if (optionIsBookable(preferredOption, timelinesByLocation)) {
       return AvailabilityResponse(availabilityOk = true, alternatives = emptyList())
     }
@@ -37,7 +37,7 @@ class AvailabilityFinderService(
       .take(maxAlternatives)
       .sortedBy { it.main.interval.start }
 
-    // Return the alternative booking suggestions
+    // Return the alternatives
     return AvailabilityResponse(availabilityOk = false, alternatives = alternatives.toList())
   }
 
@@ -72,7 +72,8 @@ class EndEvent(time: LocalTime) : Event(time)
 
 /**
  * The Timeline class is constructed with the list of video appointment start/end times occurring today.
- * Its init block it will process all events passed in the constructor, and identify the free periods.
+ * Its init block it will process all events passed in the constructor, and identify the free periods for each
+ * of the rooms requested.
  */
 
 class Timeline(events: List<Event>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityFinderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityFinderService.kt
@@ -138,7 +138,7 @@ class Timeline(events: List<Event>) {
    * Answer the question 'is this Timeline free of appointments during the specified interval'.
    */
   fun isFreeForInterval(interval: Interval): Boolean {
-    if (interval.end.isBefore(interval.start)) {
+    if (interval.end!!.isBefore(interval.start)) {
       throw IllegalArgumentException("start must precede end")
     }
     val freePeriod = emptyPeriods.floorEntry(interval.start)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityOptionsGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityOptionsGenerator.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingOption
+import java.time.Duration
+import java.time.LocalTime
+
+@Component
+class AvailabilityOptionsGenerator(
+  @DateTimeFormat(iso = DateTimeFormat.ISO.TIME)
+  @Value("\${video-link-booking.options.day-start}")
+  val dayStart: LocalTime,
+
+  @DateTimeFormat(iso = DateTimeFormat.ISO.TIME)
+  @Value("\${video-link-booking.options.day-end}")
+  val dayEnd: LocalTime,
+
+  @Value("\${video-link-booking.options.step}")
+  val step: Duration,
+) {
+  fun getOptionsInPreferredOrder(preferredOption: BookingOption): Sequence<BookingOption> =
+    durations(step)
+      .map { dayStart.plus(it) }
+      .map { preferredOption.copyStartingAt(it) }
+      .takeWhile { it.endsOnOrBefore(dayEnd) }
+      .sortedBy { Duration.between(preferredOption.main.interval.start, it.main.interval.start).abs() }
+
+  companion object {
+    fun durations(delta: Duration) = generateSequence(Duration.ZERO) { it.plus(delta) }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
@@ -30,7 +30,7 @@ class AvailabilityService(
    *  - Incorporate prison room decoration logic here, to find other rooms?
    */
 
-  fun checkAvailability(request: AvailabilityRequest, username: String): AvailabilityResponse {
+  fun checkAvailability(request: AvailabilityRequest): AvailabilityResponse {
     // Gather the distinct list of locations from the request
     val listOfLocationKeys = listOfNotNull(
       request.preAppointment?.prisonLocKey,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
@@ -43,7 +43,7 @@ class AvailabilityService(
     // Get the existing VLB appointments at these locations, on this date
     val videoAppointments = videoAppointmentRepository.findVideoAppointmentsAtPrison(
       forDate = request.date,
-      forPrison = request.prisonCode,
+      forPrison = request.prisonCode!!,
       forLocationKeys = listOfLocationKeys,
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
@@ -35,14 +35,14 @@ class AvailabilityService(
     val listOfLocationKeys = listOfNotNull(
       request.preAppointment?.prisonLocKey,
       request.postAppointment?.prisonLocKey,
-      request.mainAppointment.prisonLocKey,
+      request.mainAppointment!!.prisonLocKey,
     ).distinct()
 
     log.info("Checking availability for locationKeys $listOfLocationKeys")
 
     // Get the existing VLB appointments at these locations, on this date
     val videoAppointments = videoAppointmentRepository.findVideoAppointmentsAtPrison(
-      forDate = request.date,
+      forDate = request.date!!,
       forPrison = request.prisonCode!!,
       forLocationKeys = listOfLocationKeys,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AvailabilityRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AvailabilityResponse
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoAppointmentRepository
+
+@Service
+class AvailabilityService(
+  private val videoAppointmentRepository: VideoAppointmentRepository,
+  private val availabilityFinderService: AvailabilityFinderService,
+) {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  /**
+   * Assumptions:
+   *  - we consider ONLY video link bookings (not other appointment types from NOMIS or A&A in these locations)
+   *  - we consider ONLY bookings present in the BVLS service, not in A&A or NOMIS (i.e. all video link bookings)
+   *  - current booking journeys for BVLS allows only one person at one prison per booking.
+   *  - we consider ONLY the prison locations in the request for alternative times (we do not consider others - yet)
+   *  - the decision about whether a user is allowed to book into a locations is still the users own.
+   *  - we assume all appointments for this booking are on the same day and at the same prison
+   *
+   * To consider later:
+   *  - Get other VCC-enabled rooms at these prison(s) and offer them?
+   *  - Incorporate prison room decoration logic here, to find other rooms?
+   */
+
+  fun checkAvailability(request: AvailabilityRequest, username: String): AvailabilityResponse {
+    // Gather the distinct list of locations from the request
+    val listOfLocationKeys = listOfNotNull(
+      request.preAppointment?.prisonLocKey,
+      request.postAppointment?.prisonLocKey,
+      request.mainAppointment.prisonLocKey,
+    ).distinct()
+
+    log.info("Checking availability for locationKeys $listOfLocationKeys")
+
+    // Get the existing VLB appointments at these locations, on this date
+    val videoAppointments = videoAppointmentRepository.findVideoAppointmentsAtPrison(
+      forDate = request.date,
+      forPrison = request.prisonCode,
+      forLocationKeys = listOfLocationKeys,
+    )
+
+    log.info("Found ${videoAppointments.size} appointments in these rooms")
+
+    // Check if the requested times are free, and offer alternatives if not
+    return availabilityFinderService.getOptions(request, videoAppointments)
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,3 +107,11 @@ notify:
 springdoc:
   swagger-ui:
     tags-sorter: alpha
+
+# Options to configure suggested alternative booking times
+video-link-booking:
+  options:
+    day-start: "10:00"
+    day-end: "17:00"
+    step: "PT15M"
+    max-alternatives: 3

--- a/src/main/resources/migrations/common/R__v_video_appointments.sql
+++ b/src/main/resources/migrations/common/R__v_video_appointments.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE VIEW v_video_appointments
+AS
+select
+  pa.prison_appointment_id,
+  vlb.video_booking_id,
+  vlb.booking_type,
+  vlb.status_code,
+  c.code as "court_code",
+  pt.code as "probation_team_code",
+  pa.prison_code,
+  pa.prisoner_number,
+  pa.appointment_type,
+  pa.prison_loc_key,
+  pa.appointment_date,
+  pa.start_time,
+  pa.end_time
+from video_booking vlb
+  left join court c on c.court_id = vlb.court_id and c.enabled = true
+  left join probation_team pt on pt.probation_team_id = vlb.probation_team_id and pt.enabled = true
+  join prison_appointment pa on pa.video_booking_id = vlb.video_booking_id
+  join prison p on p.code = pa.prison_code and p.enabled = true;

--- a/src/main/resources/migrations/common/R__v_video_appointments.sql
+++ b/src/main/resources/migrations/common/R__v_video_appointments.sql
@@ -5,8 +5,8 @@ select
   vlb.video_booking_id,
   vlb.booking_type,
   vlb.status_code,
-  c.code as "court_code",
-  pt.code as "probation_team_code",
+  c.code as court_code,
+  pt.code as probation_team_code,
   pa.prison_code,
   pa.prisoner_number,
   pa.appointment_type,
@@ -18,4 +18,4 @@ from video_booking vlb
   left join court c on c.court_id = vlb.court_id and c.enabled = true
   left join probation_team pt on pt.probation_team_id = vlb.probation_team_id and pt.enabled = true
   join prison_appointment pa on pa.video_booking_id = vlb.video_booking_id
-  join prison p on p.code = pa.prison_code and p.enabled = true;
+  join prison p on p.code = pa.prison_code;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/AvailabilityResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/AvailabilityResourceIntegrationTest.kt
@@ -1,0 +1,210 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WERRINGTON
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.werringtonLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AvailabilityRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Interval
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.LocationAndInterval
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AvailabilityResponse
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
+import java.time.LocalDate
+import java.time.LocalTime
+
+class AvailabilityResourceIntegrationTest : IntegrationTestBase() {
+  @Autowired
+  private lateinit var videoBookingRepository: VideoBookingRepository
+
+  @Test
+  fun `should confirm availability for a court booking when the prison room is free`() {
+    val bookingCreator = "BOOKING_CREATOR"
+
+    videoBookingRepository.findAll() hasSize 0
+
+    // With no bookings present, the availability check should succeed
+    val availabilityRequest = AvailabilityRequest(
+      bookingType = BookingType.COURT,
+      courtOrProbationCode = "DRBYMC",
+      prisonCode = WERRINGTON,
+      date = LocalDate.now().plusDays(1),
+      mainAppointment = LocationAndInterval(
+        werringtonLocation.key,
+        Interval(
+          start = LocalTime.of(12, 0),
+          end = LocalTime.of(12, 30),
+        ),
+      ),
+    )
+
+    val availabilityResponse = webTestClient.availabilityCheck(bookingCreator, availabilityRequest)
+
+    assertThat(availabilityResponse).isNotNull
+    with(availabilityResponse) {
+      assertThat(availabilityOk).isTrue()
+      assertThat(alternatives).isEmpty()
+    }
+  }
+
+  @Test
+  fun `should offer alternatives for a court booking when the prison room is already occupied`() {
+    val bookingCreator = "BOOKING_CREATOR"
+
+    videoBookingRepository.findAll() hasSize 0
+
+    prisonSearchApi().stubGetPrisoner("A1111AA", WERRINGTON)
+    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(werringtonLocation.key), WERRINGTON)
+
+    val courtBookingRequest = courtBookingRequest(
+      courtCode = "DRBYMC",
+      prisonerNumber = "A1111AA",
+      prisonCode = WERRINGTON,
+      location = werringtonLocation,
+      startTime = LocalTime.of(12, 0),
+      endTime = LocalTime.of(12, 30),
+      comments = "integration test court booking comments",
+    )
+
+    webTestClient.createBooking(bookingCreator, courtBookingRequest)
+
+    // Do the availability check for a booking at the same time as the existing booking above
+    val availabilityRequest = AvailabilityRequest(
+      bookingType = BookingType.COURT,
+      courtOrProbationCode = "DRBYMC",
+      prisonCode = WERRINGTON,
+      date = LocalDate.now().plusDays(1),
+      mainAppointment = LocationAndInterval(
+        werringtonLocation.key,
+        Interval(
+          start = LocalTime.of(12, 0),
+          end = LocalTime.of(12, 30),
+        ),
+      ),
+    )
+
+    val availabilityResponse = webTestClient.availabilityCheck(bookingCreator, availabilityRequest)
+
+    assertThat(availabilityResponse).isNotNull
+    with(availabilityResponse) {
+      assertThat(availabilityOk).isFalse()
+      assertThat(alternatives).isNotEmpty()
+      assertThat(alternatives).hasSize(3)
+    }
+  }
+
+  @Test
+  fun `should confirm availability for a probation booking when the prison room is free`() {
+    val bookingCreator = "BOOKING_CREATOR"
+
+    videoBookingRepository.findAll() hasSize 0
+
+    val availabilityRequest = AvailabilityRequest(
+      bookingType = BookingType.PROBATION,
+      courtOrProbationCode = "BLKPPP",
+      prisonCode = WERRINGTON,
+      date = LocalDate.now().plusDays(1),
+      mainAppointment = LocationAndInterval(
+        werringtonLocation.key,
+        Interval(
+          start = LocalTime.of(12, 0),
+          end = LocalTime.of(12, 30),
+        ),
+      ),
+    )
+
+    val availabilityResponse = webTestClient.availabilityCheck(bookingCreator, availabilityRequest)
+
+    assertThat(availabilityResponse).isNotNull
+    with(availabilityResponse) {
+      assertThat(availabilityOk).isTrue()
+      assertThat(alternatives).isEmpty()
+    }
+  }
+
+  @Test
+  fun `should return alternatives for a probation booking when the prison room is already occupied`() {
+    val bookingCreator = "BOOKING_CREATOR"
+
+    videoBookingRepository.findAll() hasSize 0
+
+    prisonSearchApi().stubGetPrisoner("A1111AA", WERRINGTON)
+    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(werringtonLocation.key), WERRINGTON)
+
+    val probationBookingRequest = probationBookingRequest(
+      probationTeamCode = "BLKPPP",
+      probationMeetingType = ProbationMeetingType.PSR,
+      videoLinkUrl = "https://probation.videolink.com",
+      prisonCode = WERRINGTON,
+      prisonerNumber = "A1111AA",
+      startTime = LocalTime.of(9, 0),
+      endTime = LocalTime.of(9, 30),
+      appointmentType = AppointmentType.VLB_PROBATION,
+      location = werringtonLocation,
+    )
+
+    webTestClient.createBooking(bookingCreator, probationBookingRequest)
+
+    videoBookingRepository.findAll() hasSize 1
+
+    // Check for availability of the times just created i.e. an overlapping appointment
+    val availabilityRequest = AvailabilityRequest(
+      bookingType = BookingType.PROBATION,
+      courtOrProbationCode = "BLKPPP",
+      prisonCode = WERRINGTON,
+      date = LocalDate.now().plusDays(1),
+      mainAppointment = LocationAndInterval(
+        werringtonLocation.key,
+        Interval(
+          start = LocalTime.of(9, 0),
+          end = LocalTime.of(9, 30),
+        ),
+      ),
+    )
+
+    val availabilityResponse = webTestClient.availabilityCheck(bookingCreator, availabilityRequest)
+
+    assertThat(availabilityResponse).isNotNull
+    with(availabilityResponse) {
+      assertThat(availabilityOk).isFalse()
+      assertThat(alternatives).isNotEmpty()
+      assertThat(alternatives).hasSize(3)
+    }
+  }
+
+  private fun WebTestClient.createBooking(username: String, request: CreateVideoBookingRequest) =
+    this
+      .post()
+      .uri("/video-link-booking")
+      .bodyValue(request)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(user = username, roles = listOf("ROLE_BOOK_A_VIDEO_LINK_ADMIN")))
+      .exchange()
+      .expectStatus().isCreated
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(Long::class.java)
+      .returnResult().responseBody!!
+
+  private fun WebTestClient.availabilityCheck(username: String, request: AvailabilityRequest) =
+    this
+      .post()
+      .uri("/availability")
+      .bodyValue(request)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(user = username, roles = listOf("ROLE_BOOK_A_VIDEO_LINK_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(AvailabilityResponse::class.java)
+      .returnResult().responseBody!!
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/AvailabilityResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/AvailabilityResourceIntegrationTest.kt
@@ -98,7 +98,6 @@ class AvailabilityResourceIntegrationTest : IntegrationTestBase() {
     assertThat(availabilityResponse).isNotNull
     with(availabilityResponse) {
       assertThat(availabilityOk).isFalse()
-      assertThat(alternatives).isNotEmpty()
       assertThat(alternatives).hasSize(3)
     }
   }
@@ -177,7 +176,6 @@ class AvailabilityResourceIntegrationTest : IntegrationTestBase() {
     assertThat(availabilityResponse).isNotNull
     with(availabilityResponse) {
       assertThat(availabilityOk).isFalse()
-      assertThat(alternatives).isNotEmpty()
       assertThat(alternatives).hasSize(3)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityServiceTest.kt
@@ -1,0 +1,221 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyList
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AvailabilityRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Interval
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.LocationAndInterval
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingStatus
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoAppointmentRepository
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalTime
+
+class AvailabilityServiceTest {
+  private val videoAppointmentRepository: VideoAppointmentRepository = mock()
+
+  private val availabilityOptionsGenerator = AvailabilityOptionsGenerator(
+    dayStart = LocalTime.of(9, 0),
+    dayEnd = LocalTime.of(16, 0),
+    step = Duration.parse("PT15M"),
+  )
+
+  private val availabilityFinderService = AvailabilityFinderService(availabilityOptionsGenerator)
+
+  private val service = AvailabilityService(
+    videoAppointmentRepository,
+    availabilityFinderService,
+  )
+
+  private fun createVideoAppointment(
+    videoBookId: Long,
+    appId: Long,
+    locKey: String,
+    appType: String,
+    startTime: LocalTime,
+    endTime: LocalTime,
+  ) =
+    VideoAppointment(
+      videoBookingId = videoBookId,
+      prisonAppointmentId = appId,
+      bookingType = BookingType.COURT.name,
+      statusCode = BookingStatus.ACTIVE.name,
+      courtCode = "TESTC",
+      probationTeamCode = null,
+      prisonCode = MOORLAND,
+      prisonerNumber = "A1234AA",
+      appointmentType = appType,
+      prisonLocKey = locKey,
+      appointmentDate = LocalDate.now(),
+      startTime = startTime,
+      endTime = endTime,
+    )
+
+  private val room1 = "MDI-VCC-1"
+  private val room2 = "MDI-VCC-2"
+  private val room3 = "MDI-VCC-3"
+
+  private val videoAppointments = listOf(
+    createVideoAppointment(1L, 1L, room1, "VLB_COURT_PRE", LocalTime.of(9, 15), LocalTime.of(9, 30)),
+    createVideoAppointment(1L, 2L, room1, "VLB_COURT_MAIN", LocalTime.of(9, 30), LocalTime.of(10, 0)),
+    createVideoAppointment(2L, 3L, room1, "VLB_COURT_MAIN", LocalTime.of(10, 0), LocalTime.of(11, 0)),
+    createVideoAppointment(2L, 4L, room1, "VLB_COURT_POST", LocalTime.of(11, 0), LocalTime.of(11, 15)),
+    createVideoAppointment(3L, 5L, room1, "VLB_COURT_MAIN", LocalTime.of(11, 15), LocalTime.of(11, 45)),
+    createVideoAppointment(4L, 6L, room2, "VLB_COURT_MAIN", LocalTime.of(9, 30), LocalTime.of(12, 30)),
+    createVideoAppointment(5L, 7L, room2, "VLB_COURT_MAIN", LocalTime.of(13, 30), LocalTime.of(16, 30)),
+    createVideoAppointment(6L, 8L, room3, "VLB_COURT_MAIN", LocalTime.of(9, 0), LocalTime.of(19, 0)),
+  )
+
+  @BeforeEach
+  fun setUpMock() {
+    // Mock the view of existing video appointments
+    whenever(
+      videoAppointmentRepository.findVideoAppointmentsAtPrison(
+        forDate = any(),
+        forPrison = any(),
+        forLocationKeys = anyList(),
+      ),
+    ).thenReturn(videoAppointments)
+  }
+
+  @Test
+  fun `No options when the requested time is free`() {
+    // Request for a time which is currently free
+    val request = AvailabilityRequest(
+      bookingType = BookingType.COURT,
+      courtOrProbationCode = "TESTC",
+      prisonCode = MOORLAND,
+      date = LocalDate.now(),
+      mainAppointment = LocationAndInterval(
+        prisonLocKey = room1,
+        interval = Interval(start = LocalTime.of(12, 0), end = LocalTime.of(12, 30)),
+      ),
+    )
+
+    val response = service.checkAvailability(request)
+
+    assertThat(response).isNotNull
+    with(response) {
+      assertThat(availabilityOk).isTrue()
+      assertThat(alternatives).hasSize(0)
+    }
+  }
+
+  @Test
+  fun `Options provided when the requested time is not free`() {
+    // Request for a time already taken
+    val request = AvailabilityRequest(
+      bookingType = BookingType.COURT,
+      courtOrProbationCode = "TESTC",
+      prisonCode = MOORLAND,
+      date = LocalDate.now(),
+      mainAppointment = LocationAndInterval(
+        prisonLocKey = room1,
+        interval = Interval(start = LocalTime.of(11, 0), end = LocalTime.of(11, 30)),
+      ),
+    )
+
+    val response = service.checkAvailability(request)
+
+    assertThat(response).isNotNull
+    with(response) {
+      assertThat(availabilityOk).isFalse()
+      assertThat(alternatives).hasSize(3)
+      assertThat(alternatives).extracting("main").containsAll(
+        listOf(
+          LocationAndInterval(
+            prisonLocKey = room1,
+            interval = Interval(start = LocalTime.of(11, 45), end = LocalTime.of(12, 15)),
+          ),
+          LocationAndInterval(
+            prisonLocKey = room1,
+            interval = Interval(start = LocalTime.of(12, 0), end = LocalTime.of(12, 30)),
+          ),
+          LocationAndInterval(
+            prisonLocKey = room1,
+            interval = Interval(start = LocalTime.of(12, 15), end = LocalTime.of(12, 45)),
+          ),
+        ),
+      )
+    }
+  }
+
+  @Test
+  fun `Considers all rooms when multiple rooms are requested and one is unavailable`() {
+    // Request for multiple rooms with one of them busy at this time
+    val request = AvailabilityRequest(
+      bookingType = BookingType.COURT,
+      courtOrProbationCode = "TESTC",
+      prisonCode = MOORLAND,
+      date = LocalDate.now(),
+      preAppointment = LocationAndInterval(
+        prisonLocKey = room1,
+        interval = Interval(start = LocalTime.of(14, 0), end = LocalTime.of(14, 15)),
+      ),
+      mainAppointment = LocationAndInterval(
+        prisonLocKey = room2,
+        interval = Interval(start = LocalTime.of(14, 15), end = LocalTime.of(14, 45)),
+      ),
+      postAppointment = LocationAndInterval(
+        prisonLocKey = room1,
+        interval = Interval(start = LocalTime.of(14, 45), end = LocalTime.of(15, 0)),
+      ),
+    )
+
+    val response = service.checkAvailability(request)
+
+    assertThat(response).isNotNull
+    with(response) {
+      assertThat(availabilityOk).isFalse()
+      assertThat(alternatives).hasSize(3)
+      assertThat(alternatives).extracting("main").containsAll(
+        listOf(
+          LocationAndInterval(
+            prisonLocKey = room2,
+            interval = Interval(start = LocalTime.of(12, 30), end = LocalTime.of(13, 0)),
+          ),
+          LocationAndInterval(
+            prisonLocKey = room2,
+            interval = Interval(start = LocalTime.of(12, 45), end = LocalTime.of(13, 15)),
+          ),
+          LocationAndInterval(
+            prisonLocKey = room2,
+            interval = Interval(start = LocalTime.of(13, 0), end = LocalTime.of(13, 30)),
+          ),
+        ),
+      )
+    }
+  }
+
+  @Test
+  fun `No options are provided when room is busy and requested times are outside the start and end day times`() {
+    // Request for a time outside the start/end times of the day
+    val request = AvailabilityRequest(
+      bookingType = BookingType.COURT,
+      courtOrProbationCode = "TESTC",
+      prisonCode = MOORLAND,
+      date = LocalDate.now(),
+      mainAppointment = LocationAndInterval(
+        prisonLocKey = room3,
+        interval = Interval(start = LocalTime.of(18, 0), end = LocalTime.of(19, 0)),
+      ),
+    )
+
+    val response = service.checkAvailability(request)
+
+    // Room3 is busy all day
+    assertThat(response).isNotNull
+    with(response) {
+      assertThat(availabilityOk).isFalse()
+      assertThat(alternatives).hasSize(0)
+    }
+  }
+}


### PR DESCRIPTION
The availability check is called by the UI prior to creating bookings.
It checks that the prison rooms are free at the requested times, and if not will offer up to 3 alternatives (configurable).
It uses a new view of video appointments in the DB for a date and prison.
More tests for the OptionsFinderService are on their way in the next PR.