### PR TITLE
BAVL-235 should be using the last known prison on release/transfer of prisoners when sending emails.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonersearch/PrisonerSearchClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonersearch/PrisonerSearchClient.kt
@@ -37,4 +37,5 @@ data class Prisoner(
   val lastName: String,
   val dateOfBirth: LocalDate,
   val bookingId: String? = null,
+  val lastPrisonId: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
@@ -68,18 +68,21 @@ class BookingFacade(
     val booking = cancelVideoBookingService.cancel(videoBookingId, username)
     log.info("Video booking ${booking.videoBookingId} cancelled due to transfer")
     outboundEventsService.send(DomainEventType.VIDEO_BOOKING_CANCELLED, booking.videoBookingId)
-    sendBookingEmails(BookingAction.TRANSFERRED, booking, getPrisoner(booking.prisoner()))
+    sendBookingEmails(BookingAction.TRANSFERRED, booking, getReleasedOrTransferredPrisoner(booking.prisoner()))
   }
 
   fun prisonerReleased(videoBookingId: Long, username: String) {
     val booking = cancelVideoBookingService.cancel(videoBookingId, username)
     log.info("Video booking ${booking.videoBookingId} cancelled due to release")
     outboundEventsService.send(DomainEventType.VIDEO_BOOKING_CANCELLED, booking.videoBookingId)
-    sendBookingEmails(BookingAction.RELEASED, booking, getPrisoner(booking.prisoner()))
+    sendBookingEmails(BookingAction.RELEASED, booking, getReleasedOrTransferredPrisoner(booking.prisoner()))
   }
 
   private fun getPrisoner(prisonerNumber: String) =
     prisonerSearchClient.getPrisoner(prisonerNumber)!!.let { Prisoner(it.prisonerNumber, it.prisonId!!, it.firstName, it.lastName, it.dateOfBirth) }
+
+  private fun getReleasedOrTransferredPrisoner(prisonerNumber: String) =
+    prisonerSearchClient.getPrisoner(prisonerNumber)!!.let { Prisoner(it.prisonerNumber, it.lastPrisonId!!, it.firstName, it.lastName, it.dateOfBirth) }
 
   private fun VideoBooking.bookingType() = if (isCourtBooking()) BookingType.COURT else BookingType.PROBATION
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -47,6 +47,7 @@ fun prisonerSearchPrisoner(
   firstName: String = "Fred",
   lastName: String = "Bloggs",
   bookingId: Long = -1,
+  lastPrisonCode: String? = null,
 ) = Prisoner(
   prisonerNumber = prisonerNumber,
   prisonId = prisonCode,
@@ -54,6 +55,7 @@ fun prisonerSearchPrisoner(
   lastName = lastName,
   bookingId = bookingId.toString(),
   dateOfBirth = LocalDate.of(2000, 1, 1),
+  lastPrisonId = lastPrisonCode,
 )
 
 fun userEmail(username: String, email: String, verified: Boolean = true) = EmailAddressDto(username, email, verified)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/InboundEventsIntegrationTest.kt
@@ -166,13 +166,15 @@ class InboundEventsIntegrationTest : SqsIntegrationTestBase() {
 
     val bookingId = webTestClient.createBooking(courtBookingRequest, TEST_USERNAME)
 
+    prisonSearchApi().stubGetPrisoner(prisonNumber = "YD1234", prisonCode = "TRN", lastPrisonCode = WERRINGTON)
+
     inboundEventsListener.onMessage(
       raw(
         PrisonerReleasedEvent(
           ReleaseInformation(
             nomsNumber = "YD1234",
-            prisonId = WERRINGTON,
-            reason = "RELEASED",
+            prisonId = "TRN",
+            reason = "TRANSFERRED",
           ),
         ),
       ),
@@ -186,8 +188,8 @@ class InboundEventsIntegrationTest : SqsIntegrationTestBase() {
           PrisonerReleasedEvent(
             ReleaseInformation(
               nomsNumber = "YD1234",
-              prisonId = WERRINGTON,
-              reason = "RELEASED",
+              prisonId = "TRN",
+              reason = "TRANSFERRED",
             ),
           ),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonerSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonerSearchApiMockServer.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonerSearch
 
 class PrisonerSearchApiMockServer : MockServer(8092) {
 
-  fun stubGetPrisoner(prisonNumber: String, prisonCode: String = "MDI") {
+  fun stubGetPrisoner(prisonNumber: String, prisonCode: String = "MDI", lastPrisonCode: String? = null) {
     stubFor(
       get("/prisoner/$prisonNumber")
         .willReturn(
@@ -21,6 +21,7 @@ class PrisonerSearchApiMockServer : MockServer(8092) {
                 prisonerSearchPrisoner(
                   prisonerNumber = prisonNumber,
                   prisonCode = prisonCode,
+                  lastPrisonCode = lastPrisonCode,
                 ),
               ),
             )


### PR DESCRIPTION
This change fixes an issue when a prisoner is release or transferred.

When looking up the prisoner from prisoner search we should be using the prisoners last prison id/code when looking up the prison details in our service otherwise they will not match.