### PR TITLE
BAVL-235 adding support for processing of prisoner released events to handle potential cancellation of future bookings.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/ServiceName.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/ServiceName.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity
+
+enum class ServiceName {
+  BOOK_A_VIDEO_LINK_SERVICE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/PrisonAppointmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/PrisonAppointmentRepository.kt
@@ -1,14 +1,17 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import java.time.LocalDate
+import java.time.LocalTime
 
 interface PrisonAppointmentRepository : JpaRepository<PrisonAppointment, Long> {
   fun findByVideoBooking(booking: VideoBooking): List<PrisonAppointment>
 
   fun findByPrisonCodeAndPrisonLocKeyAndAppointmentDate(prisonCode: String, key: String, date: LocalDate): List<PrisonAppointment>
 
-  fun deletePrisonAppointmentsByVideoBooking(booking: VideoBooking)
+  @Query(value = "SELECT pa FROM PrisonAppointment pa WHERE pa.appointmentDate >= :date AND pa.startTime > :time")
+  fun findPrisonAppointmentsAfter(date: LocalDate, time: LocalTime): List<PrisonAppointment>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsListener.kt
@@ -28,8 +28,6 @@ class InboundEventsListener(
   @SqsListener("bvls", factory = "hmppsQueueContainerFactoryProxy")
   @WithSpan(value = "farsight-devs-book_a_video_link_queue", kind = SpanKind.SERVER)
   fun onMessage(rawMessage: String) {
-    log.info("LISTENER: raw message $rawMessage")
-
     if (features.isEnabled(Feature.SNS_ENABLED)) {
       val message: Message = mapper.readValue(rawMessage)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsService.kt
@@ -4,6 +4,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.AppointmentCreatedEventHandler
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerReleasedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.VideoBookingCancelledEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.VideoBookingCreatedEventHandler
 
@@ -12,6 +13,7 @@ class InboundEventsService(
   private val appointmentCreatedEventHandler: AppointmentCreatedEventHandler,
   private val videoBookingCreatedEventHandler: VideoBookingCreatedEventHandler,
   private val videoBookingCancelledEventHandler: VideoBookingCancelledEventHandler,
+  private val prisonerReleasedEventHandler: PrisonerReleasedEventHandler,
 ) {
   companion object {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -22,6 +24,7 @@ class InboundEventsService(
       is VideoBookingCreatedEvent -> videoBookingCreatedEventHandler.handle(event)
       is AppointmentCreatedEvent -> appointmentCreatedEventHandler.handle(event)
       is VideoBookingCancelledEvent -> videoBookingCancelledEventHandler.handle(event)
+      is PrisonerReleasedEvent -> prisonerReleasedEventHandler.handle(event)
       else -> log.warn("Unsupported domain event ${event.javaClass.name}")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/OutboundEventsService.kt
@@ -34,6 +34,7 @@ class OutboundEventsServiceImpl(
       APPOINTMENT_CREATED -> send(AppointmentCreatedEvent(identifier))
       VIDEO_BOOKING_CREATED -> send(VideoBookingCreatedEvent(identifier))
       VIDEO_BOOKING_CANCELLED -> send(VideoBookingCancelledEvent(identifier))
+      else -> throw IllegalArgumentException("Unsupported domain event $domainEventType")
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerReleasedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerReleasedEventHandler.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ServiceName
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingFacade
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PrisonerReleasedEvent
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Component
+class PrisonerReleasedEventHandler(
+  private val prisonAppointmentRepository: PrisonAppointmentRepository,
+  private val bookingFacade: BookingFacade,
+) : DomainEventHandler<PrisonerReleasedEvent> {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  override fun handle(event: PrisonerReleasedEvent) {
+    when {
+      // Doing the temporary check first to avoid potentially unnecessary database calls.
+      event.isTemporary() -> log.info("RELEASE EVENT HANDLER: Ignoring temporary release event $event")
+      event.isPermanent() -> cancelFutureBookingsFor(event.prisonerNumber())
+      else -> log.warn("RELEASE EVENT HANDLER: Ignoring unknown release event $event")
+    }
+  }
+
+  private fun cancelFutureBookingsFor(prisonerNumber: String) {
+    prisonAppointmentRepository.findPrisonAppointmentsAfter(LocalDate.now(), LocalTime.now())
+      .map { it.videoBooking.videoBookingId }
+      .distinct()
+      .forEach { booking ->
+        log.info("RELEASE EVENT HANDLER: cancelling video booking $booking for prisoner number $prisonerNumber")
+        bookingFacade.cancel(booking, ServiceName.BOOK_A_VIDEO_LINK_SERVICE.name)
+      }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/DomainEventTypeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/DomainEventTypeTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isInstanceOf
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.DomainEventType.APPOINTMENT_CREATED
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.DomainEventType.PRISONER_RELEASED
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.DomainEventType.VIDEO_BOOKING_CANCELLED
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.DomainEventType.VIDEO_BOOKING_CREATED
 
@@ -18,6 +19,7 @@ class DomainEventTypeTest {
     VIDEO_BOOKING_CREATED.toInboundEvent(mapper, rawMessage(VideoBookingCreatedEvent(1))) isInstanceOf VideoBookingCreatedEvent::class.java
     APPOINTMENT_CREATED.toInboundEvent(mapper, rawMessage(AppointmentCreatedEvent(1))) isInstanceOf AppointmentCreatedEvent::class.java
     VIDEO_BOOKING_CANCELLED.toInboundEvent(mapper, rawMessage(VideoBookingCancelledEvent(1))) isInstanceOf VideoBookingCancelledEvent::class.java
+    PRISONER_RELEASED.toInboundEvent(mapper, rawMessage(PrisonerReleasedEvent(ReleaseInformation("noms number", "reason", "prison id")))) isInstanceOf PrisonerReleasedEvent::class.java
   }
 
   @Test
@@ -25,6 +27,7 @@ class DomainEventTypeTest {
     VIDEO_BOOKING_CREATED.eventType isEqualTo "book-a-video-link.video-booking.created"
     APPOINTMENT_CREATED.eventType isEqualTo "book-a-video-link.appointment.created"
     VIDEO_BOOKING_CANCELLED.eventType isEqualTo "book-a-video-link.video-booking.cancelled"
+    PRISONER_RELEASED.eventType isEqualTo "prisoner-offender-search.prisoner.released"
   }
 
   private fun rawMessage(event: DomainEvent<*>) = mapper.writeValueAsString(event)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsServiceTest.kt
@@ -3,7 +3,9 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.AppointmentCreatedEventHandler
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerReleasedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.VideoBookingCancelledEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.VideoBookingCreatedEventHandler
 
@@ -12,10 +14,12 @@ class InboundEventsServiceTest {
   private val appointmentCreatedEventHandler: AppointmentCreatedEventHandler = mock()
   private val videoBookingCreatedEventHandler: VideoBookingCreatedEventHandler = mock()
   private val videoBookingCancelledEventHandler: VideoBookingCancelledEventHandler = mock()
+  private val prisonerReleasedEventHandler: PrisonerReleasedEventHandler = mock()
   private val service = InboundEventsService(
     appointmentCreatedEventHandler,
     videoBookingCreatedEventHandler,
     videoBookingCancelledEventHandler,
+    prisonerReleasedEventHandler,
   )
 
   @Test
@@ -49,5 +53,16 @@ class InboundEventsServiceTest {
     val event2 = VideoBookingCancelledEvent(2)
     service.process(event2)
     verify(videoBookingCancelledEventHandler).handle(event2)
+  }
+
+  @Test
+  fun `should call prisoner released handler when for prisoner released event`() {
+    val event1 = PrisonerReleasedEvent(ReleaseInformation("123456", "RELEASED", BIRMINGHAM))
+    service.process(event1)
+    verify(prisonerReleasedEventHandler).handle(event1)
+
+    val event2 = PrisonerReleasedEvent(ReleaseInformation("78910", "RELEASED", BIRMINGHAM))
+    service.process(event2)
+    verify(prisonerReleasedEventHandler).handle(event2)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/OutboundEventsServiceImplTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/OutboundEventsServiceImplTest.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
@@ -46,6 +48,17 @@ class OutboundEventsServiceImplTest {
       expectedAdditionalInformation = VideoBookingInformation(1),
       expectedDescription = "A video booking has been cancelled in the book a video link service",
     )
+  }
+
+  @Test
+  fun `should not be able to publish prisoner released event`() {
+    val error = assertThrows<IllegalArgumentException> {
+      service.send(DomainEventType.PRISONER_RELEASED, 1)
+    }
+
+    error.message isEqualTo "Unsupported domain event ${DomainEventType.PRISONER_RELEASED}"
+
+    verifyNoInteractions(eventsPublisher)
   }
 
   private fun verify(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerReleasedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerReleasedEventHandlerTest.kt
@@ -1,0 +1,82 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.isOnOrAfter
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ServiceName
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isCloseTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingFacade
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PrisonerReleasedEvent
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.ReleaseInformation
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class PrisonerReleasedEventHandlerTest {
+  private val courtBooking: VideoBooking = mock { on { videoBookingId } doReturn 1 }
+  private val courtAppointment1: PrisonAppointment = mock { on { videoBooking } doReturn courtBooking }
+  private val courtAppointment2: PrisonAppointment = mock { on { videoBooking } doReturn courtBooking }
+  private val probationBooking: VideoBooking = mock { on { videoBookingId } doReturn 2 }
+  private val probationAppointment: PrisonAppointment = mock { on { videoBooking } doReturn probationBooking }
+  private val prisonAppointmentRepository: PrisonAppointmentRepository = mock()
+  private val bookingFacade: BookingFacade = mock()
+  private val handler = PrisonerReleasedEventHandler(prisonAppointmentRepository, bookingFacade)
+  private val dateCaptor = argumentCaptor<LocalDate>()
+  private val timeCaptor = argumentCaptor<LocalTime>()
+  private val timeNow = LocalTime.now()
+
+  @Test
+  fun `should ignore temporary absence release of prisoner`() {
+    handler.handle(PrisonerReleasedEvent(ReleaseInformation("123456", "TEMPORARY_ABSENCE_RELEASE", BIRMINGHAM)))
+    handler.handle(PrisonerReleasedEvent(ReleaseInformation("123456", "SENT_TO_COURT", BIRMINGHAM)))
+
+    verifyNoInteractions(prisonAppointmentRepository, bookingFacade)
+  }
+
+  @Test
+  fun `should cancel single video booking on permanent release of prisoner`() {
+    whenever(
+      prisonAppointmentRepository.findPrisonAppointmentsAfter(
+        eq(LocalDate.now()),
+        argThat { time -> time.isOnOrAfter(timeNow) },
+      ),
+    ) doReturn listOf(courtAppointment1)
+    handler.handle(PrisonerReleasedEvent(ReleaseInformation("123456", "RELEASED", BIRMINGHAM)))
+
+    verify(prisonAppointmentRepository).findPrisonAppointmentsAfter(dateCaptor.capture(), timeCaptor.capture())
+
+    dateCaptor.firstValue.atTime(timeCaptor.firstValue) isCloseTo LocalDateTime.now()
+
+    verify(bookingFacade).cancel(courtBooking.videoBookingId, ServiceName.BOOK_A_VIDEO_LINK_SERVICE.name)
+  }
+
+  @Test
+  fun `should cancel multiple video bookings on permanent release of prisoner`() {
+    whenever(
+      prisonAppointmentRepository.findPrisonAppointmentsAfter(
+        eq(LocalDate.now()),
+        argThat { time -> time.isOnOrAfter(timeNow) },
+      ),
+    ) doReturn listOf(courtAppointment1, courtAppointment2, probationAppointment)
+
+    handler.handle(PrisonerReleasedEvent(ReleaseInformation("123456", "RELEASED", BIRMINGHAM)))
+
+    verify(prisonAppointmentRepository).findPrisonAppointmentsAfter(dateCaptor.capture(), timeCaptor.capture())
+
+    dateCaptor.firstValue.atTime(timeCaptor.firstValue) isCloseTo LocalDateTime.now()
+
+    verify(bookingFacade).cancel(1, ServiceName.BOOK_A_VIDEO_LINK_SERVICE.name)
+    verify(bookingFacade).cancel(2, ServiceName.BOOK_A_VIDEO_LINK_SERVICE.name)
+  }
+}


### PR DESCRIPTION
The intention is to add localstack integration test coverage in a separate PR.

We also need a cloud platform change to take place to listen for the release event.  Until that happens the code for release events will not fire.