### PR TITLE
BAVL-25 switching send/receive events on in dev.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,6 +16,7 @@ generic-service:
     API_BASE_URL_MANAGE_USERS: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
     API_BASE_URL_PRISON_API: "https://prison-api-dev.prison.service.justice.gov.uk"
     API_BASE_URL_PRISONER_SEARCH: "https://prisoner-search-dev.prison.service.justice.gov.uk"
+    FEATURE_EVENTS_SNS_ENABLED: true
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/DomainEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/DomainEvents.kt
@@ -14,6 +14,8 @@ abstract class DomainEvent<T : AdditionalInformation>(
   val occurredAt: LocalDateTime = LocalDateTime.now()
 
   fun toEventType() = DomainEventType.valueOf(eventType)
+
+  override fun toString() = this::class.simpleName + "(eventType = $eventType, additionalInformation = $additionalInformation)"
 }
 
 interface AdditionalInformation

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsListener.kt
@@ -26,8 +26,10 @@ class InboundEventsListener(
   }
 
   @SqsListener("bvls", factory = "hmppsQueueContainerFactoryProxy")
-  @WithSpan(value = "Digital-Prison-Services-book_a_video_link_queue", kind = SpanKind.SERVER)
+  @WithSpan(value = "farsight-devs-book_a_video_link_queue", kind = SpanKind.SERVER)
   fun onMessage(rawMessage: String) {
+    log.info("LISTENER: raw message $rawMessage")
+
     if (features.isEnabled(Feature.SNS_ENABLED)) {
       val message: Message = mapper.readValue(rawMessage)
 
@@ -37,12 +39,12 @@ class InboundEventsListener(
             runCatching {
               inboundEventsService.process(eventType.toInboundEvent(mapper, message.Message))
             }.onFailure {
-              log.error("Error processing message ${message.MessageId}", it)
+              log.error("LISTENER: Error processing message ${message.MessageId}", it)
               throw it
             }
-          } ?: log.info("Unrecognised event ${message.MessageAttributes.eventType.Value}")
+          } ?: log.info("LISTENER: Unrecognised event ${message.MessageAttributes.eventType.Value}")
         }
-        else -> log.info("Ignoring message, actual message type '${message.Type}' is not a Notification.")
+        else -> log.info("LISTENER: Ignoring message, actual message type '${message.Type}' is not a Notification.")
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
@@ -32,6 +32,8 @@ class ManageExternalAppointmentsService(
     prisonAppointmentRepository.findById(prisonAppointmentId).ifPresentOrElse(
       { appointment ->
         if (activitiesAppointmentsClient.isAppointmentsRolledOutAt(appointment.prisonCode)) {
+          log.info("EXTERNAL APPOINTMENTS: appointments rolled out at ${appointment.prisonCode} creating via activities and appointments")
+
           activitiesAppointmentsClient.createAppointment(
             prisonCode = appointment.prisonCode,
             prisonerNumber = appointment.prisonerNumber,
@@ -43,6 +45,8 @@ class ManageExternalAppointmentsService(
             log.info("EXTERNAL APPOINTMENTS: created activities and appointments series ${appointmentSeries.id} for prison appointment $prisonAppointmentId")
           }
         } else {
+          log.info("EXTERNAL APPOINTMENTS: appointments not rolled out at ${appointment.prisonCode} creating via prison api")
+
           prisonApiClient.createAppointment(
             bookingId = appointment.bookingId(),
             locationId = appointment.internalLocationId(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/OutboundEventsPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/OutboundEventsPublisher.kt
@@ -34,6 +34,8 @@ class OutboundEventsPublisher(
 
   fun send(event: DomainEvent<*>) {
     if (isSnsEnabled) {
+      log.info("PUBLISHER: publishing domain event $event")
+
       runCatching {
         domainEventsTopic.snsClient.publish(
           PublishRequest.builder()
@@ -43,6 +45,8 @@ class OutboundEventsPublisher(
             .build(),
         ).get()
       }.onFailure { log.error("PUBLISHER: error publishing event $event", it) }
+    } else {
+      log.info("PUBLISHER: domain event $event not published, publishing is disabled ")
     }
   }
 


### PR DESCRIPTION
Flicks the switch to **ON** for creating bookings (appointments) in external services.

Gone a bit heavier on the logging just so we can see it though better in early stages.