### PR TITLE
BAVL-177: Exclude existing booking while carrying out availability check

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
@@ -66,6 +66,12 @@ data class AvailabilityRequest(
     requiredMode = RequiredMode.NOT_REQUIRED,
   )
   val postAppointment: LocationAndInterval? = null,
+
+  @Schema(
+    description = "Exclude the video link booking with this ID from the availability check. Useful when checking availability during the amending of a booking.",
+    requiredMode = RequiredMode.NOT_REQUIRED,
+  )
+  val vlbIdToExclude: Long? = null,
 )
 
 @Schema(description = "The prison location key and start/end interval for an appointment slot")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
@@ -45,7 +45,7 @@ class AvailabilityService(
       forDate = request.date!!,
       forPrison = request.prisonCode!!,
       forLocationKeys = listOfLocationKeys,
-    )
+    ).filter { vlb -> vlb.videoBookingId != request.vlbIdToExclude }
 
     log.info("Found ${videoAppointments.size} appointments in these rooms")
 


### PR DESCRIPTION
Exclude a specific booking from the availability check. For example, exclude the appointment which you are amending.