### PR TITLE
BAVL-284 send prison emails on probation booking.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
@@ -19,7 +19,8 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBooki
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingUserEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingPrisonNoProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingPrisonProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonNoProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonProbationTeamEmail
@@ -66,7 +67,8 @@ class EmailConfiguration(
   @Value("\${notify.templates.probation.booking-request.prison-probation-team-email:}") private val probationBookingRequestPrisonProbationTeamEmail: String,
   @Value("\${notify.templates.probation.booking-request.prison-no-probation-team-email:}") private val probationBookingRequestPrisonNoProbationTeamEmail: String,
   @Value("\${notify.templates.probation.new-booking.user:}") private val newProbationBookingUser: String,
-  @Value("\${notify.templates.probation.new-booking.probation:}") private val newProbationBookingProbation: String,
+  @Value("\${notify.templates.probation.new-booking.prison-probation-email:}") private val newProbationBookingPrisonProbationEmail: String,
+  @Value("\${notify.templates.probation.new-booking.prison-no-probation-email:}") private val newProbationBookingPrisonNoProbationEmail: String,
 ) {
 
   companion object {
@@ -105,7 +107,8 @@ class EmailConfiguration(
     releaseCourtBookingPrisonCourtEmail = releaseCourtBookingPrisonCourtEmail,
     releaseCourtBookingPrisonNoCourtEmail = releaseCourtBookingPrisonNoCourtEmail,
     newProbationBookingUser = newProbationBookingUser,
-    newProbationBookingProbation = newProbationBookingProbation,
+    newProbationBookingPrisonProbationEmail = newProbationBookingPrisonProbationEmail,
+    newProbationBookingPrisonNoProbationEmail = newProbationBookingPrisonNoProbationEmail,
   )
 }
 
@@ -163,7 +166,8 @@ data class EmailTemplates(
   val releaseCourtBookingPrisonCourtEmail: String,
   val releaseCourtBookingPrisonNoCourtEmail: String,
   val newProbationBookingUser: String,
-  val newProbationBookingProbation: String,
+  val newProbationBookingPrisonProbationEmail: String,
+  val newProbationBookingPrisonNoProbationEmail: String,
 ) {
 
   private val emailTemplateMappings = mapOf(
@@ -190,7 +194,8 @@ data class EmailTemplates(
     ReleasedCourtBookingPrisonCourtEmail::class.java to releaseCourtBookingPrisonCourtEmail,
     ReleasedCourtBookingPrisonNoCourtEmail::class.java to releaseCourtBookingPrisonNoCourtEmail,
     NewProbationBookingUserEmail::class.java to newProbationBookingUser,
-    NewProbationBookingProbationEmail::class.java to newProbationBookingProbation,
+    NewProbationBookingPrisonProbationEmail::class.java to newProbationBookingPrisonProbationEmail,
+    NewProbationBookingPrisonNoProbationEmail::class.java to newProbationBookingPrisonNoProbationEmail,
   )
 
   init {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
@@ -117,7 +117,7 @@ class BookingFacade(
     contacts.mapNotNull { contact ->
       when (contact.contactType) {
         ContactType.USER -> ProbationEmailFactory.user(contact, prisoner, booking, prison, appointment, location, eventType)
-        ContactType.PROBATION -> ProbationEmailFactory.probation(contact, prisoner, booking, prison, appointment, location, eventType)
+        ContactType.PRISON -> ProbationEmailFactory.prison(contact, prisoner, booking, prison, appointment, location, eventType, contacts)
         else -> null
       }
     }.forEach { probationEmail -> sendEmailAndSaveNotification(probationEmail, booking, eventType) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailService.kt
@@ -587,13 +587,34 @@ class NewProbationBookingUserEmail(
   }
 }
 
-class NewProbationBookingProbationEmail(
+class NewProbationBookingPrisonProbationEmail(
   address: String,
-  prison: String,
-  prisonerNumber: String,
   prisonerFirstName: String,
   prisonerLastName: String,
+  prisonerNumber: String,
   probationTeam: String,
+  probationEmailAddress: String,
+  prison: String,
+  appointmentDate: LocalDate,
+  appointmentInfo: String,
+  comments: String?,
+) : Email(address, prisonerFirstName, prisonerLastName, appointmentDate, comments) {
+  init {
+    addPersonalisation("offenderNo", prisonerNumber)
+    addPersonalisation("probationTeam", probationTeam)
+    addPersonalisation("probationEmailAddress", probationEmailAddress)
+    addPersonalisation("prison", prison)
+    addPersonalisation("appointmentInfo", appointmentInfo)
+  }
+}
+
+class NewProbationBookingPrisonNoProbationEmail(
+  address: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  prisonerNumber: String,
+  probationTeam: String,
+  prison: String,
   appointmentDate: LocalDate,
   appointmentInfo: String,
   comments: String?,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -144,7 +144,8 @@ notify:
         prison-no-probation-team-email: "2326fa9d-1627-4c04-8c8d-a6e1ae19a6cb"
       new-booking:
         user: "20fddb45-3907-4e10-a570-86377bbe9dd1"
-        probation: "1a3cdd5a-411b-4365-9613-e1211a0f15b6"
+        prison-probation-email: "73a0e2b3-6b49-4a31-8960-973e3e833e81"
+        prison-no-probation-email: "bf2c340e-31a4-45db-bc70-e902ee499ec5"
 
 
 springdoc:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailTemplatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailTemplatesTest.kt
@@ -15,7 +15,8 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBooki
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingUserEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingPrisonNoProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingPrisonProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonNoProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonProbationTeamEmail
@@ -53,7 +54,8 @@ class EmailTemplatesTest {
     ReleasedCourtBookingPrisonCourtEmail::class.java to "releaseCourtBookingPrisonCourtEmail",
     ReleasedCourtBookingPrisonNoCourtEmail::class.java to "releaseCourtBookingPrisonNoCourtEmail",
     NewProbationBookingUserEmail::class.java to "newProbationBookingUser",
-    NewProbationBookingProbationEmail::class.java to "newProbationBookingProbation",
+    NewProbationBookingPrisonProbationEmail::class.java to "newProbationBookingPrisonProbationEmail",
+    NewProbationBookingPrisonNoProbationEmail::class.java to "newProbationBookingPrisonNoProbationEmail",
   )
 
   private val templates = EmailTemplates(
@@ -80,7 +82,8 @@ class EmailTemplatesTest {
     releaseCourtBookingPrisonCourtEmail = "releaseCourtBookingPrisonCourtEmail",
     releaseCourtBookingPrisonNoCourtEmail = "releaseCourtBookingPrisonNoCourtEmail",
     newProbationBookingUser = "newProbationBookingUser",
-    newProbationBookingProbation = "newProbationBookingProbation",
+    newProbationBookingPrisonProbationEmail = "newProbationBookingPrisonProbationEmail",
+    newProbationBookingPrisonNoProbationEmail = "newProbationBookingPrisonNoProbationEmail",
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -76,7 +76,8 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBooki
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewCourtBookingUserEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingPrisonNoProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingPrisonProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonNoProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ProbationBookingRequestPrisonProbationTeamEmail
@@ -1650,7 +1651,8 @@ class TestEmailConfiguration {
         is ProbationBookingRequestPrisonProbationTeamEmail -> Result.success(UUID.randomUUID() to "requested probation booking prison template id with email address")
         is ProbationBookingRequestPrisonNoProbationTeamEmail -> Result.success(UUID.randomUUID() to "requested probation booking prison template id with no email address")
         is NewProbationBookingUserEmail -> Result.success(UUID.randomUUID() to "new probation booking user template id")
-        is NewProbationBookingProbationEmail -> Result.success(UUID.randomUUID() to "new probation booking probation template id")
+        is NewProbationBookingPrisonProbationEmail -> Result.success(UUID.randomUUID() to "new probation booking prison template id with email address")
+        is NewProbationBookingPrisonNoProbationEmail -> Result.success(UUID.randomUUID() to "new probation booking prison template id no email address")
         else -> throw RuntimeException("Unsupported email in test email configuration: ${email.javaClass.simpleName}")
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
@@ -45,7 +45,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.Domain
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.OutboundEventsService
 import java.time.LocalDate
 import java.time.LocalTime
-import java.util.UUID
+import java.util.*
 
 class BookingFacadeTest {
   private val emailCaptor = argumentCaptor<Email>()
@@ -442,7 +442,7 @@ class BookingFacadeTest {
 
     whenever(createBookingService.create(request, user("facade probation team user"))) doReturn Pair(probationBookingAtBirminghamPrison, prisoner(prisonCode = prisoner.prisonId!!, prisonerNumber = prisoner.prisonerNumber, firstName = prisoner.firstName, lastName = prisoner.lastName))
     whenever(emailService.send(any<NewProbationBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
-    whenever(emailService.send(any<NewProbationBookingProbationEmail>())) doReturn Result.success(emailNotificationId to "probation template id")
+    whenever(emailService.send(any<NewProbationBookingPrisonProbationEmail>())) doReturn Result.success(emailNotificationId to "probation template id")
 
     facade.create(request, user("facade probation team user"))
 
@@ -473,8 +473,8 @@ class BookingFacadeTest {
     }
 
     with(emailCaptor.secondValue) {
-      this isInstanceOf NewProbationBookingProbationEmail::class.java
-      address isEqualTo "jon@probation.com"
+      this isInstanceOf NewProbationBookingPrisonProbationEmail::class.java
+      address isEqualTo "jon@prison.com"
       personalisation() containsEntriesExactlyInAnyOrder mapOf(
         "probationTeam" to "probation team description",
         "prison" to "Birmingham",
@@ -483,6 +483,7 @@ class BookingFacadeTest {
         "date" to tomorrow().toMediumFormatStyle(),
         "appointmentInfo" to "${birminghamLocation.localName} - 00:00 to 01:00",
         "comments" to "Probation meeting comments",
+        "probationEmailAddress" to "jon@probation.com",
       )
     }
 
@@ -496,7 +497,7 @@ class BookingFacadeTest {
     }
 
     with(notificationCaptor.secondValue) {
-      email isEqualTo "jon@probation.com"
+      email isEqualTo "jon@prison.com"
       templateName isEqualTo "probation template id"
       govNotifyNotificationId isEqualTo emailNotificationId
       videoBooking isEqualTo probationBookingAtBirminghamPrison

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/GovNotifyEmailServiceTest.kt
@@ -17,7 +17,7 @@ import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.NotificationClientException
 import uk.gov.service.notify.SendEmailResponse
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 class GovNotifyEmailServiceTest {
   private val today = LocalDate.now()
@@ -48,7 +48,8 @@ class GovNotifyEmailServiceTest {
     releaseCourtBookingPrisonCourtEmail = "releaseCourtBookingPrisonCourtEmail",
     releaseCourtBookingPrisonNoCourtEmail = "releaseCourtBookingPrisonNoCourtEmail",
     newProbationBookingUser = "newProbationBookingUser",
-    newProbationBookingProbation = "newProbationBookingProbation",
+    newProbationBookingPrisonProbationEmail = "newProbationBookingPrisonProbationEmail",
+    newProbationBookingPrisonNoProbationEmail = "newProbationBookingPrisonNoProbationEmail",
   )
 
   private val service = GovNotifyEmailService(client, emailTemplates)
@@ -794,9 +795,9 @@ class GovNotifyEmailServiceTest {
   }
 
   @Test
-  fun `should send probation probation new booking email and return a notification ID`() {
+  fun `should send prison probation new booking email and return a notification ID`() {
     val result = service.send(
-      NewProbationBookingProbationEmail(
+      NewProbationBookingPrisonProbationEmail(
         address = "recipient@emailaddress.com",
         prisonerFirstName = "builder",
         prisonerLastName = "bob",
@@ -806,13 +807,14 @@ class GovNotifyEmailServiceTest {
         appointmentInfo = "bobs appointment info",
         probationTeam = "the probation team",
         prison = "the prison",
+        probationEmailAddress = "jim@probation.com",
       ),
     )
 
-    result.getOrThrow() isEqualTo Pair(notificationId, "newProbationBookingProbation")
+    result.getOrThrow() isEqualTo Pair(notificationId, "newProbationBookingPrisonProbationEmail")
 
     verify(client).sendEmail(
-      "newProbationBookingProbation",
+      "newProbationBookingPrisonProbationEmail",
       "recipient@emailaddress.com",
       mapOf(
         "date" to today.toMediumFormatStyle(),
@@ -822,6 +824,7 @@ class GovNotifyEmailServiceTest {
         "probationTeam" to "the probation team",
         "prison" to "the prison",
         "appointmentInfo" to "bobs appointment info",
+        "probationEmailAddress" to "jim@probation.com",
       ),
       null,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/ProbationEmailFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/ProbationEmailFactoryTest.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingAction
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingPrisonProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.NewProbationBookingUserEmail
 import java.time.LocalDate
 import java.time.LocalTime
@@ -83,8 +83,8 @@ class ProbationEmailFactoryTest {
     BookingAction.CREATE to NewProbationBookingUserEmail::class.java,
   )
 
-  private val probationEmails = mapOf(
-    BookingAction.CREATE to NewProbationBookingProbationEmail::class.java,
+  private val prisonEmails = mapOf(
+    BookingAction.CREATE to NewProbationBookingPrisonProbationEmail::class.java,
   )
 
   companion object {
@@ -95,7 +95,7 @@ class ProbationEmailFactoryTest {
     fun unsupportedUserBookingActions() = setOf(BookingAction.RELEASED, BookingAction.TRANSFERRED)
 
     @JvmStatic
-    fun supportedProbationBookingActions() = setOf(BookingAction.CREATE)
+    fun supportedPrisonBookingActions() = setOf(BookingAction.CREATE)
 
     @JvmStatic
     fun unsupportedProbationBookingActions() = setOf(BookingAction.AMEND, BookingAction.CANCEL)
@@ -154,7 +154,7 @@ class ProbationEmailFactoryTest {
   @Test
   fun `should reject court video bookings for probation emails`() {
     val error = assertThrows<IllegalArgumentException> {
-      ProbationEmailFactory.probation(
+      ProbationEmailFactory.prison(
         action = BookingAction.CREATE,
         contact = prisonBookingContact,
         prisoner = prisoner,
@@ -162,6 +162,7 @@ class ProbationEmailFactoryTest {
         prison = prison,
         appointment = courtBooking.appointments().single(),
         location = birminghamLocation,
+        contacts = emptySet(),
       )
     }
 
@@ -169,25 +170,26 @@ class ProbationEmailFactoryTest {
   }
 
   @ParameterizedTest
-  @MethodSource("supportedProbationBookingActions")
-  fun `should return probation emails for supported user based actions`(action: BookingAction) {
-    val email = ProbationEmailFactory.probation(
+  @MethodSource("supportedPrisonBookingActions")
+  fun `should return prison probation emails for supported user based actions`(action: BookingAction) {
+    val email = ProbationEmailFactory.prison(
       action = action,
-      contact = probationBookingContact,
+      contact = prisonBookingContact,
       prisoner = prisoner,
       booking = probationBooking,
       prison = prison,
       appointment = probationBooking.appointments().single(),
       location = moorlandLocation,
+      contacts = setOf(probationBookingContact),
     )
 
-    email isInstanceOf probationEmails[action]!!
+    email isInstanceOf prisonEmails[action]!!
   }
 
   @Test
-  fun `should reject incorrect contact type for probation emails`() {
+  fun `should reject incorrect contact type for prison probation emails`() {
     val error = assertThrows<IllegalArgumentException> {
-      ProbationEmailFactory.probation(
+      ProbationEmailFactory.prison(
         action = BookingAction.CREATE,
         contact = courtBookingContact,
         prisoner = prisoner,
@@ -195,9 +197,10 @@ class ProbationEmailFactoryTest {
         prison = prison,
         appointment = probationBooking.appointments().single(),
         location = birminghamLocation,
+        contacts = emptySet(),
       )
     }
 
-    error.message isEqualTo "Incorrect contact type ${courtBookingContact.contactType} for probation probation email"
+    error.message isEqualTo "Incorrect contact type ${courtBookingContact.contactType} for prison probation email"
   }
 }


### PR DESCRIPTION
Taken out probation email for probation contact, done in error.  Added two prison emails set on creation of a booking by an probation user.