### PR TITLE
BAVL-25: Fix syncing of bookings without comments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
@@ -45,7 +45,7 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
     startTime: LocalTime,
     endTime: LocalTime,
     internalLocationId: Long,
-    comments: String,
+    comments: String?,
   ): AppointmentSeries? =
     activitiesAppointmentsApiWebClient.post()
       .uri("/appointment-series")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
@@ -200,12 +200,14 @@ class ManageExternalAppointmentsService(
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in prison-api for booking history appointment ${bha.bookingHistoryAppointmentId}") }
     }
 
-  private fun PrisonAppointment.detailedComments() =
-    if (videoBooking.isCourtBooking()) {
+  private fun PrisonAppointment.detailedComments(): String? {
+    if (comments == null) return null
+    return if (videoBooking.isCourtBooking()) {
       "Video booking for court hearing type ${videoBooking.hearingType} at ${videoBooking.court?.description}\n\n$comments"
     } else {
       "Video booking for probation meeting type ${videoBooking.probationMeetingType} at ${videoBooking.probationTeam?.description}\n\n$comments"
     }
+  }
 
   // This should never happen but if it ever happens we are throwing NPE with a bit more context to it!
   private fun PrisonAppointment.internalLocationId() =


### PR DESCRIPTION
Previously would have synced to A&A like this

<img width="612" alt="Screenshot 2024-07-10 at 13 46 05" src="https://github.com/ministryofjustice/hmpps-book-a-video-link-api/assets/30229564/abe07394-7e56-438e-9ac6-4a2101ac551e">
