### PR TITLE
BAVL-284 send probation creation email to user when probation booking is made

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationsInsidePrisonClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationsInsidePrisonClient.kt
@@ -53,11 +53,15 @@ class LocationsInsidePrisonClient(private val locationsInsidePrisonApiWebClient:
 class LocationValidator(private val locationsInsidePrisonClient: LocationsInsidePrisonClient) {
 
   fun validatePrisonLocation(prisonCode: String, locationKey: String) {
-    validatePrisonLocations(prisonCode, setOf(locationKey))
+    validate(prisonCode, setOf(locationKey), listOfNotNull(locationsInsidePrisonClient.getLocationByKey(locationKey)))
   }
 
   fun validatePrisonLocations(prisonCode: String, locationKeys: Set<String>) {
-    val maybeFoundLocations = locationsInsidePrisonClient.getLocationsByKeys(locationKeys).associateBy { it.key }
+    validate(prisonCode, locationKeys, locationsInsidePrisonClient.getLocationsByKeys(locationKeys))
+  }
+
+  private fun validate(prisonCode: String, locationKeys: Set<String>, maybeLocations: List<Location>) {
+    val maybeFoundLocations = maybeLocations.associateBy { it.key }
 
     if (maybeFoundLocations.isEmpty()) {
       validationError("The following ${if (locationKeys.size == 1) "location was" else "locations were"} not found $locationKeys")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationsInsidePrisonClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationsInsidePrisonClient.kt
@@ -17,6 +17,13 @@ inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>(
 @Component
 class LocationsInsidePrisonClient(private val locationsInsidePrisonApiWebClient: WebClient) {
 
+  fun getLocationByKey(key: String): Location? = locationsInsidePrisonApiWebClient.get()
+    .uri("/locations/key/{key}", key)
+    .retrieve()
+    .bodyToMono(Location::class.java)
+    .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
+    .block()
+
   fun getLocationsByKeys(keys: Set<String>): List<Location> = locationsInsidePrisonApiWebClient.post()
     .uri("/locations/keys")
     .bodyValue(keys)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBooki
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonNoProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonProbationTeamEmail
@@ -65,6 +66,7 @@ class EmailConfiguration(
   @Value("\${notify.templates.probation.booking-request.prison-probation-team-email:}") private val probationBookingRequestPrisonProbationTeamEmail: String,
   @Value("\${notify.templates.probation.booking-request.prison-no-probation-team-email:}") private val probationBookingRequestPrisonNoProbationTeamEmail: String,
   @Value("\${notify.templates.probation.new-booking.user:}") private val newProbationBookingUser: String,
+  @Value("\${notify.templates.probation.new-booking.probation:}") private val newProbationBookingProbation: String,
 ) {
 
   companion object {
@@ -103,6 +105,7 @@ class EmailConfiguration(
     releaseCourtBookingPrisonCourtEmail = releaseCourtBookingPrisonCourtEmail,
     releaseCourtBookingPrisonNoCourtEmail = releaseCourtBookingPrisonNoCourtEmail,
     newProbationBookingUser = newProbationBookingUser,
+    newProbationBookingProbation = newProbationBookingProbation,
   )
 }
 
@@ -160,6 +163,7 @@ data class EmailTemplates(
   val releaseCourtBookingPrisonCourtEmail: String,
   val releaseCourtBookingPrisonNoCourtEmail: String,
   val newProbationBookingUser: String,
+  val newProbationBookingProbation: String,
 ) {
 
   private val emailTemplateMappings = mapOf(
@@ -186,6 +190,7 @@ data class EmailTemplates(
     ReleasedCourtBookingPrisonCourtEmail::class.java to releaseCourtBookingPrisonCourtEmail,
     ReleasedCourtBookingPrisonNoCourtEmail::class.java to releaseCourtBookingPrisonNoCourtEmail,
     NewProbationBookingUserEmail::class.java to newProbationBookingUser,
+    NewProbationBookingProbationEmail::class.java to newProbationBookingProbation,
   )
 
   init {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBooki
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonNoProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestUserEmail
@@ -41,28 +42,29 @@ import java.util.UUID
 @Configuration
 class EmailConfiguration(
   @Value("\${notify.api.key:}") private val apiKey: String,
-  @Value("\${notify.templates.new-court-booking.user:}") private val newCourtBookingUser: String,
-  @Value("\${notify.templates.new-court-booking.court:}") private val newCourtBookingCourt: String,
-  @Value("\${notify.templates.new-court-booking.prison-court-email:}") private val newCourtBookingPrisonCourtEmail: String,
-  @Value("\${notify.templates.new-court-booking.prison-no-court-email:}") private val newCourtBookingPrisonNoCourtEmail: String,
-  @Value("\${notify.templates.amended-court-booking.user:}") private val amendedCourtBookingUser: String,
-  @Value("\${notify.templates.amended-court-booking.prison-court-email:}") private val amendedCourtBookingPrisonCourtEmail: String,
-  @Value("\${notify.templates.amended-court-booking.prison-no-court-email:}") private val amendedCourtBookingPrisonNoCourtEmail: String,
-  @Value("\${notify.templates.cancelled-court-booking.user:}") private val cancelledCourtBookingUser: String,
-  @Value("\${notify.templates.cancelled-court-booking.prison-court-email:}") private val cancelledCourtBookingPrisonCourtEmail: String,
-  @Value("\${notify.templates.cancelled-court-booking.prison-no-court-email:}") private val cancelledCourtBookingPrisonNoCourtEmail: String,
-  @Value("\${notify.templates.court-booking-request.user:}") private val courtBookingRequestUser: String,
-  @Value("\${notify.templates.court-booking-request.prison-court-email:}") private val courtBookingRequestPrisonCourtEmail: String,
-  @Value("\${notify.templates.court-booking-request.prison-no-court-email:}") private val courtBookingRequestPrisonNoCourtEmail: String,
-  @Value("\${notify.templates.probation-booking-request.user:}") private val probationBookingRequestUser: String,
-  @Value("\${notify.templates.probation-booking-request.prison-probation-team-email:}") private val probationBookingRequestPrisonProbationTeamEmail: String,
-  @Value("\${notify.templates.probation-booking-request.prison-no-probation-team-email:}") private val probationBookingRequestPrisonNoProbationTeamEmail: String,
-  @Value("\${notify.templates.transfer-court-booking.court:}") private val transferCourtBookingCourt: String,
-  @Value("\${notify.templates.transfer-court-booking.prison-court-email:}") private val transferCourtBookingPrisonCourtEmail: String,
-  @Value("\${notify.templates.transfer-court-booking.prison-no-court-email:}") private val transferCourtBookingPrisonNoCourtEmail: String,
-  @Value("\${notify.templates.release-court-booking.court:}") private val releaseCourtBookingCourt: String,
-  @Value("\${notify.templates.release-court-booking.prison-court-email:}") private val releaseCourtBookingPrisonCourtEmail: String,
-  @Value("\${notify.templates.release-court-booking.prison-no-court-email:}") private val releaseCourtBookingPrisonNoCourtEmail: String,
+  @Value("\${notify.templates.court.new-booking.user:}") private val newCourtBookingUser: String,
+  @Value("\${notify.templates.court.new-booking.court:}") private val newCourtBookingCourt: String,
+  @Value("\${notify.templates.court.new-booking.prison-court-email:}") private val newCourtBookingPrisonCourtEmail: String,
+  @Value("\${notify.templates.court.new-booking.prison-no-court-email:}") private val newCourtBookingPrisonNoCourtEmail: String,
+  @Value("\${notify.templates.court.amended-booking.user:}") private val amendedCourtBookingUser: String,
+  @Value("\${notify.templates.court.amended-booking.prison-court-email:}") private val amendedCourtBookingPrisonCourtEmail: String,
+  @Value("\${notify.templates.court.amended-booking.prison-no-court-email:}") private val amendedCourtBookingPrisonNoCourtEmail: String,
+  @Value("\${notify.templates.court.cancelled-booking.user:}") private val cancelledCourtBookingUser: String,
+  @Value("\${notify.templates.court.cancelled-booking.prison-court-email:}") private val cancelledCourtBookingPrisonCourtEmail: String,
+  @Value("\${notify.templates.court.cancelled-booking.prison-no-court-email:}") private val cancelledCourtBookingPrisonNoCourtEmail: String,
+  @Value("\${notify.templates.court.booking-request.user:}") private val courtBookingRequestUser: String,
+  @Value("\${notify.templates.court.booking-request.prison-court-email:}") private val courtBookingRequestPrisonCourtEmail: String,
+  @Value("\${notify.templates.court.booking-request.prison-no-court-email:}") private val courtBookingRequestPrisonNoCourtEmail: String,
+  @Value("\${notify.templates.court.transfer-booking.court:}") private val transferCourtBookingCourt: String,
+  @Value("\${notify.templates.court.transfer-booking.prison-court-email:}") private val transferCourtBookingPrisonCourtEmail: String,
+  @Value("\${notify.templates.court.transfer-booking.prison-no-court-email:}") private val transferCourtBookingPrisonNoCourtEmail: String,
+  @Value("\${notify.templates.court.release-booking.court:}") private val releaseCourtBookingCourt: String,
+  @Value("\${notify.templates.court.release-booking.prison-court-email:}") private val releaseCourtBookingPrisonCourtEmail: String,
+  @Value("\${notify.templates.court.release-booking.prison-no-court-email:}") private val releaseCourtBookingPrisonNoCourtEmail: String,
+  @Value("\${notify.templates.probation.booking-request.user:}") private val probationBookingRequestUser: String,
+  @Value("\${notify.templates.probation.booking-request.prison-probation-team-email:}") private val probationBookingRequestPrisonProbationTeamEmail: String,
+  @Value("\${notify.templates.probation.booking-request.prison-no-probation-team-email:}") private val probationBookingRequestPrisonNoProbationTeamEmail: String,
+  @Value("\${notify.templates.probation.new-booking.user:}") private val newProbationBookingUser: String,
 ) {
 
   companion object {
@@ -100,6 +102,7 @@ class EmailConfiguration(
     releaseCourtBookingCourt = releaseCourtBookingCourt,
     releaseCourtBookingPrisonCourtEmail = releaseCourtBookingPrisonCourtEmail,
     releaseCourtBookingPrisonNoCourtEmail = releaseCourtBookingPrisonNoCourtEmail,
+    newProbationBookingUser = newProbationBookingUser,
   )
 }
 
@@ -156,6 +159,7 @@ data class EmailTemplates(
   val releaseCourtBookingCourt: String,
   val releaseCourtBookingPrisonCourtEmail: String,
   val releaseCourtBookingPrisonNoCourtEmail: String,
+  val newProbationBookingUser: String,
 ) {
 
   private val emailTemplateMappings = mapOf(
@@ -181,6 +185,7 @@ data class EmailTemplates(
     ReleasedCourtBookingCourtEmail::class.java to releaseCourtBookingCourt,
     ReleasedCourtBookingPrisonCourtEmail::class.java to releaseCourtBookingPrisonCourtEmail,
     ReleasedCourtBookingPrisonNoCourtEmail::class.java to releaseCourtBookingPrisonNoCourtEmail,
+    NewProbationBookingUserEmail::class.java to newProbationBookingUser,
   )
 
   init {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailService.kt
@@ -565,3 +565,24 @@ class TransferredCourtBookingPrisonNoCourtEmail(
     addPersonalisation("postAppointmentInfo", postAppointmentInfo ?: "Not required")
   }
 }
+
+class NewProbationBookingUserEmail(
+  address: String,
+  prisonerNumber: String,
+  userName: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  probationTeam: String,
+  prison: String,
+  date: LocalDate = LocalDate.now(),
+  appointmentInfo: String,
+  comments: String?,
+) : Email(address, prisonerFirstName, prisonerLastName, date, comments) {
+  init {
+    addPersonalisation("offenderNo", prisonerNumber)
+    addPersonalisation("userName", userName)
+    addPersonalisation("probationTeam", probationTeam)
+    addPersonalisation("prison", prison)
+    addPersonalisation("appointmentInfo", appointmentInfo)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailService.kt
@@ -586,3 +586,22 @@ class NewProbationBookingUserEmail(
     addPersonalisation("appointmentInfo", appointmentInfo)
   }
 }
+
+class NewProbationBookingProbationEmail(
+  address: String,
+  prison: String,
+  prisonerNumber: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  probationTeam: String,
+  appointmentDate: LocalDate,
+  appointmentInfo: String,
+  comments: String?,
+) : Email(address, prisonerFirstName, prisonerLastName, appointmentDate, comments) {
+  init {
+    addPersonalisation("offenderNo", prisonerNumber)
+    addPersonalisation("probationTeam", probationTeam)
+    addPersonalisation("prison", prison)
+    addPersonalisation("appointmentInfo", appointmentInfo)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/CourtEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/CourtEmailFactory.kt
@@ -43,7 +43,7 @@ object CourtEmailFactory {
     booking.requireIsCourtBooking()
 
     require(contact.contactType == ContactType.USER) {
-      "Incorrect contact type ${contact.contactType} for user email"
+      "Incorrect contact type ${contact.contactType} for court user email"
     }
 
     return when (action) {
@@ -107,7 +107,7 @@ object CourtEmailFactory {
     booking.requireIsCourtBooking()
 
     require(contact.contactType == ContactType.COURT) {
-      "Incorrect contact type ${contact.contactType} for court email"
+      "Incorrect contact type ${contact.contactType} for court court email"
     }
 
     return when (action) {
@@ -176,7 +176,7 @@ object CourtEmailFactory {
     booking.requireIsCourtBooking()
 
     require(contact.contactType == ContactType.PRISON) {
-      "Incorrect contact type ${contact.contactType} for prison email"
+      "Incorrect contact type ${contact.contactType} for court prison email"
     }
 
     val primaryCourtContact = contacts.primaryCourtContact()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/ProbationEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/ProbationEmailFactory.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails
+
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.requireNot
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toHourMinuteStyle
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Email
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingContact
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ContactType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingAction
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingUserEmail
+
+object ProbationEmailFactory {
+  fun user(
+    contact: BookingContact,
+    prisoner: Prisoner,
+    booking: VideoBooking,
+    prison: Prison,
+    appointment: PrisonAppointment,
+    location: Location,
+    action: BookingAction,
+  ): Email? {
+    booking.requireIsProbationBooking()
+
+    require(contact.contactType == ContactType.USER) {
+      "Incorrect contact type ${contact.contactType} for probation user email"
+    }
+
+    return when (action) {
+      BookingAction.CREATE -> NewProbationBookingUserEmail(
+        address = contact.email!!,
+        prisonerNumber = prisoner.prisonerNumber,
+        userName = contact.name ?: "Book Video",
+        probationTeam = booking.probationTeam!!.description,
+        appointmentInfo = appointment.appointmentInformation(location),
+        comments = booking.comments,
+        prisonerFirstName = prisoner.firstName,
+        prisonerLastName = prisoner.lastName,
+        prison = prison.name,
+      )
+      BookingAction.AMEND -> null
+      BookingAction.CANCEL -> null
+      else -> null
+    }
+  }
+
+  private fun VideoBooking.requireIsProbationBooking() {
+    requireNot(isCourtBooking()) { "Booking ID $videoBookingId is not a probation booking" }
+  }
+
+  private fun PrisonAppointment.appointmentInformation(location: Location) =
+    "${location.localName} - ${startTime.toHourMinuteStyle()} to ${endTime.toHourMinuteStyle()}"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/ProbationEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/ProbationEmailFactory.kt
@@ -35,6 +35,7 @@ object ProbationEmailFactory {
         prisonerNumber = prisoner.prisonerNumber,
         userName = contact.name ?: "Book Video",
         probationTeam = booking.probationTeam!!.description,
+        date = appointment.appointmentDate,
         appointmentInfo = appointment.appointmentInformation(location),
         comments = booking.comments,
         prisonerFirstName = prisoner.firstName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/ProbationEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/ProbationEmailFactory.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointm
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingAction
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingUserEmail
 
 object ProbationEmailFactory {
@@ -44,6 +45,37 @@ object ProbationEmailFactory {
       )
       BookingAction.AMEND -> null
       BookingAction.CANCEL -> null
+      else -> null
+    }
+  }
+
+  fun probation(
+    contact: BookingContact,
+    prisoner: Prisoner,
+    booking: VideoBooking,
+    prison: Prison,
+    appointment: PrisonAppointment,
+    location: Location,
+    action: BookingAction,
+  ): Email? {
+    booking.requireIsProbationBooking()
+
+    require(contact.contactType == ContactType.PROBATION) {
+      "Incorrect contact type ${contact.contactType} for probation probation email"
+    }
+
+    return when (action) {
+      BookingAction.CREATE -> NewProbationBookingProbationEmail(
+        address = contact.email!!,
+        prisonerNumber = prisoner.prisonerNumber,
+        probationTeam = booking.probationTeam!!.description,
+        appointmentDate = appointment.appointmentDate,
+        appointmentInfo = appointment.appointmentInformation(location),
+        comments = booking.comments,
+        prisonerFirstName = prisoner.firstName,
+        prisonerLastName = prisoner.lastName,
+        prison = prison.name,
+      )
       else -> null
     }
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -111,35 +111,39 @@ management:
 
 notify:
   templates:
-    new-court-booking:
-      user: "c8d61c0f-1fa0-4281-9597-a45780e345d4"
-      court: "f1713d8d-b622-4b07-8182-27275bfbb24d"
-      prison-court-email: "bf2c340e-31a4-45db-bc70-e902ee499ec5"
-      prison-no-court-email: "d555929e-c8a5-4771-911b-4538ba259eba"
-    amended-court-booking:
-      user: "443760a3-e644-4228-8c60-ecb76fb39664"
-      prison-court-email: "9edef9a6-df69-462a-995c-010c2b4f2cbf"
-      prison-no-court-email: "d756d798-bf1b-4651-85e5-6f42c741e33b"
-    cancelled-court-booking:
-      user: "946a129a-ed09-40ca-b0ac-a39ec6c1bc2b"
-      prison-court-email: "9c80bb57-abed-4316-8404-cbdcd48b8f25"
-      prison-no-court-email: "602981eb-cc7f-4a85-aba3-577167f1ee83"
-    court-booking-request:
-      user: "cccb8914-8418-4382-9a9d-2d5defe7c1c6"
-      prison-court-email: "7c246d95-60b5-4c3c-a7b3-2c43c42b61b0"
-      prison-no-court-email: "a82f319b-1a44-4d0f-aed5-a7b28857cc42"
-    probation-booking-request:
-      user: "d401c074-6914-4910-b29c-92b328951925"
-      prison-probation-team-email: "a8f74eda-c327-4dde-88db-354843292c6c"
-      prison-no-probation-team-email: "2326fa9d-1627-4c04-8c8d-a6e1ae19a6cb"
-    transfer-court-booking:
-      court: "3fe1e9d5-3319-496c-90df-0115087cd31b"
-      prison-court-email: "6fdf202b-01f9-48e7-b216-35c695f84df3"
-      prison-no-court-email: "0498e8d9-a2ea-4e00-9e5c-96d1d3cd6cb9"
-    release-court-booking:
-      court: "55817f53-211c-442d-ac6f-f3fda3adee84"
-      prison-court-email: "e5bbd8a8-f59c-4670-9ba3-fd4cda922a21"
-      prison-no-court-email: "da59e795-aef6-4cb9-be68-54435df8c8b1"
+    court:
+      new-booking:
+        user: "c8d61c0f-1fa0-4281-9597-a45780e345d4"
+        court: "f1713d8d-b622-4b07-8182-27275bfbb24d"
+        prison-court-email: "bf2c340e-31a4-45db-bc70-e902ee499ec5"
+        prison-no-court-email: "d555929e-c8a5-4771-911b-4538ba259eba"
+      amended-booking:
+        user: "443760a3-e644-4228-8c60-ecb76fb39664"
+        prison-court-email: "9edef9a6-df69-462a-995c-010c2b4f2cbf"
+        prison-no-court-email: "d756d798-bf1b-4651-85e5-6f42c741e33b"
+      cancelled-booking:
+        user: "946a129a-ed09-40ca-b0ac-a39ec6c1bc2b"
+        prison-court-email: "9c80bb57-abed-4316-8404-cbdcd48b8f25"
+        prison-no-court-email: "602981eb-cc7f-4a85-aba3-577167f1ee83"
+      booking-request:
+        user: "cccb8914-8418-4382-9a9d-2d5defe7c1c6"
+        prison-court-email: "7c246d95-60b5-4c3c-a7b3-2c43c42b61b0"
+        prison-no-court-email: "a82f319b-1a44-4d0f-aed5-a7b28857cc42"
+      transfer-booking:
+        court: "3fe1e9d5-3319-496c-90df-0115087cd31b"
+        prison-court-email: "6fdf202b-01f9-48e7-b216-35c695f84df3"
+        prison-no-court-email: "0498e8d9-a2ea-4e00-9e5c-96d1d3cd6cb9"
+      release-booking:
+        court: "55817f53-211c-442d-ac6f-f3fda3adee84"
+        prison-court-email: "e5bbd8a8-f59c-4670-9ba3-fd4cda922a21"
+        prison-no-court-email: "da59e795-aef6-4cb9-be68-54435df8c8b1"
+    probation:
+      booking-request:
+        user: "d401c074-6914-4910-b29c-92b328951925"
+        prison-probation-team-email: "a8f74eda-c327-4dde-88db-354843292c6c"
+        prison-no-probation-team-email: "2326fa9d-1627-4c04-8c8d-a6e1ae19a6cb"
+      new-booking:
+        user: "20fddb45-3907-4e10-a570-86377bbe9dd1"
 
 
 springdoc:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -144,6 +144,7 @@ notify:
         prison-no-probation-team-email: "2326fa9d-1627-4c04-8c8d-a6e1ae19a6cb"
       new-booking:
         user: "20fddb45-3907-4e10-a570-86377bbe9dd1"
+        probation: "1a3cdd5a-411b-4365-9613-e1211a0f15b6"
 
 
 springdoc:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationValidatorTest.kt
@@ -21,7 +21,7 @@ class LocationValidatorTest {
 
   @Test
   fun `should pass validation when location found`() {
-    whenever(client.getLocationsByKeys(setOf(birminghamLocation.key))) doReturn listOf(birminghamLocation)
+    whenever(client.getLocationByKey(birminghamLocation.key)) doReturn birminghamLocation
 
     assertDoesNotThrow {
       validator.validatePrisonLocation(BIRMINGHAM, birminghamLocation.key)
@@ -30,7 +30,7 @@ class LocationValidatorTest {
 
   @Test
   fun `should fail validation when single location not found`() {
-    whenever(client.getLocationsByKeys(setOf("location_does_not_exist"))) doReturn emptyList()
+    whenever(client.getLocationByKey("location_does_not_exist")) doReturn null
 
     val error = assertThrows<ValidationException> { validator.validatePrisonLocation(BIRMINGHAM, "location_does_not_exist") }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailTemplatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailTemplatesTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBooki
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonNoProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestUserEmail
@@ -50,6 +51,7 @@ class EmailTemplatesTest {
     ReleasedCourtBookingCourtEmail::class.java to "releaseCourtBookingCourt",
     ReleasedCourtBookingPrisonCourtEmail::class.java to "releaseCourtBookingPrisonCourtEmail",
     ReleasedCourtBookingPrisonNoCourtEmail::class.java to "releaseCourtBookingPrisonNoCourtEmail",
+    NewProbationBookingUserEmail::class.java to "newProbationBookingUser",
   )
 
   private val templates = EmailTemplates(
@@ -75,6 +77,7 @@ class EmailTemplatesTest {
     releaseCourtBookingCourt = "releaseCourtBookingCourt",
     releaseCourtBookingPrisonCourtEmail = "releaseCourtBookingPrisonCourtEmail",
     releaseCourtBookingPrisonNoCourtEmail = "releaseCourtBookingPrisonNoCourtEmail",
+    newProbationBookingUser = "newProbationBookingUser",
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailTemplatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailTemplatesTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBooki
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonNoProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonProbationTeamEmail
@@ -52,6 +53,7 @@ class EmailTemplatesTest {
     ReleasedCourtBookingPrisonCourtEmail::class.java to "releaseCourtBookingPrisonCourtEmail",
     ReleasedCourtBookingPrisonNoCourtEmail::class.java to "releaseCourtBookingPrisonNoCourtEmail",
     NewProbationBookingUserEmail::class.java to "newProbationBookingUser",
+    NewProbationBookingProbationEmail::class.java to "newProbationBookingProbation",
   )
 
   private val templates = EmailTemplates(
@@ -78,6 +80,7 @@ class EmailTemplatesTest {
     releaseCourtBookingPrisonCourtEmail = "releaseCourtBookingPrisonCourtEmail",
     releaseCourtBookingPrisonNoCourtEmail = "releaseCourtBookingPrisonNoCourtEmail",
     newProbationBookingUser = "newProbationBookingUser",
+    newProbationBookingProbation = "newProbationBookingProbation",
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -24,7 +24,7 @@ import java.time.LocalTime
 import java.util.*
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prisoner as ModelPrisoner
 
-val birminghamLocation = location(prisonCode = BIRMINGHAM, locationKeySuffix = "ABCEDFG")
+val birminghamLocation = location(prisonCode = BIRMINGHAM, locationKeySuffix = "ABCEDFG", localName = "Birmingham room")
 val inactiveBirminghamLocation = location(prisonCode = BIRMINGHAM, locationKeySuffix = "HIJLKLM", active = false)
 val moorlandLocation = location(prisonCode = MOORLAND, locationKeySuffix = "ABCEDFG", localName = "Moorland room")
 val werringtonLocation = location(prisonCode = WERRINGTON, locationKeySuffix = "ABCDEFG")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/AvailabilityResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/AvailabilityResourceIntegrationTest.kt
@@ -174,7 +174,7 @@ class AvailabilityResourceIntegrationTest : IntegrationTestBase() {
     videoBookingRepository.findAll() hasSize 0
 
     prisonSearchApi().stubGetPrisoner("A1111AA", WERRINGTON)
-    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(werringtonLocation.key), WERRINGTON)
+    locationsInsidePrisonApi().stubGetLocationByKey(werringtonLocation.key, WERRINGTON)
 
     val probationBookingRequest = probationBookingRequest(
       probationTeamCode = "BLKPPP",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/BookingContactsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/BookingContactsResourceIntegrationTest.kt
@@ -65,7 +65,7 @@ class BookingContactsResourceIntegrationTest : IntegrationTestBase() {
   @Test
   fun `should return a list of prison and probation contacts for a booking`() {
     prisonSearchApi().stubGetPrisoner("A1111AA", WERRINGTON)
-    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(werringtonLocation.key), WERRINGTON)
+    locationsInsidePrisonApi().stubGetLocationByKey(werringtonLocation.key, WERRINGTON)
 
     val probationBookingRequest = probationBookingRequest(
       probationTeamCode = "BLKPPP",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ScheduleResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ScheduleResourceIntegrationTest.kt
@@ -92,6 +92,7 @@ class ScheduleResourceIntegrationTest : IntegrationTestBase() {
 
       prisonSearchApi().stubGetPrisoner("A1111AA", WERRINGTON)
       locationsInsidePrisonApi().stubPostLocationByKeys(setOf(werringtonLocation.key), WERRINGTON)
+      locationsInsidePrisonApi().stubGetLocationByKey(werringtonLocation.key, WERRINGTON)
 
       // Will default to tomorrow's date
       val courtBookingRequest = courtBookingRequest(
@@ -158,7 +159,7 @@ class ScheduleResourceIntegrationTest : IntegrationTestBase() {
       videoBookingRepository.findAll() hasSize 0
 
       prisonSearchApi().stubGetPrisoner("A1111AA", WERRINGTON)
-      locationsInsidePrisonApi().stubPostLocationByKeys(setOf(werringtonLocation.key), WERRINGTON)
+      locationsInsidePrisonApi().stubGetLocationByKey(werringtonLocation.key, WERRINGTON)
 
       // Will default to tomorrow's date
       val probationBookingRequest = probationBookingRequest(
@@ -266,7 +267,7 @@ class ScheduleResourceIntegrationTest : IntegrationTestBase() {
       videoBookingRepository.findAll() hasSize 0
 
       prisonSearchApi().stubGetPrisoner("A1111AA", WERRINGTON)
-      locationsInsidePrisonApi().stubPostLocationByKeys(setOf(werringtonLocation.key), WERRINGTON)
+      locationsInsidePrisonApi().stubGetLocationByKey(werringtonLocation.key, WERRINGTON)
 
       // Will default to tomorrow's date
       val probationBookingRequest = probationBookingRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -76,6 +76,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBooki
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonNoProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonProbationTeamEmail
@@ -90,7 +91,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.VideoB
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.VideoBookingInformation
 import java.time.LocalDate
 import java.time.LocalTime
-import java.util.*
+import java.util.UUID
 
 @ContextConfiguration(classes = [TestEmailConfiguration::class])
 // This is not ideal. Due to potential timing issues with messages/events we disable this on the CI pipeline.
@@ -1649,7 +1650,8 @@ class TestEmailConfiguration {
         is ProbationBookingRequestPrisonProbationTeamEmail -> Result.success(UUID.randomUUID() to "requested probation booking prison template id with email address")
         is ProbationBookingRequestPrisonNoProbationTeamEmail -> Result.success(UUID.randomUUID() to "requested probation booking prison template id with no email address")
         is NewProbationBookingUserEmail -> Result.success(UUID.randomUUID() to "new probation booking user template id")
-        else -> throw RuntimeException("Unsupported email")
+        is NewProbationBookingProbationEmail -> Result.success(UUID.randomUUID() to "new probation booking probation template id")
+        else -> throw RuntimeException("Unsupported email in test email configuration: ${email.javaClass.simpleName}")
       }
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -76,6 +76,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBooki
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonNoProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestUserEmail
@@ -486,7 +487,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     videoBookingRepository.findAll() hasSize 0
 
     prisonSearchApi().stubGetPrisoner("123456", BIRMINGHAM)
-    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(birminghamLocation.key), BIRMINGHAM)
+    locationsInsidePrisonApi().stubGetLocationByKey(birminghamLocation.key, BIRMINGHAM)
 
     val probationBookingRequest = probationBookingRequest(
       probationTeamCode = BLACKPOOL_MC_PPOC,
@@ -543,7 +544,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     videoBookingRepository.findAll() hasSize 0
 
     prisonSearchApi().stubGetPrisoner("123456", BIRMINGHAM)
-    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(birminghamLocation.key), BIRMINGHAM)
+    locationsInsidePrisonApi().stubGetLocationByKey(birminghamLocation.key, BIRMINGHAM)
 
     val probationBookingRequest = probationBookingRequest(
       probationTeamCode = BLACKPOOL_MC_PPOC,
@@ -585,7 +586,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
   @Test
   fun `should fail to create a clashing probation booking`() {
     prisonSearchApi().stubGetPrisoner("123456", MOORLAND)
-    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(moorlandLocation.key), MOORLAND)
+    locationsInsidePrisonApi().stubGetLocationByKey(moorlandLocation.key, MOORLAND)
 
     val probationBookingRequest = probationBookingRequest(
       probationTeamCode = BLACKPOOL_MC_PPOC,
@@ -740,7 +741,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     videoBookingRepository.findAll() hasSize 0
 
     prisonSearchApi().stubGetPrisoner("123456", MOORLAND)
-    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(moorlandLocation.key), MOORLAND)
+    locationsInsidePrisonApi().stubGetLocationByKey(moorlandLocation.key, MOORLAND)
 
     val probationBookingRequest = probationBookingRequest(
       probationTeamCode = BLACKPOOL_MC_PPOC,
@@ -1054,7 +1055,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     videoBookingRepository.findAll() hasSize 0
 
     prisonSearchApi().stubGetPrisoner("123456", BIRMINGHAM)
-    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(birminghamLocation.key), BIRMINGHAM)
+    locationsInsidePrisonApi().stubGetLocationByKey(birminghamLocation.key, BIRMINGHAM)
 
     val probationBookingRequest = probationBookingRequest(
       probationTeamCode = BLACKPOOL_MC_PPOC,
@@ -1118,7 +1119,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     videoBookingRepository.findAll() hasSize 0
 
     prisonSearchApi().stubGetPrisoner("123456", BIRMINGHAM)
-    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(birminghamLocation.key), BIRMINGHAM)
+    locationsInsidePrisonApi().stubGetLocationByKey(birminghamLocation.key, BIRMINGHAM)
 
     val probationBookingRequest1 = probationBookingRequest(
       probationTeamCode = BLACKPOOL_MC_PPOC,
@@ -1184,7 +1185,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     videoBookingRepository.findAll() hasSize 0
 
     prisonSearchApi().stubGetPrisoner("123456", BIRMINGHAM)
-    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(birminghamLocation.key), BIRMINGHAM)
+    locationsInsidePrisonApi().stubGetLocationByKey(birminghamLocation.key, BIRMINGHAM)
 
     val probationBookingRequest = probationBookingRequest(
       probationTeamCode = BLACKPOOL_MC_PPOC,
@@ -1202,7 +1203,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     val videoBookingId = webTestClient.createBooking(probationBookingRequest)
 
     prisonSearchApi().stubGetPrisoner("123456", MOORLAND)
-    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(birminghamLocation.key), BIRMINGHAM)
+    locationsInsidePrisonApi().stubGetLocationByKey(birminghamLocation.key, BIRMINGHAM)
 
     val amendBookingRequest = amendProbationBookingRequest(
       probationTeamCode = BLACKPOOL_MC_PPOC,
@@ -1388,7 +1389,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
   fun `should request a Blackpool probation team booking and emails sent to Norwich prison`() {
     notificationRepository.findAll() hasSize 0
 
-    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(norwichLocation.key), NORWICH)
+    locationsInsidePrisonApi().stubGetLocationByKey(norwichLocation.key, NORWICH)
 
     val probationRequest = requestProbationVideoLinkRequest(
       probationTeamCode = BLACKPOOL_MC_PPOC,
@@ -1415,7 +1416,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
   fun `should request a Harrow probation booking and emails sent to Birmingham prison`() {
     notificationRepository.findAll() hasSize 0
 
-    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(birminghamLocation.key), BIRMINGHAM)
+    locationsInsidePrisonApi().stubGetLocationByKey(birminghamLocation.key, BIRMINGHAM)
 
     val probationRequest = requestProbationVideoLinkRequest(
       probationTeamCode = HARROW,
@@ -1443,7 +1444,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     videoBookingRepository.findAll() hasSize 0
 
     prisonSearchApi().stubGetPrisoner("123456", BIRMINGHAM)
-    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(birminghamLocation.key), BIRMINGHAM)
+    locationsInsidePrisonApi().stubGetLocationByKey(birminghamLocation.key, BIRMINGHAM)
 
     val probationBookingRequest = probationBookingRequest(
       probationTeamCode = BLACKPOOL_MC_PPOC,
@@ -1647,6 +1648,7 @@ class TestEmailConfiguration {
         is ProbationBookingRequestUserEmail -> Result.success(UUID.randomUUID() to "requested probation booking user template id")
         is ProbationBookingRequestPrisonProbationTeamEmail -> Result.success(UUID.randomUUID() to "requested probation booking prison template id with email address")
         is ProbationBookingRequestPrisonNoProbationTeamEmail -> Result.success(UUID.randomUUID() to "requested probation booking prison template id with no email address")
+        is NewProbationBookingUserEmail -> Result.success(UUID.randomUUID() to "new probation booking user template id")
         else -> throw RuntimeException("Unsupported email")
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/LocationsInsidePrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/LocationsInsidePrisonApiMockServer.kt
@@ -16,6 +16,40 @@ import java.util.UUID
 
 class LocationsInsidePrisonApiMockServer : MockServer(8091) {
 
+  fun stubGetLocationByKey(key: String, prisonId: String = "MDI") {
+    val id = UUID.randomUUID()
+
+    stubFor(
+      get("/locations/key/$key").willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody(
+            mapper.writeValueAsString(
+              Location(
+                id = id,
+                prisonId = prisonId,
+                code = "001",
+                pathHierarchy = "A-1-001",
+                locationType = Location.LocationType.VIDEO_LINK,
+                permanentlyInactive = false,
+                active = true,
+                deactivatedByParent = false,
+                topLevelId = id,
+                key = key,
+                isResidential = true,
+                lastModifiedBy = "test user",
+                lastModifiedDate = LocalDateTime.now().toIsoDateTime(),
+                level = 2,
+                leafLevel = true,
+                status = Location.Status.ACTIVE,
+              ),
+            ),
+          )
+          .withStatus(200),
+      ),
+    )
+  }
+
   fun stubPostLocationByKeys(keys: Set<String>, prisonCode: String = MOORLAND) {
     stubFor(
       post("/locations/keys")
@@ -52,7 +86,12 @@ class LocationsInsidePrisonApiMockServer : MockServer(8091) {
     )
   }
 
-  fun stubNonResidentialAppointmentLocationsAtPrison(keys: Set<String>, enabled: Boolean = true, prisonCode: String = MOORLAND, leafLevel: Boolean = true) {
+  fun stubNonResidentialAppointmentLocationsAtPrison(
+    keys: Set<String>,
+    enabled: Boolean = true,
+    prisonCode: String = MOORLAND,
+    leafLevel: Boolean = true,
+  ) {
     stubFor(
       get("/locations/prison/$prisonCode/non-residential-usage-type/APPOINTMENT")
         .willReturn(
@@ -88,7 +127,12 @@ class LocationsInsidePrisonApiMockServer : MockServer(8091) {
     )
   }
 
-  fun stubVideoLinkLocationsAtPrison(keys: Set<String>, enabled: Boolean = true, prisonCode: String = MOORLAND, leafLevel: Boolean = true) {
+  fun stubVideoLinkLocationsAtPrison(
+    keys: Set<String>,
+    enabled: Boolean = true,
+    prisonCode: String = MOORLAND,
+    leafLevel: Boolean = true,
+  ) {
     stubFor(
       get("/locations/prison/$prisonCode/location-type/VIDEO_LINK")
         .willReturn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
@@ -8,7 +8,6 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationsInsidePrisonClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.Prisoner
@@ -23,6 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.amendCourtBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.amendProbationBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.bookingContact
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntriesExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
@@ -35,8 +35,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.user
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.yesterday
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.NotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
@@ -94,10 +96,25 @@ class BookingFacadeTest {
       locationKey = moorlandLocation.key,
     )
 
+  private val probationBookingAtBirminghamPrison = probationBooking()
+    .addAppointment(
+      prisonCode = BIRMINGHAM,
+      prisonerNumber = "654321",
+      appointmentType = AppointmentType.VLB_PROBATION.name,
+      locationKey = birminghamLocation.key,
+      date = tomorrow(),
+      startTime = LocalTime.MIDNIGHT,
+      endTime = LocalTime.MIDNIGHT.plusHours(1),
+    )
+
+  private val emailNotificationId = UUID.randomUUID()
+
   @BeforeEach
   fun before() {
     whenever(prisonRepository.findByCode(MOORLAND)) doReturn prison(MOORLAND)
+    whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
     whenever(locationsInsidePrisonClient.getLocationsByKeys(setOf(moorlandLocation.key))) doReturn listOf(moorlandLocation)
+    whenever(locationsInsidePrisonClient.getLocationByKey(birminghamLocation.key)) doReturn birminghamLocation
     whenever(contactsService.getPrimaryBookingContacts(any(), any())) doReturn listOf(
       bookingContact(contactType = ContactType.USER, email = "jon@somewhere.com", name = "Jon"),
       bookingContact(contactType = ContactType.COURT, email = "jon@court.com", name = "Jon"),
@@ -113,16 +130,14 @@ class BookingFacadeTest {
     whenever(cancelVideoBookingService.cancel(1, user("facade court user"))) doReturn courtBooking
     whenever(prisonerSearchClient.getPrisoner(courtBooking.prisoner())) doReturn prisoner
 
-    val notificationId = UUID.randomUUID()
-
-    whenever(emailService.send(any<CancelledCourtBookingUserEmail>())) doReturn Result.success(notificationId to "user template id")
-    whenever(emailService.send(any<CancelledCourtBookingPrisonCourtEmail>())) doReturn Result.success(notificationId to "prison template id")
+    whenever(emailService.send(any<CancelledCourtBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
+    whenever(emailService.send(any<CancelledCourtBookingPrisonCourtEmail>())) doReturn Result.success(emailNotificationId to "prison template id")
 
     facade.cancel(1, user("facade court user"))
 
     inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
       verify(cancelVideoBookingService).cancel(1, user("facade court user"))
-      verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, courtBooking.videoBookingId)
+      verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
       verify(emailService).send(emailCaptor.capture())
       verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
       verify(emailService).send(emailCaptor.capture())
@@ -167,14 +182,16 @@ class BookingFacadeTest {
     with(notificationCaptor.firstValue) {
       email isEqualTo "jon@somewhere.com"
       templateName isEqualTo "user template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBooking
+      reason isEqualTo "Cancelled court booking"
     }
     with(notificationCaptor.secondValue) {
       email isEqualTo "jon@prison.com"
       templateName isEqualTo "prison template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBooking
+      reason isEqualTo "Cancelled court booking"
     }
   }
 
@@ -183,11 +200,8 @@ class BookingFacadeTest {
     val bookingRequest = courtBookingRequest(prisonCode = MOORLAND, prisonerNumber = courtBooking.prisoner())
 
     whenever(createBookingService.create(bookingRequest, user("facade court user"))) doReturn Pair(courtBooking, prisoner(prisonerNumber = courtBooking.prisoner(), prisonCode = MOORLAND))
-
-    val notificationId = UUID.randomUUID()
-
-    whenever(emailService.send(any<NewCourtBookingUserEmail>())) doReturn Result.success(notificationId to "user template id")
-    whenever(emailService.send(any<NewCourtBookingPrisonCourtEmail>())) doReturn Result.success(notificationId to "prison template id")
+    whenever(emailService.send(any<NewCourtBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
+    whenever(emailService.send(any<NewCourtBookingPrisonCourtEmail>())) doReturn Result.success(emailNotificationId to "prison template id")
 
     facade.create(bookingRequest, user("facade court user"))
 
@@ -238,14 +252,16 @@ class BookingFacadeTest {
     with(notificationCaptor.firstValue) {
       email isEqualTo "jon@somewhere.com"
       templateName isEqualTo "user template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBooking
+      reason isEqualTo "New court booking"
     }
     with(notificationCaptor.secondValue) {
       email isEqualTo "jon@prison.com"
       templateName isEqualTo "prison template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBooking
+      reason isEqualTo "New court booking"
     }
   }
 
@@ -255,12 +271,9 @@ class BookingFacadeTest {
     val bookingRequest = courtBookingRequest(prisonCode = MOORLAND, prisonerNumber = courtBookingCreatedByPrison.prisoner())
 
     whenever(createBookingService.create(bookingRequest, user)) doReturn Pair(courtBookingCreatedByPrison, prisoner(prisonerNumber = courtBookingCreatedByPrison.prisoner(), prisonCode = MOORLAND))
-
-    val notificationId = UUID.randomUUID()
-
-    whenever(emailService.send(any<NewCourtBookingUserEmail>())) doReturn Result.success(notificationId to "user template id")
-    whenever(emailService.send(any<NewCourtBookingCourtEmail>())) doReturn Result.success(notificationId to "court template id")
-    whenever(emailService.send(any<NewCourtBookingPrisonCourtEmail>())) doReturn Result.success(notificationId to "prison template id")
+    whenever(emailService.send(any<NewCourtBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
+    whenever(emailService.send(any<NewCourtBookingCourtEmail>())) doReturn Result.success(emailNotificationId to "court template id")
+    whenever(emailService.send(any<NewCourtBookingPrisonCourtEmail>())) doReturn Result.success(emailNotificationId to "prison template id")
 
     facade.create(bookingRequest, user)
 
@@ -328,20 +341,23 @@ class BookingFacadeTest {
     with(notificationCaptor.firstValue) {
       email isEqualTo "jon@somewhere.com"
       templateName isEqualTo "user template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBookingCreatedByPrison
+      reason isEqualTo "New court booking"
     }
     with(notificationCaptor.secondValue) {
       email isEqualTo "jon@court.com"
       templateName isEqualTo "court template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBookingCreatedByPrison
+      reason isEqualTo "New court booking"
     }
     with(notificationCaptor.thirdValue) {
       email isEqualTo "jon@prison.com"
       templateName isEqualTo "prison template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBookingCreatedByPrison
+      reason isEqualTo "New court booking"
     }
   }
 
@@ -350,11 +366,8 @@ class BookingFacadeTest {
     val bookingRequest = amendCourtBookingRequest(prisonCode = MOORLAND, prisonerNumber = "123456")
 
     whenever(amendBookingService.amend(1, bookingRequest, user("facade court user"))) doReturn Pair(courtBooking, prisoner(prisonerNumber = "123456", prisonCode = MOORLAND))
-
-    val notificationId = UUID.randomUUID()
-
-    whenever(emailService.send(any<AmendedCourtBookingUserEmail>())) doReturn Result.success(notificationId to "user template id")
-    whenever(emailService.send(any<AmendedCourtBookingPrisonCourtEmail>())) doReturn Result.success(notificationId to "prison template id")
+    whenever(emailService.send(any<AmendedCourtBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
+    whenever(emailService.send(any<AmendedCourtBookingPrisonCourtEmail>())) doReturn Result.success(emailNotificationId to "prison template id")
 
     facade.amend(1, bookingRequest, user("facade court user"))
 
@@ -403,41 +416,93 @@ class BookingFacadeTest {
     with(notificationCaptor.firstValue) {
       email isEqualTo "jon@somewhere.com"
       templateName isEqualTo "user template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBooking
+      reason isEqualTo "Amended court booking"
     }
     with(notificationCaptor.secondValue) {
       email isEqualTo "jon@prison.com"
       templateName isEqualTo "prison template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBooking
+      reason isEqualTo "Amended court booking"
     }
   }
 
   @Test
-  fun `should delegate probation booking creation to booking creation service`() {
-    val booking = probationBookingRequest(prisonCode = BIRMINGHAM, prisonerNumber = "123456")
+  fun `should send emails on probation booking creation by external user`() {
+    val prisoner = Prisoner(probationBookingAtBirminghamPrison.prisoner(), BIRMINGHAM, "Bob", "Builder", yesterday())
 
-    whenever(createBookingService.create(booking, user("facade probation team user"))) doReturn Pair(probationBooking(), prisoner(prisonerNumber = "123456", prisonCode = BIRMINGHAM))
+    whenever(prisonerSearchClient.getPrisoner(prisoner.prisonerNumber)) doReturn prisoner
 
-    facade.create(booking, user("facade probation team user"))
+    val request = probationBookingRequest(
+      prisonCode = prisoner.prisonId!!,
+      prisonerNumber = prisoner.prisonerNumber,
+      appointmentDate = tomorrow(),
+      startTime = LocalTime.MIDNIGHT,
+      endTime = LocalTime.MIDNIGHT.plusHours(1),
+    )
 
-    verify(createBookingService).create(booking, user("facade probation team user"))
+    whenever(createBookingService.create(request, user("facade probation team user"))) doReturn Pair(probationBookingAtBirminghamPrison, prisoner(prisonCode = prisoner.prisonId!!, prisonerNumber = prisoner.prisonerNumber, firstName = prisoner.firstName, lastName = prisoner.lastName))
+    whenever(emailService.send(any<NewProbationBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
+
+    facade.create(request, user("facade probation team user"))
+
+    inOrder(createBookingService, outboundEventsService, emailService, notificationRepository) {
+      verify(createBookingService).create(request, user("facade probation team user"))
+      verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CREATED, probationBookingAtBirminghamPrison.videoBookingId)
+      verify(emailService).send(emailCaptor.capture())
+      verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
+    }
+
+    with(emailCaptor.allValues.single()) {
+      this isInstanceOf NewProbationBookingUserEmail::class.java
+      address isEqualTo "jon@somewhere.com"
+      personalisation() containsEntriesExactlyInAnyOrder mapOf(
+        "userName" to "Jon",
+        "probationTeam" to "probation team description",
+        "prison" to "Birmingham",
+        "offenderNo" to "654321",
+        "prisonerName" to "Bob Builder",
+        "date" to tomorrow().toMediumFormatStyle(),
+        "appointmentInfo" to "${birminghamLocation.localName} - 00:00 to 01:00",
+        "comments" to "Probation meeting comments",
+      )
+    }
+
+    notificationCaptor.allValues hasSize 1
+    with(notificationCaptor.firstValue) {
+      email isEqualTo "jon@somewhere.com"
+      templateName isEqualTo "user template id"
+      govNotifyNotificationId isEqualTo emailNotificationId
+      videoBooking isEqualTo probationBookingAtBirminghamPrison
+      reason isEqualTo "New probation booking"
+    }
   }
 
   @Test
   fun `should delegate probation booking amendment to booking amendment service`() {
-    val booking = amendProbationBookingRequest(prisonCode = BIRMINGHAM, prisonerNumber = "123456")
+    val prisoner = Prisoner(probationBookingAtBirminghamPrison.prisoner(), BIRMINGHAM, "Bob", "Builder", yesterday())
 
-    whenever(amendBookingService.amend(1, booking, user("facade probation team user"))) doReturn Pair(probationBooking(), prisoner(prisonerNumber = "123456", prisonCode = BIRMINGHAM))
+    whenever(prisonerSearchClient.getPrisoner(prisoner.prisonerNumber)) doReturn prisoner
 
-    facade.amend(1, booking, user("facade probation team user"))
+    val amendRequest = amendProbationBookingRequest(prisonCode = prisoner.prisonId!!, prisonerNumber = prisoner.prisonerNumber)
 
-    verify(amendBookingService).amend(1, booking, user("facade probation team user"))
+    whenever(amendBookingService.amend(1, amendRequest, user("facade probation team user"))) doReturn Pair(probationBookingAtBirminghamPrison, prisoner(prisonerNumber = prisoner.prisonerNumber, prisonCode = prisoner.prisonId!!))
+    whenever(emailService.send(any<NewProbationBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
+
+    facade.amend(1, amendRequest, user("facade probation team user"))
+
+    inOrder(amendBookingService, outboundEventsService) {
+      verify(amendBookingService).amend(1, amendRequest, user("facade probation team user"))
+      verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_AMENDED, 1)
+    }
+
+    // TODO test emails are sent when amend emails are ready ...
   }
 
   @Test
-  fun `should send two transfer emails and booking cancellation event on transfer of prisoner`() {
+  fun `should send two court transfer emails and booking cancellation event on transfer of prisoner`() {
     val prisoner = Prisoner(
       prisonerNumber = courtBooking.prisoner(),
       prisonId = "TRN",
@@ -453,17 +518,14 @@ class BookingFacadeTest {
 
     whenever(cancelVideoBookingService.cancel(1, user("transfer user"))) doReturn courtBooking
     whenever(prisonerSearchClient.getPrisoner(courtBooking.prisoner())) doReturn prisoner
-
-    val notificationId = UUID.randomUUID()
-
-    whenever(emailService.send(any<TransferredCourtBookingCourtEmail>())) doReturn Result.success(notificationId to "user template id")
-    whenever(emailService.send(any<TransferredCourtBookingPrisonCourtEmail>())) doReturn Result.success(notificationId to "prison template id")
+    whenever(emailService.send(any<TransferredCourtBookingCourtEmail>())) doReturn Result.success(emailNotificationId to "user template id")
+    whenever(emailService.send(any<TransferredCourtBookingPrisonCourtEmail>())) doReturn Result.success(emailNotificationId to "prison template id")
 
     facade.prisonerTransferred(1, user("transfer user"))
 
     inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
       verify(cancelVideoBookingService).cancel(1, user("transfer user"))
-      verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, courtBooking.videoBookingId)
+      verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
       verify(emailService).send(emailCaptor.capture())
       verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
       verify(emailService).send(emailCaptor.capture())
@@ -508,14 +570,16 @@ class BookingFacadeTest {
     with(notificationCaptor.firstValue) {
       email isEqualTo "jon@court.com"
       templateName isEqualTo "user template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBooking
+      reason isEqualTo "Cancelled court booking due to transfer"
     }
     with(notificationCaptor.secondValue) {
       email isEqualTo "jon@prison.com"
       templateName isEqualTo "prison template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBooking
+      reason isEqualTo "Cancelled court booking due to transfer"
     }
   }
 
@@ -535,16 +599,13 @@ class BookingFacadeTest {
 
     whenever(cancelVideoBookingService.cancel(1, user("transfer user"))) doReturn courtBooking
     whenever(prisonerSearchClient.getPrisoner(courtBooking.prisoner())) doReturn prisoner
-
-    val notificationId = UUID.randomUUID()
-
-    whenever(emailService.send(any<TransferredCourtBookingPrisonNoCourtEmail>())) doReturn Result.success(notificationId to "prison template id")
+    whenever(emailService.send(any<TransferredCourtBookingPrisonNoCourtEmail>())) doReturn Result.success(emailNotificationId to "prison template id")
 
     facade.prisonerTransferred(1, user("transfer user"))
 
     inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
       verify(cancelVideoBookingService).cancel(1, user("transfer user"))
-      verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, courtBooking.videoBookingId)
+      verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
       verify(emailService).send(emailCaptor.capture())
       verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
     }
@@ -571,8 +632,9 @@ class BookingFacadeTest {
     with(notificationCaptor.firstValue) {
       email isEqualTo "jon@prison.com"
       templateName isEqualTo "prison template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBooking
+      reason isEqualTo "Cancelled court booking due to transfer"
     }
   }
 
@@ -593,17 +655,14 @@ class BookingFacadeTest {
 
     whenever(cancelVideoBookingService.cancel(1, user("release user"))) doReturn courtBooking
     whenever(prisonerSearchClient.getPrisoner(courtBooking.prisoner())) doReturn prisoner
-
-    val notificationId = UUID.randomUUID()
-
-    whenever(emailService.send(any<ReleasedCourtBookingCourtEmail>())) doReturn Result.success(notificationId to "user template id")
-    whenever(emailService.send(any<ReleasedCourtBookingPrisonCourtEmail>())) doReturn Result.success(notificationId to "prison template id")
+    whenever(emailService.send(any<ReleasedCourtBookingCourtEmail>())) doReturn Result.success(emailNotificationId to "user template id")
+    whenever(emailService.send(any<ReleasedCourtBookingPrisonCourtEmail>())) doReturn Result.success(emailNotificationId to "prison template id")
 
     facade.prisonerReleased(1, user("release user"))
 
     inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
       verify(cancelVideoBookingService).cancel(1, user("release user"))
-      verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, courtBooking.videoBookingId)
+      verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
       verify(emailService).send(emailCaptor.capture())
       verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
       verify(emailService).send(emailCaptor.capture())
@@ -648,14 +707,16 @@ class BookingFacadeTest {
     with(notificationCaptor.firstValue) {
       email isEqualTo "jon@court.com"
       templateName isEqualTo "user template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBooking
+      reason isEqualTo "Cancelled court booking due to release"
     }
     with(notificationCaptor.secondValue) {
       email isEqualTo "jon@prison.com"
       templateName isEqualTo "prison template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBooking
+      reason isEqualTo "Cancelled court booking due to release"
     }
   }
 
@@ -675,16 +736,13 @@ class BookingFacadeTest {
 
     whenever(cancelVideoBookingService.cancel(1, user("release user"))) doReturn courtBooking
     whenever(prisonerSearchClient.getPrisoner(courtBooking.prisoner())) doReturn prisoner
-
-    val notificationId = UUID.randomUUID()
-
-    whenever(emailService.send(any<ReleasedCourtBookingPrisonNoCourtEmail>())) doReturn Result.success(notificationId to "prison template id")
+    whenever(emailService.send(any<ReleasedCourtBookingPrisonNoCourtEmail>())) doReturn Result.success(emailNotificationId to "prison template id")
 
     facade.prisonerReleased(1, user("release user"))
 
     inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
       verify(cancelVideoBookingService).cancel(1, user("release user"))
-      verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, courtBooking.videoBookingId)
+      verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
       verify(emailService).send(emailCaptor.capture())
       verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
     }
@@ -711,8 +769,9 @@ class BookingFacadeTest {
     with(notificationCaptor.firstValue) {
       email isEqualTo "jon@prison.com"
       templateName isEqualTo "prison template id"
-      govNotifyNotificationId isEqualTo notificationId
+      govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo courtBooking
+      reason isEqualTo "Cancelled court booking due to release"
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailServiceTest.kt
@@ -48,6 +48,7 @@ class GovNotifyEmailServiceTest {
     releaseCourtBookingPrisonCourtEmail = "releaseCourtBookingPrisonCourtEmail",
     releaseCourtBookingPrisonNoCourtEmail = "releaseCourtBookingPrisonNoCourtEmail",
     newProbationBookingUser = "newProbationBookingUser",
+    newProbationBookingProbation = "newProbationBookingProbation",
   )
 
   private val service = GovNotifyEmailService(client, emailTemplates)
@@ -784,6 +785,40 @@ class GovNotifyEmailServiceTest {
         "comments" to "comments for bob",
         "offenderNo" to "123456",
         "userName" to "username",
+        "probationTeam" to "the probation team",
+        "prison" to "the prison",
+        "appointmentInfo" to "bobs appointment info",
+      ),
+      null,
+    )
+  }
+
+  @Test
+  fun `should send probation probation new booking email and return a notification ID`() {
+    val result = service.send(
+      NewProbationBookingProbationEmail(
+        address = "recipient@emailaddress.com",
+        prisonerFirstName = "builder",
+        prisonerLastName = "bob",
+        prisonerNumber = "123456",
+        appointmentDate = today,
+        comments = "comments for bob",
+        appointmentInfo = "bobs appointment info",
+        probationTeam = "the probation team",
+        prison = "the prison",
+      ),
+    )
+
+    result.getOrThrow() isEqualTo Pair(notificationId, "newProbationBookingProbation")
+
+    verify(client).sendEmail(
+      "newProbationBookingProbation",
+      "recipient@emailaddress.com",
+      mapOf(
+        "date" to today.toMediumFormatStyle(),
+        "prisonerName" to "builder bob",
+        "comments" to "comments for bob",
+        "offenderNo" to "123456",
         "probationTeam" to "the probation team",
         "prison" to "the prison",
         "appointmentInfo" to "bobs appointment info",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailServiceTest.kt
@@ -47,6 +47,7 @@ class GovNotifyEmailServiceTest {
     releaseCourtBookingCourt = "releaseCourtBookingCourt",
     releaseCourtBookingPrisonCourtEmail = "releaseCourtBookingPrisonCourtEmail",
     releaseCourtBookingPrisonNoCourtEmail = "releaseCourtBookingPrisonNoCourtEmail",
+    newProbationBookingUser = "newProbationBookingUser",
   )
 
   private val service = GovNotifyEmailService(client, emailTemplates)
@@ -753,5 +754,41 @@ class GovNotifyEmailServiceTest {
     result.isSuccess isBool false
     result.isFailure isBool true
     result.exceptionOrNull() isEqualTo exception
+  }
+
+  @Test
+  fun `should send probation user new booking email and return a notification ID`() {
+    val result = service.send(
+      NewProbationBookingUserEmail(
+        address = "recipient@emailaddress.com",
+        prisonerFirstName = "builder",
+        prisonerLastName = "bob",
+        prisonerNumber = "123456",
+        date = today,
+        userName = "username",
+        comments = "comments for bob",
+        appointmentInfo = "bobs appointment info",
+        probationTeam = "the probation team",
+        prison = "the prison",
+      ),
+    )
+
+    result.getOrThrow() isEqualTo Pair(notificationId, "newProbationBookingUser")
+
+    verify(client).sendEmail(
+      "newProbationBookingUser",
+      "recipient@emailaddress.com",
+      mapOf(
+        "date" to today.toMediumFormatStyle(),
+        "prisonerName" to "builder bob",
+        "comments" to "comments for bob",
+        "offenderNo" to "123456",
+        "userName" to "username",
+        "probationTeam" to "the probation team",
+        "prison" to "the prison",
+        "appointmentInfo" to "bobs appointment info",
+      ),
+      null,
+    )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/CourtEmailFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/CourtEmailFactoryTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ContactType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.bookingContact
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
@@ -73,7 +74,7 @@ class CourtEmailFactoryTest {
       locationKey = moorlandLocation.key,
     )
 
-  private val prison = prison(prisonCode = BIRMINGHAM)
+  private val prison = prison(prisonCode = MOORLAND)
 
   companion object {
     @JvmStatic
@@ -153,7 +154,7 @@ class CourtEmailFactoryTest {
       )
     }
 
-    error.message isEqualTo "Incorrect contact type ${prisonBookingContact.contactType} for user email"
+    error.message isEqualTo "Incorrect contact type ${prisonBookingContact.contactType} for court user email"
   }
 
   @Test
@@ -227,7 +228,7 @@ class CourtEmailFactoryTest {
       )
     }
 
-    error.message isEqualTo "Incorrect contact type ${userBookingContact.contactType} for court email"
+    error.message isEqualTo "Incorrect contact type ${userBookingContact.contactType} for court court email"
   }
 
   @Test
@@ -266,7 +267,7 @@ class CourtEmailFactoryTest {
       )
     }
 
-    error.message isEqualTo "Incorrect contact type ${userBookingContact.contactType} for prison email"
+    error.message isEqualTo "Incorrect contact type ${userBookingContact.contactType} for court prison email"
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/ProbationEmailFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/ProbationEmailFactoryTest.kt
@@ -1,0 +1,142 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ContactType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.bookingContact
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isInstanceOf
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.moorlandLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisoner
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingAction
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingUserEmail
+import java.time.LocalDate
+import java.time.LocalTime
+
+class ProbationEmailFactoryTest {
+
+  private val userBookingContact = bookingContact(
+    contactType = ContactType.USER,
+    email = "user@email.com",
+    name = "Fred",
+  )
+
+  private val courtBookingContact = bookingContact(
+    contactType = ContactType.COURT,
+    email = "user@email.com",
+    name = "Fred",
+  )
+
+  private val prisonBookingContact = bookingContact(
+    contactType = ContactType.PRISON,
+    email = "user@email.com",
+    name = "Fred",
+  )
+
+  private val prisoner = prisoner(
+    prisonerNumber = "123456",
+    prisonCode = BIRMINGHAM,
+    firstName = "Fred",
+    lastName = "Bloggs",
+  )
+
+  private val prison = prison(prisonCode = MOORLAND)
+
+  private val courtBooking = courtBooking()
+    .addAppointment(
+      prisonCode = BIRMINGHAM,
+      prisonerNumber = "123456",
+      appointmentType = "VLB_COURT_MAIN",
+      date = LocalDate.of(2100, 1, 1),
+      startTime = LocalTime.of(11, 0),
+      endTime = LocalTime.of(11, 30),
+      locationKey = moorlandLocation.key,
+    )
+
+  private val probationBooking = probationBooking()
+    .addAppointment(
+      prisonCode = BIRMINGHAM,
+      prisonerNumber = "123456",
+      appointmentType = "VLB_PROBATION",
+      date = LocalDate.of(2100, 1, 1),
+      startTime = LocalTime.of(11, 0),
+      endTime = LocalTime.of(11, 30),
+      locationKey = moorlandLocation.key,
+    )
+
+  private val userEmails = mapOf(
+    BookingAction.CREATE to NewProbationBookingUserEmail::class.java,
+  )
+
+  companion object {
+    @JvmStatic
+    fun supportedUserBookingActions() = setOf(BookingAction.CREATE)
+
+    @JvmStatic
+    fun unsupportedUserBookingActions() = setOf(BookingAction.RELEASED, BookingAction.TRANSFERRED)
+
+    @JvmStatic
+    fun supportedCourtBookingActions() = setOf(BookingAction.CREATE, BookingAction.RELEASED, BookingAction.TRANSFERRED)
+
+    @JvmStatic
+    fun unsupportedCourtBookingActions() = setOf(BookingAction.AMEND, BookingAction.CANCEL)
+  }
+
+  @ParameterizedTest
+  @MethodSource("supportedUserBookingActions")
+  fun `should return user emails for supported user based actions`(action: BookingAction) {
+    val email = ProbationEmailFactory.user(
+      action = action,
+      contact = userBookingContact,
+      prisoner = prisoner,
+      booking = probationBooking,
+      prison = prison,
+      appointment = probationBooking.appointments().single(),
+      location = moorlandLocation,
+    )
+
+    email isInstanceOf userEmails[action]!!
+  }
+
+  @Test
+  fun `should reject incorrect contact type for user emails`() {
+    val error = assertThrows<IllegalArgumentException> {
+      ProbationEmailFactory.user(
+        action = BookingAction.CREATE,
+        contact = prisonBookingContact,
+        prisoner = prisoner,
+        booking = probationBooking,
+        prison = prison,
+        appointment = probationBooking.appointments().single(),
+        location = birminghamLocation,
+      )
+    }
+
+    error.message isEqualTo "Incorrect contact type ${prisonBookingContact.contactType} for probation user email"
+  }
+
+  @Test
+  fun `should reject court video bookings for user emails`() {
+    val error = assertThrows<IllegalArgumentException> {
+      ProbationEmailFactory.user(
+        action = BookingAction.CREATE,
+        contact = prisonBookingContact,
+        prisoner = prisoner,
+        booking = courtBooking,
+        prison = prison,
+        appointment = courtBooking.appointments().single(),
+        location = birminghamLocation,
+      )
+    }
+
+    error.message isEqualTo "Booking ID 0 is not a probation booking"
+  }
+}


### PR DESCRIPTION
This is the first PR for getting the probation email train going.  It will send a user and probation contact email on creation.

Need to add email support for prison contacts.

I will be adding the missing emails in separate PR's.