### PR TITLE
BAVL-250 changes to support the processing of prisoner merge events.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/BookingHistoryAppointmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/BookingHistoryAppointmentRepository.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingHistoryAppointment
+
+interface BookingHistoryAppointmentRepository : JpaRepository<BookingHistoryAppointment, Long> {
+
+  fun countByPrisonerNumber(prisonerNumber: String): Long
+
+  @Query(value = "UPDATE BookingHistoryAppointment bha SET bha.prisonerNumber = :newNumber WHERE bha.prisonerNumber = :oldNumber")
+  @Modifying
+  fun mergeOldPrisonerNumberToNew(oldNumber: String, newNumber: String)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/PrisonAppointmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/PrisonAppointmentRepository.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
@@ -38,4 +39,10 @@ interface PrisonAppointmentRepository : JpaRepository<PrisonAppointment, Long> {
     date: LocalDate,
     time: LocalTime,
   ): List<PrisonAppointment>
+
+  fun countByPrisonerNumber(prisonerNumber: String): Long
+
+  @Query(value = "UPDATE PrisonAppointment pa SET pa.prisonerNumber = :newNumber WHERE pa.prisonerNumber = :oldNumber")
+  @Modifying
+  fun mergeOldPrisonerNumberToNew(oldNumber: String, newNumber: String)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
@@ -102,7 +102,7 @@ class BookingFacade(
     contacts.mapNotNull { contact ->
       when (contact.contactType) {
         ContactType.USER -> CourtEmailFactory.user(contact, prisoner, booking, prison, main, pre, post, locations, eventType)
-        ContactType.COURT -> if (user?.isPrisonUser() == true || eventType == BookingAction.RELEASED || eventType == BookingAction.TRANSFERRED) CourtEmailFactory.court(contact, prisoner, booking, prison, main, pre, post, locations, eventType) else null
+        ContactType.COURT -> if (user?.isUserType(UserType.PRISON) == true || eventType == BookingAction.RELEASED || eventType == BookingAction.TRANSFERRED) CourtEmailFactory.court(contact, prisoner, booking, prison, main, pre, post, locations, eventType) else null
         ContactType.PRISON -> CourtEmailFactory.prison(contact, prisoner, booking, prison, contacts, main, pre, post, locations, eventType)
         else -> null
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
@@ -51,7 +51,7 @@ class CreateVideoBookingService(
       comments = request.comments,
       videoUrl = request.videoLinkUrl,
       createdBy = createdBy.username,
-      createdByPrison = createdBy.isPrisonUser(),
+      createdByPrison = createdBy.isUserType(UserType.PRISON),
     )
       .also { booking -> appointmentsService.createAppointmentsForCourt(booking, request.prisoner()) }
       .also { booking -> videoBookingRepository.saveAndFlush(booking) }
@@ -72,7 +72,7 @@ class CreateVideoBookingService(
       comments = request.comments,
       videoUrl = request.videoLinkUrl,
       createdBy = createdBy.username,
-      createdByPrison = createdBy.isPrisonUser(),
+      createdByPrison = createdBy.isUserType(UserType.PRISON),
     )
       .also { thisBooking -> appointmentsService.createAppointmentForProbation(thisBooking, request.prisoner()) }
       .also { thisBooking -> videoBookingRepository.saveAndFlush(thisBooking) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/DomainEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/DomainEvents.kt
@@ -65,7 +65,15 @@ class PrisonerReleasedEvent(additionalInformation: ReleaseInformation) :
 
 data class ReleaseInformation(val nomsNumber: String, val reason: String, val prisonId: String) : AdditionalInformation
 
-enum class DomainEventType(val eventType: String, val description: String) {
+class PrisonerMergedEvent(additionalInformation: MergeInformation) :
+  DomainEvent<MergeInformation>(DomainEventType.PRISONER_MERGED, additionalInformation) {
+  fun newPrisonerNumber() = additionalInformation.nomsNumber
+  fun oldPrisonerNumber() = additionalInformation.removedNomsNumber
+}
+
+data class MergeInformation(val nomsNumber: String, val removedNomsNumber: String) : AdditionalInformation
+
+enum class DomainEventType(val eventType: String, val description: String = "") {
   VIDEO_BOOKING_CREATED(
     "book-a-video-link.video-booking.created",
     "A new video booking has been created in the book a video link service",
@@ -94,9 +102,13 @@ enum class DomainEventType(val eventType: String, val description: String) {
     override fun toInboundEvent(mapper: ObjectMapper, message: String) =
       mapper.readValue<VideoBookingAmendedEvent>(message)
   },
-  PRISONER_RELEASED("prisoner-offender-search.prisoner.released", "") {
+  PRISONER_RELEASED("prisoner-offender-search.prisoner.released") {
     override fun toInboundEvent(mapper: ObjectMapper, message: String) =
       mapper.readValue<PrisonerReleasedEvent>(message)
+  },
+  PRISONER_MERGED("prison-offender-events.prisoner.merged") {
+    override fun toInboundEvent(mapper: ObjectMapper, message: String) =
+      mapper.readValue<PrisonerMergedEvent>(message)
   },
   ;
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsService.kt
@@ -4,6 +4,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.AppointmentCreatedEventHandler
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerMergedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerReleasedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.VideoBookingAmendedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.VideoBookingCancelledEventHandler
@@ -16,6 +17,7 @@ class InboundEventsService(
   private val videoBookingCancelledEventHandler: VideoBookingCancelledEventHandler,
   private val videoBookingAmendedEventHandler: VideoBookingAmendedEventHandler,
   private val prisonerReleasedEventHandler: PrisonerReleasedEventHandler,
+  private val prisonerMergedEventHandler: PrisonerMergedEventHandler,
 ) {
   companion object {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -23,11 +25,12 @@ class InboundEventsService(
 
   fun process(event: DomainEvent<*>) {
     when (event) {
-      is VideoBookingCreatedEvent -> videoBookingCreatedEventHandler.handle(event)
       is AppointmentCreatedEvent -> appointmentCreatedEventHandler.handle(event)
-      is VideoBookingCancelledEvent -> videoBookingCancelledEventHandler.handle(event)
-      is VideoBookingAmendedEvent -> videoBookingAmendedEventHandler.handle(event)
+      is PrisonerMergedEvent -> prisonerMergedEventHandler.handle(event)
       is PrisonerReleasedEvent -> prisonerReleasedEventHandler.handle(event)
+      is VideoBookingAmendedEvent -> videoBookingAmendedEventHandler.handle(event)
+      is VideoBookingCancelledEvent -> videoBookingCancelledEventHandler.handle(event)
+      is VideoBookingCreatedEvent -> videoBookingCreatedEventHandler.handle(event)
       else -> log.warn("Unsupported domain event ${event.javaClass.name}")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerMergedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerMergedEventHandler.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.BookingHistoryAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PrisonerMergedEvent
+
+@Component
+class PrisonerMergedEventHandler(
+  private val prisonAppRepository: PrisonAppointmentRepository,
+  private val bookingHistoryAppRepository: BookingHistoryAppointmentRepository,
+) : DomainEventHandler<PrisonerMergedEvent> {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Transactional
+  override fun handle(event: PrisonerMergedEvent) {
+    val old = event.oldPrisonerNumber()
+    val new = event.newPrisonerNumber()
+
+    prisonAppRepository.countByPrisonerNumber(old).takeIf { it > 0 }?.let { count ->
+      prisonAppRepository.mergeOldPrisonerNumberToNew(oldNumber = old, newNumber = new)
+      log.info("PRISONER MERGED: merged $count prison appointment(s) for old number '$old' to new number '$new'")
+    }
+
+    bookingHistoryAppRepository.countByPrisonerNumber(old).takeIf { it > 0 }?.let { count ->
+      bookingHistoryAppRepository.mergeOldPrisonerNumberToNew(oldNumber = old, newNumber = new)
+      log.info("PRISONER MERGED: merged $count booking history appointment(s) for old number '$old' to new number '$new'")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/UserServiceTest.kt
@@ -8,8 +8,8 @@ import org.mockito.kotlin.whenever
 import org.springframework.security.access.AccessDeniedException
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.manageusers.ManageUsersClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.manageusers.model.UserDetailsDto.AuthSource
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isNotEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.userDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.userEmailAddress
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserService.Companion.getClientAsUser
@@ -22,22 +22,22 @@ class UserServiceTest {
 
   @Test
   fun `getServiceAsUser should return ContactDetails for valid email username`() {
-    val result = getServiceAsUser()
-
-    result.username isEqualTo "BOOK_A_VIDEO_LINK_SERVICE"
-    result.name isEqualTo "BOOK_A_VIDEO_LINK_SERVICE"
-    result.userType isEqualTo UserType.SERVICE
-    result.email isEqualTo null
+    with(getServiceAsUser()) {
+      username isEqualTo "BOOK_A_VIDEO_LINK_SERVICE"
+      name isEqualTo "BOOK_A_VIDEO_LINK_SERVICE"
+      isUserType(UserType.SERVICE) isBool true
+      email isEqualTo null
+    }
   }
 
   @Test
   fun `getClientAsUser should return ContactDetails for valid email username`() {
-    val result = getClientAsUser("client")
-
-    result.username isEqualTo "client"
-    result.name isEqualTo "client"
-    result.userType isEqualTo UserType.SERVICE
-    result.email isEqualTo null
+    with(getClientAsUser("client")) {
+      username isEqualTo "client"
+      name isEqualTo "client"
+      isUserType(UserType.SERVICE) isBool true
+      email isEqualTo null
+    }
   }
 
   @Test
@@ -45,11 +45,11 @@ class UserServiceTest {
     val username = "testUser"
     whenever(manageUsersClient.getUsersDetails(username)) doReturn userDetails(username, "Test User", authSource = AuthSource.nomis)
 
-    val user = userService.getUser(username)
-
-    user isNotEqualTo null
-    user?.userType isEqualTo UserType.PRISON
-    user?.name isEqualTo "Test User"
+    with(userService.getUser(username)!!) {
+      username isEqualTo "testUser"
+      isUserType(UserType.PRISON) isBool true
+      name isEqualTo "Test User"
+    }
   }
 
   @Test
@@ -57,11 +57,11 @@ class UserServiceTest {
     val username = "testUser"
     whenever(manageUsersClient.getUsersDetails(username)) doReturn userDetails(username, "Test User", authSource = AuthSource.auth)
 
-    val user = userService.getUser(username)
-
-    user isNotEqualTo null
-    user?.userType isEqualTo UserType.EXTERNAL
-    user?.name isEqualTo "Test User"
+    with(userService.getUser(username)!!) {
+      username isEqualTo "testUser"
+      isUserType(UserType.EXTERNAL) isBool true
+      name isEqualTo "Test User"
+    }
   }
 
   @Test
@@ -79,9 +79,7 @@ class UserServiceTest {
     val username = "testUser"
     whenever(manageUsersClient.getUsersDetails(username)) doReturn null
 
-    val user = userService.getUser(username)
-
-    user isEqualTo null
+    userService.getUser(username) isEqualTo null
   }
 
   @Test
@@ -89,10 +87,7 @@ class UserServiceTest {
     val username = "test@example.com"
     whenever(manageUsersClient.getUsersDetails(username)) doReturn userDetails(username, "Test User")
 
-    val user = userService.getUser(username)
-
-    user isNotEqualTo null
-    user?.email isEqualTo "test@example.com"
+    userService.getUser(username)?.email isEqualTo "test@example.com"
   }
 
   @Test
@@ -101,9 +96,6 @@ class UserServiceTest {
     whenever(manageUsersClient.getUsersDetails(username)) doReturn userDetails(username, "Test User")
     whenever(manageUsersClient.getUsersEmail(username)) doReturn userEmailAddress(username, "test@example.com")
 
-    val user = userService.getUser(username)
-
-    user isNotEqualTo null
-    user?.email isEqualTo "test@example.com"
+    userService.getUser(username)?.email isEqualTo "test@example.com"
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsServiceTest.kt
@@ -5,6 +5,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.AppointmentCreatedEventHandler
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerMergedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerReleasedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.VideoBookingAmendedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.VideoBookingCancelledEventHandler
@@ -17,6 +18,7 @@ class InboundEventsServiceTest {
   private val videoBookingCancelledEventHandler: VideoBookingCancelledEventHandler = mock()
   private val videoBookingAmendedEventHandler: VideoBookingAmendedEventHandler = mock()
   private val prisonerReleasedEventHandler: PrisonerReleasedEventHandler = mock()
+  private val prisonerMergedEventHandler: PrisonerMergedEventHandler = mock()
 
   private val service = InboundEventsService(
     appointmentCreatedEventHandler,
@@ -24,6 +26,7 @@ class InboundEventsServiceTest {
     videoBookingCancelledEventHandler,
     videoBookingAmendedEventHandler,
     prisonerReleasedEventHandler,
+    prisonerMergedEventHandler,
   )
 
   @Test
@@ -79,5 +82,12 @@ class InboundEventsServiceTest {
     val event2 = PrisonerReleasedEvent(ReleaseInformation("78910", "RELEASED", BIRMINGHAM))
     service.process(event2)
     verify(prisonerReleasedEventHandler).handle(event2)
+  }
+
+  @Test
+  fun `should call prisoner merged handler when for prisoner merged event`() {
+    val event = PrisonerMergedEvent(MergeInformation(nomsNumber = "NEW", removedNomsNumber = "OLD"))
+    service.process(event)
+    verify(prisonerMergedEventHandler).handle(event)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerMergedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerMergedEventHandlerTest.kt
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers
+
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.BookingHistoryAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.MergeInformation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PrisonerMergedEvent
+
+class PrisonerMergedEventHandlerTest {
+
+  private val mergeEvent = PrisonerMergedEvent(MergeInformation(removedNomsNumber = "old", nomsNumber = "new"))
+  private val prisonAppointmentRepository: PrisonAppointmentRepository = mock()
+  private val bookingHistoryAppointmentRepository: BookingHistoryAppointmentRepository = mock()
+  private val handler = PrisonerMergedEventHandler(prisonAppointmentRepository, bookingHistoryAppointmentRepository)
+
+  @Test
+  fun `should merge only prison appointments`() {
+    whenever(prisonAppointmentRepository.countByPrisonerNumber("old")) doReturn 1
+
+    handler.handle(mergeEvent)
+
+    verify(prisonAppointmentRepository).mergeOldPrisonerNumberToNew(oldNumber = "old", newNumber = "new")
+    verify(bookingHistoryAppointmentRepository, never()).mergeOldPrisonerNumberToNew(anyString(), anyString())
+  }
+
+  @Test
+  fun `should merge only booking history appointments`() {
+    whenever(bookingHistoryAppointmentRepository.countByPrisonerNumber("old")) doReturn 1
+
+    handler.handle(mergeEvent)
+
+    verify(bookingHistoryAppointmentRepository).mergeOldPrisonerNumberToNew(oldNumber = "old", newNumber = "new")
+    verify(prisonAppointmentRepository, never()).mergeOldPrisonerNumberToNew(anyString(), anyString())
+  }
+
+  @Test
+  fun `should merge prison appointments and booking history appointments`() {
+    whenever(prisonAppointmentRepository.countByPrisonerNumber("old")) doReturn 1
+    whenever(bookingHistoryAppointmentRepository.countByPrisonerNumber("old")) doReturn 1
+
+    handler.handle(mergeEvent)
+
+    verify(prisonAppointmentRepository).mergeOldPrisonerNumberToNew(oldNumber = "old", newNumber = "new")
+    verify(bookingHistoryAppointmentRepository).mergeOldPrisonerNumberToNew(oldNumber = "old", newNumber = "new")
+  }
+}

--- a/src/test/resources/integration-test-data/seed-prisoner-merge.sql
+++ b/src/test/resources/integration-test-data/seed-prisoner-merge.sql
@@ -1,0 +1,11 @@
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
+values (-1, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
+
+insert into prison_appointment (video_booking_id, prison_code, prisoner_number, appointment_type, comments, prison_loc_key, appointment_date,  start_time, end_time)
+values (-1, 'WNI', 'OLD123', 'VLB_COURT_MAIN', 'comments about the hearing', 'WNI-ABCDEFG', current_date, '12:00', '13:00');
+
+insert into booking_history (booking_history_id, video_booking_id, history_type, court_id, hearing_type, comments, created_by, created_time)
+values (-1, -1, 'CREATE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
+
+insert into booking_history_appointment(booking_history_appointment_id, booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_loc_key, start_time, end_time)
+values (-1, -1, 'WNI', 'OLD123', current_date, 'VLB_COURT_MAIN', 'WNI-ABCDEFG', '12:00', '13:00');


### PR DESCRIPTION
This needs to be merged before the (yet to do) cloud platform change to listen for the actual event, otherwise messages can build up on the queue.