### PR TITLE
BAVL-235 fixing offset datetime issue spotted during testing with real release event in dev.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/LocalDateExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/LocalDateExt.kt
@@ -1,9 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common
 
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 fun LocalDate.toMediumFormatStyle(): String = this.format(DateTimeFormatter.ofPattern("d MMM yyyy", Locale.ENGLISH))
 
 fun LocalDate.toIsoDate(): String = this.format(DateTimeFormatter.ISO_DATE)
+
+fun LocalDateTime.toOffsetString(): String =
+  DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(this.atOffset(ZoneId.of("Europe/London").rules.getOffset(this)))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/StringExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/StringExt.kt
@@ -1,5 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common
 
+import java.time.OffsetDateTime
+
 fun String.isEmail() = this.matches(
   Regex("[a-zA-Z0-9\\+\\.\\_\\%\\-\\+]{1,256}\\@[a-zA-Z0-9][a-zA-Z0-9\\-]{0,64}(\\.[a-zA-Z0-9][a-zA-Z0-9\\-]{0,25})+"),
 )
+
+fun String.toOffsetDateTime() = OffsetDateTime.parse(this)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/DomainEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/DomainEvents.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toOffsetString
 import java.time.LocalDateTime
 
 abstract class DomainEvent<T : AdditionalInformation>(
@@ -12,7 +13,7 @@ abstract class DomainEvent<T : AdditionalInformation>(
   val eventType = eventType.eventType
   val description = eventType.description
   val version: String = "1"
-  val occurredAt: LocalDateTime = LocalDateTime.now()
+  val occurredAt: String = LocalDateTime.now().toOffsetString()
 
   fun toEventType() = DomainEventType.valueOf(eventType)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/OutboundEventsServiceImplTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/OutboundEventsServiceImplTest.kt
@@ -7,6 +7,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toOffsetDateTime
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import java.time.LocalDateTime
@@ -72,7 +73,7 @@ class OutboundEventsServiceImplTest {
     with(eventCaptor.firstValue) {
       eventType isEqualTo expectedEventType.eventType
       additionalInformation isEqualTo expectedAdditionalInformation
-      occurredAt isCloseTo expectedOccurredAt
+      occurredAt.toOffsetDateTime().toLocalDateTime() isCloseTo expectedOccurredAt
       description isEqualTo expectedDescription
     }
 


### PR DESCRIPTION
The occurredAt is a an offset date time which we were not catering for.  This showed up a deserialisation issue when testing the release of a prisoner in dev with some video bookings.