### PR TITLE
BAVL-283 prison users cannot create probation meetings and cannot change the court on an existing booking.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/PrecondionChecks.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/PrecondionChecks.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common
+
+fun requireNot(value: Boolean, lazyMessage: () -> Any) = require(!value, lazyMessage)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/Court.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/Court.kt
@@ -39,7 +39,7 @@ class Court(
 
     other as Court
 
-    return courtId == other.courtId
+    return courtId == other.courtId && code == other.code
   }
 
   override fun hashCode(): Int {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AmendVideoBookingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AmendVideoBookingRequest.kt
@@ -20,7 +20,7 @@ data class AmendVideoBookingRequest(
   @Schema(description = "The prisoner or prisoners associated with the video link booking")
   val prisoners: List<PrisonerDetails>,
 
-  @Schema(description = "The court code is needed if booking type is COURT, otherwise null", example = "DRBYMC")
+  @Schema(description = "The court code is needed if booking type is COURT, otherwise null. This cannot be changed by prison users.", example = "DRBYMC")
   val courtCode: String? = null,
 
   @Schema(description = "The court hearing type is needed if booking type is COURT, otherwise null", example = "APPEAL")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingController.kt
@@ -41,7 +41,10 @@ class VideoLinkBookingController(
   val videoLinkBookingsService: VideoLinkBookingsService,
 ) {
 
-  @Operation(summary = "Endpoint to support the creation of video link bookings")
+  @Operation(
+    summary = "Endpoint to support the creation of video link bookings",
+    description = "Only external users can create probation meetings, prison users cannot create them.",
+  )
   @ApiResponses(
     value = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingService.kt
@@ -53,6 +53,10 @@ class AmendVideoBookingService(
       ?.also { require(it.enabled) { "Court with code ${it.code} is not enabled" } }
       ?: throw EntityNotFoundException("Court with code ${request.courtCode} not found")
 
+    if (amendedBy.isUserType(UserType.PRISON) && booking.court != court) {
+      throw IllegalArgumentException("Prison users cannot change the court on a booking.")
+    }
+
     val prisoner = request.prisoner().validate()
 
     return booking.apply {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
@@ -60,6 +60,10 @@ class CreateVideoBookingService(
   }
 
   private fun createProbation(request: CreateVideoBookingRequest, createdBy: User): Pair<VideoBooking, Prisoner> {
+    require(!createdBy.isUserType(UserType.PRISON)) {
+      "Prison users cannot create probation meetings."
+    }
+
     val probationTeam = probationTeamRepository.findByCode(request.probationTeamCode!!)
       ?.also { require(it.enabled) { "Probation team with code ${it.code} is not enabled" } }
       ?: throw EntityNotFoundException("Probation team with code ${request.probationTeamCode} not found")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -40,8 +40,8 @@ fun probationTeam(code: String = "BLKPPP", enabled: Boolean = true) = ProbationT
   createdBy = "Test",
 )
 
-fun courtBooking(createdBy: String = "court_user", createdByPrison: Boolean = false) = VideoBooking.newCourtBooking(
-  court = court(),
+fun courtBooking(createdBy: String = "court_user", createdByPrison: Boolean = false, court: Court = court()) = VideoBooking.newCourtBooking(
+  court = court,
   hearingType = "TRIBUNAL",
   comments = "Court hearing comments",
   videoUrl = "https://court.hearing.link",


### PR DESCRIPTION
Changes to prevent prison users from creating probation meetings and changing the court on an existing booking.