### PR TITLE
BAVL-246 changes to allow new bookings to be at the same date and time and location as cancelled ones, this is allowed.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/PrisonAppointmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/PrisonAppointmentRepository.kt
@@ -10,7 +10,16 @@ import java.time.LocalTime
 interface PrisonAppointmentRepository : JpaRepository<PrisonAppointment, Long> {
   fun findByVideoBooking(booking: VideoBooking): List<PrisonAppointment>
 
-  fun findByPrisonCodeAndPrisonLocKeyAndAppointmentDate(
+  @Query(
+    value = """
+    SELECT pa FROM PrisonAppointment pa 
+     WHERE pa.prisonCode = :prisonCode
+       AND pa.prisonLocKey = :key
+       AND pa.videoBooking.statusCode = 'ACTIVE'
+       AND pa.appointmentDate = :date
+  """,
+  )
+  fun findActivePrisonAppointmentsAtLocationOnDate(
     prisonCode: String,
     key: String,
     date: LocalDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AppointmentsService.kt
@@ -63,7 +63,7 @@ class AppointmentsService(
 
   private fun List<Appointment>.checkExistingCourtAppointmentDateAndTimesDoNotOverlap(prisonCode: String) {
     forEach { newAppointment ->
-      prisonAppointmentRepository.findByPrisonCodeAndPrisonLocKeyAndAppointmentDate(
+      prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(
         prisonCode,
         newAppointment.locationKey!!,
         newAppointment.date!!,
@@ -113,7 +113,7 @@ class AppointmentsService(
   }
 
   private fun Appointment.checkExistingProbationAppointmentDateAndTimesDoNotOverlap(prisonCode: String) {
-    prisonAppointmentRepository.findByPrisonCodeAndPrisonLocKeyAndAppointmentDate(
+    prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(
       prisonCode,
       locationKey!!,
       date!!,

--- a/src/main/resources/migrations/common/V2024.04.22__baseline_tables.sql
+++ b/src/main/resources/migrations/common/V2024.04.22__baseline_tables.sql
@@ -223,7 +223,7 @@ CREATE INDEX idx_prison_appointment_loc_key ON prison_appointment(prison_loc_key
 CREATE INDEX idx_prison_appointment_date ON prison_appointment(appointment_date);
 CREATE INDEX idx_prison_appointment_start_time ON prison_appointment(start_time);
 CREATE INDEX idx_prison_appointment_end_time ON prison_appointment(end_time);
-CREATE UNIQUE INDEX idx_prison_appointment_loc_date_start_end on prison_appointment(prison_loc_key, appointment_date, start_time, end_time);
+CREATE INDEX idx_prison_appointment_loc_date_start_end on prison_appointment(prison_loc_key, appointment_date, start_time, end_time);
 
 ---------------------------------------------------------------------------------------
 -- This is the third party contact details for attendees to a booking

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingServiceTest.kt
@@ -528,7 +528,7 @@ class AmendVideoBookingServiceTest {
     whenever(videoBookingRepository.findById(videoBookingId)) doReturn Optional.of(courtBooking)
     whenever(courtRepository.findByCode(amendCourtBookingRequest.courtCode!!)) doReturn requestedCourt
     whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
-    whenever(prisonAppointmentRepository.findByPrisonCodeAndPrisonLocKeyAndAppointmentDate(BIRMINGHAM, "$BIRMINGHAM-A-1-001", tomorrow())) doReturn listOf(overlappingAppointment)
+    whenever(prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(BIRMINGHAM, "$BIRMINGHAM-A-1-001", tomorrow())) doReturn listOf(overlappingAppointment)
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 
@@ -656,7 +656,7 @@ class AmendVideoBookingServiceTest {
     whenever(videoBookingRepository.findById(videoBookingId)) doReturn Optional.of(probationBooking)
     whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn requestedProbationTeam
     whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
-    whenever(prisonAppointmentRepository.findByPrisonCodeAndPrisonLocKeyAndAppointmentDate(BIRMINGHAM, "$BIRMINGHAM-B-2-001", tomorrow())) doReturn listOf(overlappingAppointment)
+    whenever(prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(BIRMINGHAM, "$BIRMINGHAM-B-2-001", tomorrow())) doReturn listOf(overlappingAppointment)
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingServiceTest.kt
@@ -475,7 +475,7 @@ class CreateVideoBookingServiceTest {
 
     whenever(courtRepository.findByCode(courtBookingRequest.courtCode!!)) doReturn requestedCourt
     whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
-    whenever(prisonAppointmentRepository.findByPrisonCodeAndPrisonLocKeyAndAppointmentDate(BIRMINGHAM, "$BIRMINGHAM-A-1-001", tomorrow())) doReturn listOf(overlappingAppointment)
+    whenever(prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(BIRMINGHAM, "$BIRMINGHAM-A-1-001", tomorrow())) doReturn listOf(overlappingAppointment)
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 
@@ -594,7 +594,7 @@ class CreateVideoBookingServiceTest {
 
     whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn requestedProbationTeam
     whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
-    whenever(prisonAppointmentRepository.findByPrisonCodeAndPrisonLocKeyAndAppointmentDate(BIRMINGHAM, "$BIRMINGHAM-B-2-001", tomorrow())) doReturn listOf(overlappingAppointment)
+    whenever(prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(BIRMINGHAM, "$BIRMINGHAM-B-2-001", tomorrow())) doReturn listOf(overlappingAppointment)
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 


### PR DESCRIPTION
So this changes fixes the initial problem.  However we would potentially need different behavior if it were created by a prison user, as in we don't care about clashes at all when done by a prison user.