### PR TITLE
Task/bavl 25 external api calls for get appointments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
@@ -1,12 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments
 
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.Appointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSearchRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeries
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeriesCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.RolloutPrisonPlan
@@ -16,21 +15,10 @@ import java.time.LocalTime
 
 const val VIDEO_LINK_BOOKING = "VLB"
 
+inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>() {}
+
 @Component
 class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClient: WebClient) {
-
-  companion object {
-    private val log: Logger = LoggerFactory.getLogger(this::class.java)
-  }
-
-  fun getAppointment(appointmentId: Long): Appointment? =
-    activitiesAppointmentsApiWebClient
-      .get()
-      .uri("/appointments/{appointmentId}", appointmentId)
-      .retrieve()
-      .bodyToMono(Appointment::class.java)
-      .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
-      .block()
 
   fun isAppointmentsRolledOutAt(prisonCode: String) =
     activitiesAppointmentsApiWebClient
@@ -70,4 +58,21 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
       .retrieve()
       .bodyToMono(AppointmentSeries::class.java)
       .block()
+
+  fun getPrisonersAppointments(prisonCode: String, prisonerNumber: String, onDate: LocalDate): List<AppointmentSearchRequest> =
+    activitiesAppointmentsApiWebClient.post()
+      .uri("/appointments/{prisonCode}/search", prisonCode)
+      .bodyValue(
+        AppointmentSearchRequest(
+          appointmentType = AppointmentSearchRequest.AppointmentType.INDIVIDUAL,
+          startDate = onDate,
+          endDate = onDate,
+          categoryCode = VIDEO_LINK_BOOKING,
+          prisonerNumbers = listOf(prisonerNumber),
+        ),
+      )
+      .retrieve()
+      .bodyToMono(typeReference<List<AppointmentSearchRequest>>())
+      .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
+      .block() ?: emptyList()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
@@ -6,6 +6,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSearchRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSearchResult
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeries
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeriesCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.RolloutPrisonPlan
@@ -59,7 +60,7 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
       .bodyToMono(AppointmentSeries::class.java)
       .block()
 
-  fun getPrisonersAppointments(prisonCode: String, prisonerNumber: String, onDate: LocalDate): List<AppointmentSearchRequest> =
+  fun getPrisonersAppointments(prisonCode: String, prisonerNumber: String, onDate: LocalDate): List<AppointmentSearchResult> =
     activitiesAppointmentsApiWebClient.post()
       .uri("/appointments/{prisonCode}/search", prisonCode)
       .bodyValue(
@@ -72,7 +73,7 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
         ),
       )
       .retrieve()
-      .bodyToMono(typeReference<List<AppointmentSearchRequest>>())
+      .bodyToMono(typeReference<List<AppointmentSearchResult>>())
       .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
       .block() ?: emptyList()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
@@ -8,10 +8,10 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.NewAppointment
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.PrisonerSchedule
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDate
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 const val VIDEO_LINK_BOOKING = "VLB"
@@ -70,5 +70,16 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .block() ?: emptyList()
 }
 
-// Overriding due to deserialisation issues from generated type.
+// Overriding due to deserialisation issues from generated type. Only including fields we are interested in.
 data class ScheduledEvent(val eventId: Long)
+
+// Overriding due to deserialisation issues from generated type. Only including fields we are interested in.
+data class PrisonerSchedule(
+  val offenderNo: String,
+  val locationId: Long,
+  val firstName: String,
+  val lastName: String,
+  val event: String,
+  val startTime: LocalDateTime,
+  val endTime: LocalDateTime,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
@@ -1,17 +1,22 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi
 
 import org.slf4j.LoggerFactory
+import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.NewAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.PrisonerSchedule
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDate
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import java.time.LocalDate
 import java.time.LocalTime
 
 const val VIDEO_LINK_BOOKING = "VLB"
+
+inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>() {}
 
 @Component
 class PrisonApiClient(private val prisonApiWebClient: WebClient) {
@@ -53,6 +58,16 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .retrieve()
       .bodyToMono(ScheduledEvent::class.java)
       .block()
+
+  fun getPrisonersAppointments(prisonCode: String, prisonerNumber: String, onDate: LocalDate): List<PrisonerSchedule> =
+    prisonApiWebClient
+      .post()
+      .uri("/api/schedules/{prisonCode}/appointments?date={date}", prisonCode, onDate.toIsoDate())
+      .bodyValue(listOf(prisonerNumber))
+      .retrieve()
+      .bodyToMono(typeReference<List<PrisonerSchedule>>())
+      .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
+      .block() ?: emptyList()
 }
 
 // Overriding due to deserialisation issues from generated type.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/LocalDateExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/LocalDateExt.kt
@@ -5,3 +5,5 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 fun LocalDate.toMediumFormatStyle(): String = this.format(DateTimeFormatter.ofPattern("d MMM yyyy", Locale.ENGLISH))
+
+fun LocalDate.toIsoDate(): String = this.format(DateTimeFormatter.ISO_DATE)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClientTest.kt
@@ -1,10 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.ActivitiesAppointmentsApiMockServer
 import java.time.LocalTime
@@ -13,13 +13,6 @@ class ActivitiesAppointmentsClientTest {
 
   private val server = ActivitiesAppointmentsApiMockServer().also { it.start() }
   private val client = ActivitiesAppointmentsClient(WebClient.create("http://localhost:${server.port()}"))
-
-  @Test
-  fun `should get matching appointment`() {
-    server.stubGetAppointment(1L)
-
-    client.getAppointment(1L)?.id isEqualTo 1L
-  }
 
   @Test
   fun `should post new appointment`() {
@@ -42,6 +35,13 @@ class ActivitiesAppointmentsClientTest {
       internalLocationId = 1,
       comments = "extra info",
     )
+  }
+
+  @Test
+  fun `should get prisoners appointments`() {
+    server.stubGetPrisonersAppointments(BIRMINGHAM, "123456", tomorrow())
+
+    assertThat(client.getPrisonersAppointments(BIRMINGHAM, "123456", tomorrow())).isNotEmpty
   }
 
   @AfterEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClientTest.kt
@@ -7,6 +7,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.PrisonApiMockServer
 import java.time.LocalDate
 import java.time.LocalTime
@@ -48,6 +49,13 @@ class PrisonApiClientTest {
     )
 
     assertThat(response).isNotNull
+  }
+
+  @Test
+  fun `should get prisoners appointments`() {
+    server.stubGetPrisonersAppointments(BIRMINGHAM, "123456", tomorrow())
+
+    assertThat(client.getPrisonersAppointments(BIRMINGHAM, "123456", tomorrow())).isNotEmpty
   }
 
   @AfterEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/LocalDateExtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/LocalDateExtTest.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import java.time.LocalDate
+
+class LocalDateExtTest {
+
+  @Test
+  fun `should format date to ISO date style`() {
+    LocalDate.of(2024, 6, 20).toIsoDate() isEqualTo "2024-06-20"
+    LocalDate.EPOCH.toIsoDate() isEqualTo "1970-01-01"
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ActivitiesAppointmentsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ActivitiesAppointmentsApiMockServer.kt
@@ -10,10 +10,14 @@ import org.junit.jupiter.api.extension.ExtensionContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.VIDEO_LINK_BOOKING
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.Appointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentAttendee
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentAttendeeSearchResult
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentCategorySummary
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSearchRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSearchResult
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeries
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeriesCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toHourMinuteStyle
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -113,10 +117,24 @@ class ActivitiesAppointmentsApiMockServer : MockServer(8089) {
             .withBody(
               mapper.writeValueAsString(
                 listOf(
-                  AppointmentSearchRequest(
-                    appointmentType = AppointmentSearchRequest.AppointmentType.INDIVIDUAL,
+                  AppointmentSearchResult(
+                    appointmentType = AppointmentSearchResult.AppointmentType.INDIVIDUAL,
                     startDate = date,
-                    endDate = date,
+                    startTime = date.atStartOfDay().toIsoDateTime(),
+                    endTime = date.atStartOfDay().plusHours(1).toIsoDateTime(),
+                    isCancelled = false,
+                    isExpired = false,
+                    isEdited = false,
+                    appointmentId = 1,
+                    appointmentSeriesId = 1,
+                    appointmentName = "appointment name",
+                    attendees = listOf(AppointmentAttendeeSearchResult(1, prisonerNumber, 1)),
+                    category = AppointmentCategorySummary("VLB", "video link booking"),
+                    inCell = false,
+                    isRepeat = false,
+                    maxSequenceNumber = 1,
+                    prisonCode = prisonCode,
+                    sequenceNumber = 1,
                   ),
                 ),
               ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
@@ -7,10 +7,10 @@ import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonerSchedule
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.ScheduledEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.NewAppointment
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.PrisonerSchedule
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDate
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import java.time.LocalDate
@@ -94,14 +94,8 @@ class PrisonApiMockServer : MockServer(8094) {
                     firstName = "JOHN",
                     lastName = "DOE",
                     event = "VLB",
-                    eventDescription = "VLB - Test",
-                    eventLocation = "VCC-CROWN-COURT-ROOM-6",
-                    comment = "3 appointment prison api test",
-                    startTime = date.atStartOfDay().toIsoDateTime(),
-                    endTime = date.atStartOfDay().plusHours(1).toIsoDateTime(),
-                    cellLocation = "cell location ",
-                    eventStatus = "event status",
-                    eventType = "event type",
+                    startTime = date.atStartOfDay(),
+                    endTime = date.atStartOfDay().plusHours(1),
                   ),
                 ),
               ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.extension.ExtensionContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.ScheduledEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.NewAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.PrisonerSchedule
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDate
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import java.time.LocalDate
 import java.time.LocalTime
@@ -66,6 +68,43 @@ class PrisonApiMockServer : MockServer(8094) {
             .withHeader("Content-Type", "application/json")
             .withBody(
               mapper.writeValueAsString(ScheduledEvent(eventId = 1)),
+            )
+            .withStatus(200),
+        ),
+    )
+  }
+
+  fun stubGetPrisonersAppointments(prisonCode: String, prisonerNumber: String, date: LocalDate) {
+    stubFor(
+      post("/api/schedules/$prisonCode/appointments?date=${date.toIsoDate()}")
+        .withRequestBody(
+          WireMock.equalToJson(
+            mapper.writeValueAsString(listOf(prisonerNumber)),
+          ),
+        )
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              mapper.writeValueAsString(
+                listOf(
+                  PrisonerSchedule(
+                    offenderNo = "G5662GI",
+                    locationId = 722209,
+                    firstName = "JOHN",
+                    lastName = "DOE",
+                    event = "VLB",
+                    eventDescription = "VLB - Test",
+                    eventLocation = "VCC-CROWN-COURT-ROOM-6",
+                    comment = "3 appointment prison api test",
+                    startTime = date.atStartOfDay().toIsoDateTime(),
+                    endTime = date.atStartOfDay().plusHours(1).toIsoDateTime(),
+                    cellLocation = "cell location ",
+                    eventStatus = "event status",
+                    eventType = "event type",
+                  ),
+                ),
+              ),
             )
             .withStatus(200),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
@@ -35,7 +35,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.Notificati
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.DomainEventType
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.OutboundEventsServiceImpl
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.OutboundEventsService
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
@@ -49,7 +49,7 @@ class BookingFacadeTest {
   private val prisonRepository: PrisonRepository = mock()
   private val emailService: EmailService = mock()
   private val notificationRepository: NotificationRepository = mock()
-  private val outboundSnsEventsService: OutboundEventsServiceImpl = mock()
+  private val outboundEventsService: OutboundEventsService = mock()
   private val notificationCaptor = argumentCaptor<Notification>()
   private val locationsInsidePrisonClient: LocationsInsidePrisonClient = mock()
   private val facade = BookingFacade(
@@ -60,7 +60,7 @@ class BookingFacadeTest {
     prisonRepository,
     emailService,
     notificationRepository,
-    outboundSnsEventsService,
+    outboundEventsService,
     locationsInsidePrisonClient,
   )
 
@@ -92,9 +92,9 @@ class BookingFacadeTest {
 
     facade.create(bookingRequest, "facade court user")
 
-    inOrder(createBookingService, outboundSnsEventsService, emailService, notificationRepository) {
+    inOrder(createBookingService, outboundEventsService, emailService, notificationRepository) {
       verify(createBookingService).create(bookingRequest, "facade court user")
-      verify(outboundSnsEventsService).send(DomainEventType.VIDEO_BOOKING_CREATED, booking.videoBookingId)
+      verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CREATED, booking.videoBookingId)
       verify(emailService).send(emailCaptor.capture())
       verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
       verify(emailService).send(emailCaptor.capture())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/VideoBookingCreatedDomainEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/VideoBookingCreatedDomainEventHandlerTest.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.DomainEventType
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.OutboundEventsServiceImpl
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.OutboundEventsService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.VideoBookingCreatedEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.VideoBookingInformation
 import java.time.LocalDate
@@ -26,7 +26,7 @@ class VideoBookingCreatedDomainEventHandlerTest {
 
   private val videoBookingRepository: VideoBookingRepository = mock()
   private val prisonAppointmentRepository: PrisonAppointmentRepository = mock()
-  private val outboundSnsEventsService: OutboundEventsServiceImpl = mock()
+  private val outboundEventsService: OutboundEventsService = mock()
   private val booking = courtBooking()
   private val appointments = listOf(
     appointment(
@@ -50,7 +50,7 @@ class VideoBookingCreatedDomainEventHandlerTest {
       locationKey = "",
     ),
   )
-  private val handler = VideoBookingCreatedEventHandler(videoBookingRepository, prisonAppointmentRepository, outboundSnsEventsService)
+  private val handler = VideoBookingCreatedEventHandler(videoBookingRepository, prisonAppointmentRepository, outboundEventsService)
 
   @Test
   fun `should publish appointment created event on receipt of video booking`() {
@@ -59,7 +59,7 @@ class VideoBookingCreatedDomainEventHandlerTest {
 
     handler.handle(VideoBookingCreatedEvent(VideoBookingInformation(1)))
 
-    verify(outboundSnsEventsService, times(2)).send(eq(DomainEventType.APPOINTMENT_CREATED), any())
+    verify(outboundEventsService, times(2)).send(eq(DomainEventType.APPOINTMENT_CREATED), any())
   }
 
   @Test
@@ -70,6 +70,6 @@ class VideoBookingCreatedDomainEventHandlerTest {
     handler.handle(VideoBookingCreatedEvent(VideoBookingInformation(1)))
 
     verifyNoInteractions(prisonAppointmentRepository)
-    verifyNoInteractions(outboundSnsEventsService)
+    verifyNoInteractions(outboundEventsService)
   }
 }


### PR DESCRIPTION
I have been able to test this with calling prison-api and again we are in a position where we have to override the return type as fields generated as mandatory are not being populated when the api is called.