### PR TITLE
BAVL-278 allow overlapping existing prison appointment creation/amending for prison users.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/PrisonAppointmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/PrisonAppointmentRepository.kt
@@ -13,6 +13,28 @@ interface PrisonAppointmentRepository : JpaRepository<PrisonAppointment, Long> {
 
   @Query(
     value = """
+    SELECT CASE WHEN count(pa) > 0 THEN TRUE ELSE FALSE END
+      FROM PrisonAppointment pa 
+     WHERE pa.prisonerNumber = :prisonerNumber
+       AND pa.prisonCode = :prisonCode
+       AND pa.prisonLocKey = :key
+       AND pa.videoBooking.statusCode = 'ACTIVE'
+       AND pa.appointmentDate = :date
+       AND pa.startTime = :startTime
+       and pa.endTime = :endTime
+  """,
+  )
+  fun existsActivePrisonAppointmentsByPrisonerNumberLocationDateAndTime(
+    prisonerNumber: String,
+    prisonCode: String,
+    key: String,
+    date: LocalDate,
+    startTime: LocalTime,
+    endTime: LocalTime,
+  ): Boolean
+
+  @Query(
+    value = """
     SELECT pa FROM PrisonAppointment pa 
      WHERE pa.prisonCode = :prisonCode
        AND pa.prisonLocKey = :key

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingService.kt
@@ -64,7 +64,7 @@ class AmendVideoBookingService(
       amendedTime = LocalDateTime.now()
     }
       .also { thisBooking -> thisBooking.removeAllAppointments() }
-      .also { thisBooking -> appointmentsService.createAppointmentsForCourt(thisBooking, request.prisoner()) }
+      .also { thisBooking -> appointmentsService.createAppointmentsForCourt(thisBooking, request.prisoner(), amendedBy) }
       .also { thisBooking -> videoBookingRepository.saveAndFlush(thisBooking) }
       .also { thisBooking -> bookingHistoryService.createBookingHistory(HistoryType.AMEND, thisBooking) }
       .also { thisBooking -> log.info("BOOKINGS: court booking ${thisBooking.videoBookingId} amended") } to prisoner
@@ -86,7 +86,7 @@ class AmendVideoBookingService(
       amendedTime = LocalDateTime.now()
     }
       .also { thisBooking -> thisBooking.removeAllAppointments() }
-      .also { thisBooking -> appointmentsService.createAppointmentForProbation(thisBooking, request.prisoner()) }
+      .also { thisBooking -> appointmentsService.createAppointmentForProbation(thisBooking, request.prisoner(), amendedBy) }
       .also { thisBooking -> videoBookingRepository.saveAndFlush(thisBooking) }
       .also { thisBooking -> bookingHistoryService.createBookingHistory(HistoryType.AMEND, thisBooking) }
       .also { thisBooking -> log.info("BOOKINGS: probation team booking ${thisBooking.videoBookingId} amended") } to prisoner

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
@@ -53,7 +53,7 @@ class CreateVideoBookingService(
       createdBy = createdBy.username,
       createdByPrison = createdBy.isUserType(UserType.PRISON),
     )
-      .also { booking -> appointmentsService.createAppointmentsForCourt(booking, request.prisoner()) }
+      .also { booking -> appointmentsService.createAppointmentsForCourt(booking, request.prisoner(), createdBy) }
       .also { booking -> videoBookingRepository.saveAndFlush(booking) }
       .also { booking -> bookingHistoryService.createBookingHistory(HistoryType.CREATE, booking) }
       .also { log.info("BOOKINGS: court booking with id ${it.videoBookingId} created") } to prisoner
@@ -74,7 +74,7 @@ class CreateVideoBookingService(
       createdBy = createdBy.username,
       createdByPrison = createdBy.isUserType(UserType.PRISON),
     )
-      .also { thisBooking -> appointmentsService.createAppointmentForProbation(thisBooking, request.prisoner()) }
+      .also { thisBooking -> appointmentsService.createAppointmentForProbation(thisBooking, request.prisoner(), createdBy) }
       .also { thisBooking -> videoBookingRepository.saveAndFlush(thisBooking) }
       .also { thisBooking -> bookingHistoryService.createBookingHistory(HistoryType.CREATE, thisBooking) }
       .also { thisBooking -> log.info("BOOKINGS: probation team booking ${thisBooking.videoBookingId} created") } to prisoner

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/RequestBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/RequestBookingService.kt
@@ -51,7 +51,7 @@ class RequestBookingService(
 
   private fun processCourtBookingRequest(request: RequestVideoBookingRequest, user: User) {
     val prisoner = request.prisoner()
-    appointmentsService.checkCourtAppointments(prisoner.appointments, prisoner.prisonCode!!)
+    appointmentsService.checkCourtAppointments(prisoner.appointments, prisoner.prisonCode!!, user)
 
     val (pre, main, post) = getCourtAppointments(prisoner)
 
@@ -73,7 +73,7 @@ class RequestBookingService(
 
   private fun processProbationBookingRequest(request: RequestVideoBookingRequest, user: User) {
     val prisoner = request.prisoner()
-    appointmentsService.checkProbationAppointments(prisoner.appointments, prisoner.prisonCode!!)
+    appointmentsService.checkProbationAppointments(prisoner.appointments, prisoner.prisonCode!!, user)
 
     val appointment = prisoner.appointments.single()
     val prison = fetchPrison(prisoner.prisonCode)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/Users.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/Users.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper
+
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserType
+
+val EXTERNAL_USER = user("TEST USER")
+val PRISON_USER = user(username = "PRISON USER", userType = UserType.PRISON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -296,6 +296,29 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
   }
 
   @Test
+  fun `should reject duplicate court booking creation as a prison user`() {
+    videoBookingRepository.findAll() hasSize 0
+    notificationRepository.findAll() hasSize 0
+
+    prisonSearchApi().stubGetPrisoner("123456", WERRINGTON)
+    prisonSearchApi().stubGetPrisoner("789101", WERRINGTON)
+    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(werringtonLocation.key), WERRINGTON)
+
+    val courtBookingRequest = courtBookingRequest(
+      courtCode = DERBY_JUSTICE_CENTRE,
+      prisonerNumber = "123456",
+      prisonCode = WERRINGTON,
+      location = werringtonLocation,
+      startTime = LocalTime.of(12, 0),
+      endTime = LocalTime.of(12, 30),
+      comments = "integration test court booking comments",
+    )
+
+    webTestClient.createBooking(courtBookingRequest, TEST_PRISON_USER)
+    webTestClient.createBookingFails(courtBookingRequest, TEST_PRISON_USER).expectStatus().isBadRequest
+  }
+
+  @Test
   fun `should create a Chesterfield court booking and emails sent to Birmingham prison`() {
     videoBookingRepository.findAll() hasSize 0
     notificationRepository.findAll() hasSize 0
@@ -640,6 +663,27 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
       userMessage isEqualTo "Validation failure: Prisoner 789012 not found at prison MDI"
       developerMessage isEqualTo "Prisoner 789012 not found at prison MDI"
     }
+  }
+
+  @Test
+  fun `should reject duplicate probation booking creation as a prison user`() {
+    prisonSearchApi().stubGetPrisoner("123456", MOORLAND)
+    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(moorlandLocation.key), MOORLAND)
+
+    val probationBookingRequest = probationBookingRequest(
+      probationTeamCode = BLACKPOOL_MC_PPOC,
+      probationMeetingType = ProbationMeetingType.PSR,
+      videoLinkUrl = "https://probation.videolink.com",
+      prisonCode = MOORLAND,
+      prisonerNumber = "123456",
+      startTime = LocalTime.of(9, 0),
+      endTime = LocalTime.of(9, 30),
+      appointmentType = AppointmentType.VLB_PROBATION,
+      location = moorlandLocation,
+    )
+
+    webTestClient.createBooking(probationBookingRequest, TEST_PRISON_USER)
+    webTestClient.createBookingFails(probationBookingRequest, TEST_PRISON_USER).expectStatus().isBadRequest
   }
 
   @Test
@@ -1497,6 +1541,15 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
       .expectBody(Long::class.java)
       .returnResult().responseBody!!
+
+  private fun WebTestClient.createBookingFails(request: CreateVideoBookingRequest, username: String = TEST_EXTERNAL_USER) =
+    this
+      .post()
+      .uri("/video-link-booking")
+      .bodyValue(request)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(user = username, roles = listOf("ROLE_BOOK_A_VIDEO_LINK_ADMIN")))
+      .exchange()
 
   private fun WebTestClient.searchForBooking(request: VideoBookingSearchRequest, username: String = TEST_EXTERNAL_USER) =
     this

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingHistoryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingHistoryServiceTest.kt
@@ -10,6 +10,7 @@ import org.mockito.kotlin.argumentCaptor
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingHistory
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.EXTERNAL_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WERRINGTON
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
@@ -40,7 +41,7 @@ class BookingHistoryServiceTest {
 
   @Test
   fun `Should create history for a court booking`() {
-    val courtBooking = courtBooking(CREATED_BY.username)
+    val courtBooking = courtBooking(EXTERNAL_USER.username)
       .addAppointment(
         prisonCode = MOORLAND,
         prisonerNumber = "A1234AA",
@@ -61,7 +62,7 @@ class BookingHistoryServiceTest {
       hearingType isEqualTo courtBooking.hearingType
       comments isEqualTo "Court hearing comments"
       videoUrl isEqualTo courtBooking.videoUrl
-      createdBy isEqualTo CREATED_BY.username
+      createdBy isEqualTo EXTERNAL_USER.username
       createdTime isCloseTo LocalDateTime.now()
       appointments() hasSize 1
       with(appointments().first()) {
@@ -114,7 +115,7 @@ class BookingHistoryServiceTest {
 
   @Test
   fun `Should create history for a court booking amendment`() {
-    val courtBooking = courtBooking(CREATED_BY.username)
+    val courtBooking = courtBooking(EXTERNAL_USER.username)
       .addAppointment(
         prisonCode = MOORLAND,
         prisonerNumber = "A1234AA",
@@ -160,7 +161,7 @@ class BookingHistoryServiceTest {
 
   @Test
   fun `Should cater for multiple prisoners at different prisons on the same booking`() {
-    val courtBooking = courtBooking(CREATED_BY.username)
+    val courtBooking = courtBooking(EXTERNAL_USER.username)
       .addAppointment(
         prisonCode = MOORLAND,
         prisonerNumber = "A1111AA",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingServiceTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -17,7 +18,9 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toMinutePrecis
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.EXTERNAL_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBookingRequest
@@ -30,7 +33,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonerSearch
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.user
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Appointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.CourtRepository
@@ -40,8 +42,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationT
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
 import java.time.LocalDateTime
 import java.time.LocalTime
-
-val CREATED_BY = user("TEST USER")
 
 class CreateVideoBookingServiceTest {
   private val courtRepository: CourtRepository = mock()
@@ -109,7 +109,7 @@ class CreateVideoBookingServiceTest {
     whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, prisonCode)) doReturn prisonerSearchPrisoner(prisonerNumber, prisonCode)
 
-    val (booking, prisoner) = service.create(courtBookingRequest, CREATED_BY)
+    val (booking, prisoner) = service.create(courtBookingRequest, EXTERNAL_USER)
 
     booking isEqualTo persistedVideoBooking
     prisoner isEqualTo prisoner(prisonerNumber, prisonCode)
@@ -123,7 +123,7 @@ class CreateVideoBookingServiceTest {
       hearingType isEqualTo courtBookingRequest.courtHearingType?.name
       comments isEqualTo "court booking comments"
       videoUrl isEqualTo courtBookingRequest.videoLinkUrl
-      createdBy isEqualTo CREATED_BY.username
+      createdBy isEqualTo EXTERNAL_USER.username
       createdTime isCloseTo LocalDateTime.now()
 
       appointments() hasSize 3
@@ -207,7 +207,7 @@ class CreateVideoBookingServiceTest {
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 
-    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, CREATED_BY) }
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Court bookings can only have one pre-conference, one hearing and one post-conference."
   }
@@ -243,7 +243,7 @@ class CreateVideoBookingServiceTest {
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 
-    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, CREATED_BY) }
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Requested court booking appointments must not overlap."
   }
@@ -279,7 +279,7 @@ class CreateVideoBookingServiceTest {
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 
-    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, CREATED_BY) }
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Requested court booking appointments must not overlap."
   }
@@ -315,7 +315,7 @@ class CreateVideoBookingServiceTest {
     whenever(prisonRepository.findByCode(MOORLAND)) doReturn prison(MOORLAND)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, MOORLAND)) doReturn prisonerSearchPrisoner(prisonerNumber, MOORLAND)
 
-    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, CREATED_BY) }
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Court bookings can only have one pre-conference, one hearing and one post-conference."
   }
@@ -358,7 +358,7 @@ class CreateVideoBookingServiceTest {
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 
-    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, CREATED_BY) }
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Court bookings can only have one pre-conference, one hearing and one post-conference."
   }
@@ -401,7 +401,7 @@ class CreateVideoBookingServiceTest {
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 
-    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, CREATED_BY) }
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Court bookings can only have one pre-conference, one hearing and one post-conference."
   }
@@ -444,13 +444,13 @@ class CreateVideoBookingServiceTest {
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 
-    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, CREATED_BY) }
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Court bookings can only have one pre-conference, one hearing and one post-conference."
   }
 
   @Test
-  fun `should fail to create a court video booking when new appointment overlaps existing`() {
+  fun `should fail to create a court video booking when new appointment overlaps existing for external user`() {
     val prisonCode = BIRMINGHAM
     val prisonerNumber = "123456"
     val courtBookingRequest = courtBookingRequest(
@@ -480,9 +480,45 @@ class CreateVideoBookingServiceTest {
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 
-    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, CREATED_BY) }
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "One or more requested court appointments overlaps with an existing appointment at location $prisonCode-A-1-001"
+  }
+
+  @Test
+  fun `should succeed to create a court video booking when new appointment overlaps existing for prison user`() {
+    val prisonCode = BIRMINGHAM
+    val prisonerNumber = "123456"
+    val courtBookingRequest = courtBookingRequest(
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      appointments = listOf(
+        Appointment(
+          type = AppointmentType.VLB_COURT_MAIN,
+          locationKey = "$prisonCode-A-1-001",
+          date = tomorrow(),
+          startTime = LocalTime.of(9, 30),
+          endTime = LocalTime.of(10, 0),
+        ),
+      ),
+    )
+
+    val overlappingAppointment: PrisonAppointment = mock {
+      on { startTime } doReturn LocalTime.of(9, 0)
+      on { endTime } doReturn LocalTime.of(10, 0)
+    }
+
+    val requestedCourt = court(courtBookingRequest.courtCode!!)
+
+    whenever(courtRepository.findByCode(courtBookingRequest.courtCode!!)) doReturn requestedCourt
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+    whenever(prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(BIRMINGHAM, "$BIRMINGHAM-A-1-001", tomorrow())) doReturn listOf(overlappingAppointment)
+    whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
+    whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
+
+    assertDoesNotThrow {
+      service.create(courtBookingRequest, PRISON_USER)
+    }
   }
 
   @Test
@@ -492,7 +528,7 @@ class CreateVideoBookingServiceTest {
 
     whenever(courtRepository.findByCode(courtBookingRequest.courtCode!!)) doReturn disabledCourt
 
-    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, CREATED_BY) }
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Court with code ${courtBookingRequest.courtCode} is not enabled"
 
@@ -506,7 +542,7 @@ class CreateVideoBookingServiceTest {
     whenever(courtRepository.findByCode(courtBookingRequest.courtCode!!)) doReturn court(courtBookingRequest.courtCode!!)
     whenever(prisonRepository.findByCode(MOORLAND)) doReturn null
 
-    val error = assertThrows<EntityNotFoundException> { service.create(courtBookingRequest, CREATED_BY) }
+    val error = assertThrows<EntityNotFoundException> { service.create(courtBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Prison with code $MOORLAND not found"
 
@@ -519,7 +555,7 @@ class CreateVideoBookingServiceTest {
 
     whenever(courtRepository.findByCode(courtBookingRequest.courtCode!!)) doReturn null
 
-    val error = assertThrows<EntityNotFoundException> { service.create(courtBookingRequest, CREATED_BY) }
+    val error = assertThrows<EntityNotFoundException> { service.create(courtBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Court with code ${courtBookingRequest.courtCode} not found"
 
@@ -538,7 +574,7 @@ class CreateVideoBookingServiceTest {
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, prisonCode)) doReturn prisonerSearchPrisoner(prisonerNumber, prisonCode)
 
-    val (booking, prisoner) = service.create(probationBookingRequest, CREATED_BY)
+    val (booking, prisoner) = service.create(probationBookingRequest, EXTERNAL_USER)
 
     booking isEqualTo persistedVideoBooking
     prisoner isEqualTo prisoner(prisonerNumber, prisonCode)
@@ -552,7 +588,7 @@ class CreateVideoBookingServiceTest {
       probationMeetingType isEqualTo probationBookingRequest.probationMeetingType?.name
       comments isEqualTo "probation booking comments"
       videoUrl isEqualTo probationBookingRequest.videoLinkUrl
-      createdBy isEqualTo CREATED_BY.username
+      createdBy isEqualTo EXTERNAL_USER.username
       createdTime isCloseTo LocalDateTime.now()
 
       appointments() hasSize 1
@@ -576,7 +612,7 @@ class CreateVideoBookingServiceTest {
   }
 
   @Test
-  fun `should fail to create a probation video booking when new appointment overlaps existing`() {
+  fun `should fail to create a probation video booking when new appointment overlaps existing for external user`() {
     val prisonCode = BIRMINGHAM
     val prisonerNumber = "123456"
     val probationBookingRequest = probationBookingRequest(
@@ -599,9 +635,38 @@ class CreateVideoBookingServiceTest {
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 
-    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest, CREATED_BY) }
+    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Requested probation appointment overlaps with an existing appointment at location $BIRMINGHAM-B-2-001"
+  }
+
+  @Test
+  fun `should succeed to create a probation video booking when new appointment overlaps existing for prison user`() {
+    val prisonCode = BIRMINGHAM
+    val prisonerNumber = "123456"
+    val probationBookingRequest = probationBookingRequest(
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      startTime = LocalTime.of(8, 30),
+      endTime = LocalTime.of(9, 30),
+      locationSuffix = "B-2-001",
+    )
+    val requestedProbationTeam = probationTeam(probationBookingRequest.probationTeamCode!!)
+
+    val overlappingAppointment: PrisonAppointment = mock {
+      on { startTime } doReturn LocalTime.of(9, 0)
+      on { endTime } doReturn LocalTime.of(10, 0)
+    }
+
+    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn requestedProbationTeam
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+    whenever(prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(BIRMINGHAM, "$BIRMINGHAM-B-2-001", tomorrow())) doReturn listOf(overlappingAppointment)
+    whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
+    whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
+
+    assertDoesNotThrow {
+      service.create(probationBookingRequest, PRISON_USER)
+    }
   }
 
   @Test
@@ -610,7 +675,7 @@ class CreateVideoBookingServiceTest {
 
     whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn null
 
-    val error = assertThrows<EntityNotFoundException> { service.create(probationBookingRequest, CREATED_BY) }
+    val error = assertThrows<EntityNotFoundException> { service.create(probationBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Probation team with code ${probationBookingRequest.probationTeamCode} not found"
 
@@ -624,7 +689,7 @@ class CreateVideoBookingServiceTest {
     whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn probationTeam()
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn null
 
-    val error = assertThrows<EntityNotFoundException> { service.create(probationBookingRequest, CREATED_BY) }
+    val error = assertThrows<EntityNotFoundException> { service.create(probationBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Prison with code $BIRMINGHAM not found"
 
@@ -638,7 +703,7 @@ class CreateVideoBookingServiceTest {
 
     whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn disabledProbationTeam
 
-    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest, CREATED_BY) }
+    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Probation team with code ${probationBookingRequest.probationTeamCode} is not enabled"
 
@@ -657,7 +722,7 @@ class CreateVideoBookingServiceTest {
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 
-    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest, CREATED_BY) }
+    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest, EXTERNAL_USER) }
 
     error.message isEqualTo "Appointment type VLB_COURT_MAIN is not valid for probation appointments"
   }


### PR DESCRIPTION
These changes relax the rules regarding booking prison appointment creation/amending by prison users to align with Activities and Appointments which allows overlapping appointments.

Note external users cannot do this so any attempt to create overlapping will still be rejected.