### PR TITLE
BAVL-266 adding location caching and capping the max number of days of data to 1 year.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationsInsidePrisonClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationsInsidePrisonClient.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison
 
 import jakarta.validation.ValidationException
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
@@ -9,6 +10,7 @@ import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.extensions.isActive
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.extensions.isAtPrison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.CacheConfiguration
 
 inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>() {}
 
@@ -23,6 +25,7 @@ class LocationsInsidePrisonClient(private val locationsInsidePrisonApiWebClient:
     .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
     .block() ?: emptyList()
 
+  @Cacheable(CacheConfiguration.NON_RESIDENTIAL_LOCATIONS_CACHE_NAME)
   fun getNonResidentialAppointmentLocationsAtPrison(prisonCode: String): List<Location> = locationsInsidePrisonApiWebClient.get()
     .uri("/locations/prison/{prisonCode}/non-residential-usage-type/APPOINTMENT", prisonCode)
     .retrieve()
@@ -30,6 +33,7 @@ class LocationsInsidePrisonClient(private val locationsInsidePrisonApiWebClient:
     .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
     .block() ?: emptyList()
 
+  @Cacheable(CacheConfiguration.VIDEO_LINK_LOCATIONS_CACHE_NAME)
   fun getVideoLinkLocationsAtPrison(prisonCode: String): List<Location> = locationsInsidePrisonApiWebClient.get()
     .uri("/locations/prison/{prisonCode}/location-type/VIDEO_LINK", prisonCode)
     .retrieve()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/CacheConfiguration.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.annotation.Scheduled
+import java.util.concurrent.TimeUnit
+
+@Configuration
+@EnableCaching
+@EnableScheduling
+class CacheConfiguration {
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+
+    const val VIDEO_LINK_LOCATIONS_CACHE_NAME: String = "video_link_locations"
+    const val NON_RESIDENTIAL_LOCATIONS_CACHE_NAME: String = "non_residential_locations"
+  }
+
+  @Bean
+  fun cacheManager(): CacheManager {
+    return ConcurrentMapCacheManager(VIDEO_LINK_LOCATIONS_CACHE_NAME, NON_RESIDENTIAL_LOCATIONS_CACHE_NAME)
+  }
+
+  @CacheEvict(value = [VIDEO_LINK_LOCATIONS_CACHE_NAME])
+  @Scheduled(fixedDelay = 12, timeUnit = TimeUnit.HOURS)
+  fun cacheEvictVideoLinkLocations() {
+    log.info("Evicting cache: $VIDEO_LINK_LOCATIONS_CACHE_NAME after 12 hours")
+  }
+
+  @CacheEvict(value = [NON_RESIDENTIAL_LOCATIONS_CACHE_NAME])
+  @Scheduled(fixedDelay = 12, timeUnit = TimeUnit.HOURS)
+  fun cacheEvictNonResidentialLocations() {
+    log.info("Evicting cache: $NON_RESIDENTIAL_LOCATIONS_CACHE_NAME after 12 hours")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/PrisonsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/PrisonsResourceIntegrationTest.kt
@@ -1,8 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.CacheManager
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
@@ -18,7 +20,16 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepo
 class PrisonsResourceIntegrationTest : IntegrationTestBase() {
 
   @Autowired
+  private lateinit var cacheManager: CacheManager
+
+  @Autowired
   private lateinit var prisonRepository: PrisonRepository
+
+  @BeforeEach
+  fun before() {
+    // Some location endpoints are being cached, so we need to clear them so as not to impact the unit tests in this class.
+    cacheManager.clearAllCaches()
+  }
 
   @Test
   fun `should return a list of enabled prisons`() {
@@ -106,4 +117,8 @@ class PrisonsResourceIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
       .expectBodyList(Location::class.java)
       .returnResult().responseBody!!
+
+  private fun CacheManager.clearAllCaches() {
+    cacheNames.forEach { cacheManager.getCache(it)?.clear() }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CsvDataExtractionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CsvDataExtractionServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -85,6 +86,29 @@ class CsvDataExtractionServiceTest {
     csvOutputStream.toString() isEqualTo
       "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName\n" +
       "1,2024-07-01T09:00:00,1,CREATE,$MOORLAND,\"court description\",\"court code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T09:00:00,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T12:00:00,\"Main location\",\"Pre location\",\"Post location\"\n"
+  }
+
+  @Test
+  fun `should fail to produce CSV reports when requested date range more than a year`() {
+    assertThrows<IllegalArgumentException> {
+      service.courtBookingsByHearingDateToCsv(today(), today().plusDays(366), csvOutputStream)
+    }
+      .message isEqualTo "CSV extracts are limited to a years worth of data."
+
+    assertThrows<IllegalArgumentException> {
+      service.courtBookingsByBookingDateToCsv(today(), today().plusDays(366), csvOutputStream)
+    }
+      .message isEqualTo "CSV extracts are limited to a years worth of data."
+
+    assertThrows<IllegalArgumentException> {
+      service.probationBookingsByMeetingDateToCsv(today(), today().plusDays(366), csvOutputStream)
+    }
+      .message isEqualTo "CSV extracts are limited to a years worth of data."
+
+    assertThrows<IllegalArgumentException> {
+      service.probationBookingsByBookingDateToCsv(today(), today().plusDays(366), csvOutputStream)
+    }
+      .message isEqualTo "CSV extracts are limited to a years worth of data."
   }
 
   @Test


### PR DESCRIPTION
Changes to cache locations primarily for CSV extracts.

Also adding cap to prevent requesting more that 1 years worth of data.