### PR TITLE
BAVL-235 missing brackets off query when looking for bookings that can be cancelled.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/PrisonAppointmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/PrisonAppointmentRepository.kt
@@ -21,8 +21,7 @@ interface PrisonAppointmentRepository : JpaRepository<PrisonAppointment, Long> {
     SELECT pa FROM PrisonAppointment pa 
      WHERE pa.prisonerNumber = :prisonerNumber
        AND pa.videoBooking.statusCode = 'ACTIVE'
-       AND (pa.appointmentDate = :date AND pa.startTime > :time)
-        OR (pa.appointmentDate > :date)
+       AND ((pa.appointmentDate = :date AND pa.startTime > :time) OR (pa.appointmentDate > :date))
   """,
   )
   fun findActivePrisonerPrisonAppointmentsAfter(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerReleasedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerReleasedEventHandler.kt
@@ -21,7 +21,6 @@ class PrisonerReleasedEventHandler(
 
   override fun handle(event: PrisonerReleasedEvent) {
     when {
-      // Doing the temporary check first to avoid potentially unnecessary database calls.
       event.isTemporary() -> log.info("RELEASE EVENT HANDLER: Ignoring temporary release event $event")
       event.isPermanent() -> cancelFutureBookingsFor(event.prisonerNumber())
       else -> log.warn("RELEASE EVENT HANDLER: Ignoring unknown release event $event")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/SqsIntegrationTestBase.kt
@@ -58,7 +58,7 @@ abstract class SqsIntegrationTestBase : IntegrationTestBase() {
     eventsClient.sendMessage(SendMessageRequest.builder().queueUrl(eventsQueue.queueUrl).messageBody(raw(message)).build()).get()
   }
 
-  private fun raw(event: DomainEvent<*>) =
+  protected fun raw(event: DomainEvent<*>): String =
     mapper.writeValueAsString(
       Message(
         "Notification",


### PR DESCRIPTION
Missing brackets of JPQL query when looking for active bookings that could be cancelled.  Backed up with a test this time.