### PR TITLE
BAVL-25 adding in the necessary calls to activities api and prison api for creation of appoinments.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
@@ -41,25 +41,6 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
       .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
       .block()?.appointmentsRolledOut == true
 
-  @Deprecated(
-    message = "Temporary until we can work out internal location ids",
-    replaceWith = ReplaceWith(
-      """
-      createAppointment(
-        prisonCode: String,
-        prisonerNumber: String,
-        startDate: LocalDate,
-        startTime: LocalTime,
-        endTime: LocalTime,
-        internalLocationId: Long,
-      )
-    """,
-    ),
-  )
-  fun createAppointment() {
-    TODO("to be implemented")
-  }
-
   fun createAppointment(
     prisonCode: String,
     prisonerNumber: String,
@@ -67,7 +48,7 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
     startTime: LocalTime,
     endTime: LocalTime,
     internalLocationId: Long,
-  ) {
+  ): AppointmentSeries? =
     activitiesAppointmentsApiWebClient.post()
       .uri("/appointment-series")
       .bodyValue(
@@ -87,8 +68,6 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
       )
       .retrieve()
       .bodyToMono(AppointmentSeries::class.java)
-      .block()?.also {
-        log.info("Single appointment series created in activities and appointments with series ID ${it.id}")
-      } ?: log.error("Failed to create single appointment series in activities and appointments")
-  }
+      .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
+      .block()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
@@ -12,6 +12,8 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import java.time.LocalDate
 import java.time.LocalTime
 
+const val VIDEO_LINK_BOOKING = "VLB"
+
 @Component
 class PrisonApiClient(private val prisonApiWebClient: WebClient) {
 
@@ -30,7 +32,6 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
 
   fun createAppointment(
     bookingId: Long,
-    appointmentType: String,
     locationId: Long,
     appointmentDate: LocalDate,
     startTime: LocalTime,
@@ -43,7 +44,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .header("no-event-propagation", true.toString())
       .bodyValue(
         NewAppointment(
-          appointmentType = appointmentType,
+          appointmentType = VIDEO_LINK_BOOKING,
           locationId = locationId,
           startTime = appointmentDate.atTime(startTime).toIsoDateTime(),
           endTime = appointmentDate.atTime(endTime).toIsoDateTime(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
@@ -1,10 +1,57 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi
 
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.Event
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.NewAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
+import java.time.LocalDate
+import java.time.LocalTime
 
 @Component
-class PrisonApiClient {
-  fun createAppointment() {
-    TODO("to be implemented")
+class PrisonApiClient(private val prisonApiWebClient: WebClient) {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
   }
+
+  fun getInternalLocationByKey(key: String): Location? =
+    prisonApiWebClient
+      .get()
+      .uri("/api/locations/code/{code}", key)
+      .retrieve()
+      .bodyToMono(Location::class.java)
+      .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
+      .block()
+
+  fun createAppointment(
+    bookingId: Long,
+    appointmentType: String,
+    locationId: Long,
+    appointmentDate: LocalDate,
+    startTime: LocalTime,
+    endTime: LocalTime,
+    comments: String? = null,
+  ): Event? =
+    prisonApiWebClient
+      .post()
+      .uri("/bookings/{bookingId}/appointments", bookingId)
+      .header("no-event-propagation", true.toString())
+      .bodyValue(
+        NewAppointment(
+          appointmentType = appointmentType,
+          locationId = locationId,
+          startTime = appointmentDate.atTime(startTime).toIsoDateTime(),
+          endTime = appointmentDate.atTime(endTime).toIsoDateTime(),
+          comment = comments,
+        ),
+      )
+      .retrieve()
+      .bodyToMono(Event::class.java)
+      .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
+      .block()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonersearch/PrisonerSearchClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonersearch/PrisonerSearchClient.kt
@@ -31,7 +31,8 @@ class PrisonerValidator(val prisonerSearchClient: PrisonerSearchClient) {
 // TODO add additional fields as and when needed e.g. ACTIVE/NOT ACTIVE in prison
 data class Prisoner(
   val prisonerNumber: String,
-  val prisonId: String?,
+  val prisonId: String? = null,
   val firstName: String,
   val lastName: String,
+  val bookingId: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/LocalDateTimeExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/LocalDateTimeExt.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+fun LocalDateTime.toIsoDateTime(): String = this.format(DateTimeFormatter.ISO_DATE_TIME)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
@@ -16,6 +16,7 @@ import kotlin.reflect.KClass
 
 @Schema(description = "The request object sent to the availability check endpoint")
 data class AvailabilityRequest(
+  @field:NotNull(message = "The date is mandatory")
   @Schema(
     description = "The booking type",
     example = "COURT",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
@@ -4,6 +4,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.ActivitiesAppointmentsClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonApiClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 
 /**
@@ -17,6 +19,7 @@ class ManageExternalAppointmentsService(
   private val prisonAppointmentRepository: PrisonAppointmentRepository,
   private val activitiesAppointmentsClient: ActivitiesAppointmentsClient,
   private val prisonApiClient: PrisonApiClient,
+  private val prisonerSearchClient: PrisonerSearchClient,
 ) {
 
   companion object {
@@ -29,20 +32,44 @@ class ManageExternalAppointmentsService(
     prisonAppointmentRepository.findById(prisonAppointmentId).ifPresentOrElse(
       { appointment ->
         if (activitiesAppointmentsClient.isAppointmentsRolledOutAt(appointment.prisonCode)) {
-          // TODO change to call proper create method when we can establish the internal location ID.
-          activitiesAppointmentsClient.createAppointment()
-
-          log.info("EXTERNAL APPOINTMENTS: created appointment for prison appointment ID $prisonAppointmentId in activities and appointments")
+          activitiesAppointmentsClient.createAppointment(
+            prisonCode = appointment.prisonCode,
+            prisonerNumber = appointment.prisonerNumber,
+            startDate = appointment.appointmentDate,
+            startTime = appointment.startTime,
+            endTime = appointment.endTime,
+            internalLocationId = appointment.internalLocationId(),
+          )?.let { appointmentSeries ->
+            log.info("EXTERNAL APPOINTMENTS: created activities and appointments series ${appointmentSeries.id} for prison appointment $prisonAppointmentId")
+          }
         } else {
-          prisonApiClient.createAppointment()
-
-          log.info("EXTERNAL APPOINTMENTS: created appointment for prison appointment ID $prisonAppointmentId in prison api")
+          prisonApiClient.createAppointment(
+            bookingId = appointment.bookingId(),
+            appointmentType = appointment.appointmentType,
+            locationId = appointment.internalLocationId(),
+            appointmentDate = appointment.appointmentDate,
+            startTime = appointment.startTime,
+            endTime = appointment.endTime,
+            comments = appointment.comments,
+          )?.let { event ->
+            log.info("EXTERNAL APPOINTMENTS: created prison api event ${event.id} for prison appointment $prisonAppointmentId")
+          }
         }
       },
       {
         // Ignore, there is nothing we can do if we do not find the prison appointment
-        log.warn("Prison appointment with ID $prisonAppointmentId not found")
+        log.warn("EXTERNAL APPOINTMENTS: Prison appointment with ID $prisonAppointmentId not found")
       },
     )
   }
+
+  // TODO question - this should never happen but what happens if we find no location? An exception here means the event will never clean up.
+  private fun PrisonAppointment.internalLocationId() =
+    prisonApiClient.getInternalLocationByKey(prisonLocKey)?.locationId
+      ?: throw NullPointerException("Internal location id not found for prison appointment $prisonAppointmentId")
+
+  // TODO question - this should never happen but what happens if we find no booking id? An exception here means the event will never clean up.
+  private fun PrisonAppointment.bookingId() =
+    prisonerSearchClient.getPrisoner(prisonerNumber)?.bookingId?.toLong()
+      ?: throw NullPointerException("Booking id not found for prisoner $prisonerNumber for prison appointment $prisonAppointmentId")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
@@ -45,7 +45,6 @@ class ManageExternalAppointmentsService(
         } else {
           prisonApiClient.createAppointment(
             bookingId = appointment.bookingId(),
-            appointmentType = appointment.appointmentType,
             locationId = appointment.internalLocationId(),
             appointmentDate = appointment.appointmentDate,
             startTime = appointment.startTime,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClientTest.kt
@@ -31,7 +31,7 @@ class PrisonApiClientTest {
   fun `should post appointment`() {
     server.stubPostCreateAppointment(
       bookingId = 1,
-      appointmentType = "TEST",
+      appointmentType = "VLB",
       locationId = 2,
       appointmentDate = LocalDate.now(),
       startTime = LocalTime.MIDNIGHT,
@@ -40,7 +40,6 @@ class PrisonApiClientTest {
 
     client.createAppointment(
       bookingId = 1,
-      appointmentType = "TEST",
       locationId = 2,
       appointmentDate = LocalDate.now(),
       startTime = LocalTime.MIDNIGHT,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClientTest.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.PrisonApiMockServer
+import java.time.LocalDate
+import java.time.LocalTime
+
+class PrisonApiClientTest {
+
+  private val server = PrisonApiMockServer().also { it.start() }
+  private val client = PrisonApiClient(WebClient.create("http://localhost:${server.port()}"))
+
+  @Test
+  fun `should get location by key`() {
+    server.stubGetInternalLocationByKey("key", BIRMINGHAM, "A-123")
+
+    client.getInternalLocationByKey("key") isEqualTo Location(
+      locationId = 1,
+      locationType = "VIDEO_LINK",
+      agencyId = BIRMINGHAM,
+      description = "A-123",
+    )
+  }
+
+  @Test
+  fun `should post appointment`() {
+    server.stubPostCreateAppointment(
+      bookingId = 1,
+      appointmentType = "TEST",
+      locationId = 2,
+      appointmentDate = LocalDate.now(),
+      startTime = LocalTime.MIDNIGHT,
+      endTime = LocalTime.MIDNIGHT.plusHours(1),
+    )
+
+    client.createAppointment(
+      bookingId = 1,
+      appointmentType = "TEST",
+      locationId = 2,
+      appointmentDate = LocalDate.now(),
+      startTime = LocalTime.MIDNIGHT,
+      endTime = LocalTime.MIDNIGHT.plusHours(1),
+    )
+  }
+
+  @AfterEach
+  fun after() {
+    server.stop()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -43,11 +43,13 @@ fun prisonerSearchPrisoner(
   prisonCode: String,
   firstName: String = "Fred",
   lastName: String = "Bloggs",
+  bookingId: Long = -1,
 ) = Prisoner(
   prisonerNumber = prisonerNumber,
   prisonId = prisonCode,
   firstName = firstName,
   lastName = lastName,
+  bookingId = bookingId.toString(),
 )
 
 fun userEmail(username: String, email: String, verified: Boolean = true) = EmailAddressDto(username, email, verified)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
@@ -1,11 +1,87 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock
 
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.post
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.Event
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.NewAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 
-class PrisonApiMockServer : MockServer(8094)
+class PrisonApiMockServer : MockServer(8094) {
+
+  fun stubGetInternalLocationByKey(key: String, prisonCode: String, description: String) {
+    stubFor(
+      get("/api/locations/code/$key")
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              mapper.writeValueAsString(
+                Location(
+                  locationId = 1,
+                  locationType = "VIDEO_LINK",
+                  agencyId = prisonCode,
+                  description = description,
+                ),
+              ),
+            )
+            .withStatus(200),
+        ),
+    )
+  }
+
+  fun stubPostCreateAppointment(
+    bookingId: Long,
+    appointmentType: String,
+    locationId: Long,
+    appointmentDate: LocalDate,
+    startTime: LocalTime,
+    endTime: LocalTime,
+    comments: String? = null,
+  ) {
+    stubFor(
+      post("/bookings/$bookingId/appointments")
+        .withRequestBody(
+          WireMock.equalToJson(
+            mapper.writeValueAsString(
+              NewAppointment(
+                appointmentType = appointmentType,
+                locationId = locationId,
+                startTime = appointmentDate.atTime(startTime).toIsoDateTime(),
+                endTime = appointmentDate.atTime(endTime).toIsoDateTime(),
+                comment = comments,
+              ),
+            ),
+          ),
+        )
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              mapper.writeValueAsString(
+                Event(
+                  id = 1,
+                  type = appointmentType,
+                  prisonId = "MDI",
+                  nomsId = "ABC123",
+                  timestamp = LocalDateTime.now().toIsoDateTime(),
+                  eventData = null,
+                ),
+              ),
+            )
+            .withStatus(200),
+        ),
+    )
+  }
+}
 
 class PrisonApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsServiceTest.kt
@@ -74,7 +74,6 @@ class ManageExternalAppointmentsServiceTest {
     verify(activitiesAppointmentsClient, never()).createAppointment(any(), any(), any(), any(), any(), any())
     verify(prisonApiClient).createAppointment(
       bookingId = 1,
-      appointmentType = "VLB_COURT_PRE",
       locationId = 123456,
       appointmentDate = LocalDate.of(2100, 1, 1),
       startTime = LocalTime.of(11, 0),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsServiceTest.kt
@@ -1,17 +1,21 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events
 
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.ActivitiesAppointmentsClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonApiClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.appointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonerSearchPrisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import java.time.LocalDate
 import java.time.LocalTime
@@ -22,6 +26,8 @@ class ManageExternalAppointmentsServiceTest {
   private val prisonAppointmentRepository: PrisonAppointmentRepository = mock()
   private val activitiesAppointmentsClient: ActivitiesAppointmentsClient = mock()
   private val prisonApiClient: PrisonApiClient = mock()
+  private val prisonerSearchClient: PrisonerSearchClient = mock()
+  private val prisonLocation: Location = mock { on { locationId } doReturn 123456 }
   private val booking = courtBooking()
   private val appointment = appointment(
     booking = booking,
@@ -31,31 +37,50 @@ class ManageExternalAppointmentsServiceTest {
     date = LocalDate.of(2100, 1, 1),
     startTime = LocalTime.of(11, 0),
     endTime = LocalTime.of(11, 30),
-    locationKey = "",
+    locationKey = "ABC",
   )
   private val service =
-    ManageExternalAppointmentsService(prisonAppointmentRepository, activitiesAppointmentsClient, prisonApiClient)
+    ManageExternalAppointmentsService(prisonAppointmentRepository, activitiesAppointmentsClient, prisonApiClient, prisonerSearchClient)
 
   @Test
   fun `should call create appointment on activities client when appointments rolled out`() {
     whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(appointment)
     whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn true
+    whenever(prisonApiClient.getInternalLocationByKey(appointment.prisonLocKey)) doReturn prisonLocation
 
     service.createAppointment(1)
 
-    verify(activitiesAppointmentsClient).createAppointment()
-    verifyNoInteractions(prisonApiClient)
+    verify(prisonApiClient).getInternalLocationByKey(appointment.prisonLocKey)
+
+    verify(activitiesAppointmentsClient).createAppointment(
+      prisonCode = BIRMINGHAM,
+      prisonerNumber = "123456",
+      startDate = LocalDate.of(2100, 1, 1),
+      startTime = LocalTime.of(11, 0),
+      endTime = LocalTime.of(11, 30),
+      internalLocationId = 123456,
+    )
   }
 
   @Test
   fun `should call create appointment on prison api client when appointments not rolled out`() {
     whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(appointment)
     whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn false
+    whenever(prisonerSearchClient.getPrisoner(appointment.prisonerNumber)) doReturn prisonerSearchPrisoner(prisonerNumber = appointment.prisonerNumber, prisonCode = appointment.prisonCode, bookingId = 1)
+    whenever(prisonApiClient.getInternalLocationByKey(appointment.prisonLocKey)) doReturn prisonLocation
 
     service.createAppointment(1)
 
-    verify(activitiesAppointmentsClient, never()).createAppointment()
-    verify(prisonApiClient).createAppointment()
+    verify(activitiesAppointmentsClient, never()).createAppointment(any(), any(), any(), any(), any(), any())
+    verify(prisonApiClient).createAppointment(
+      bookingId = 1,
+      appointmentType = "VLB_COURT_PRE",
+      locationId = 123456,
+      appointmentDate = LocalDate.of(2100, 1, 1),
+      startTime = LocalTime.of(11, 0),
+      endTime = LocalTime.of(11, 30),
+      comments = "Court hearing comments",
+    )
   }
 
   @Test


### PR DESCRIPTION
These changes now mean we can establish the locations IDs from our location keys for creation of appointments in the activities and appointments api and prison api.

Note: we are still not actually raising events yet.  I have not wired in the calls to SQS and the cloud platform work is still missing.