### PR TITLE
BAVL-297 new endpoints to return enabled only or all courts and probations teams.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/ProbationTeamsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/ProbationTeamsController.kt
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.ErrorResponse
@@ -68,9 +69,53 @@ class ProbationTeamsController(private val probationTeamsService: ProbationTeams
   )
   @GetMapping(value = ["/enabled"], produces = [MediaType.APPLICATION_JSON_VALUE])
   @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN', 'BVLS_ACCESS__RW')")
-  fun enabledProbationTeams(): List<ProbationTeam> = probationTeamsService.getEnabledProbationTeams()
+  @Deprecated(message = "Do not use.", replaceWith = ReplaceWith("getProbationTeams"))
+  fun enabledProbationTeams(): List<ProbationTeam> = probationTeamsService.getProbationTeams(true)
 
-  @Operation(summary = "Endpoint to return the list of enabled probation teams select by a user (identified from the token content)")
+  @Operation(summary = "Endpoint to return a list of probation teams for video link bookings")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Probation teams",
+        content = [
+          Content(
+            mediaType = "application/json",
+            array = ArraySchema(schema = Schema(implementation = ProbationTeam::class)),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+  @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN', 'BVLS_ACCESS__RW')")
+  fun getProbationTeams(
+    @Parameter(description = "Enabled only, true or false. When true only returns enabled probation teams. Defaults to true if not supplied.")
+    @RequestParam(name = "enabledOnly", required = false)
+    enabledOnly: Boolean = true,
+  ): List<ProbationTeam> = probationTeamsService.getProbationTeams(enabledOnly)
+
+  @Operation(summary = "Endpoint to return the list of probation teams select by a user (identified from the token content)")
   @ApiResponses(
     value = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CourtsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CourtsService.kt
@@ -14,8 +14,13 @@ class CourtsService(
   private val courtRepository: CourtRepository,
   private val userCourtRepository: UserCourtRepository,
 ) {
-  fun getEnabledCourts() =
-    courtRepository.findAllByEnabledIsTrue().toModel()
+
+  fun getCourts(enabledOnly: Boolean) =
+    if (enabledOnly) {
+      courtRepository.findAllByEnabledIsTrue().toModel()
+    } else {
+      courtRepository.findAll().toModel()
+    }
 
   fun getUserCourtPreferences(user: User) =
     courtRepository.findCourtsByUsername(user.username).toModel()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
@@ -40,7 +40,7 @@ class CreateVideoBookingService(
 
   private fun createCourt(request: CreateVideoBookingRequest, createdBy: User): Pair<VideoBooking, Prisoner> {
     val court = courtRepository.findByCode(request.courtCode!!)
-      ?.also { require(it.enabled) { "Court with code ${it.code} is not enabled" } }
+      ?.also { if (!createdBy.isUserType(UserType.PRISON)) require(it.enabled) { "Court with code ${it.code} is not enabled" } }
       ?: throw EntityNotFoundException("Court with code ${request.courtCode} not found")
 
     val prisoner = request.prisoner().validate()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ProbationTeamsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ProbationTeamsService.kt
@@ -14,8 +14,12 @@ class ProbationTeamsService(
   private val probationTeamRepository: ProbationTeamRepository,
   private val userProbationRepository: UserProbationRepository,
 ) {
-  fun getEnabledProbationTeams() =
-    probationTeamRepository.findAllByEnabledIsTrue().toModel()
+  fun getProbationTeams(enabledOnly: Boolean) =
+    if (enabledOnly) {
+      probationTeamRepository.findAllByEnabledIsTrue().toModel()
+    } else {
+      probationTeamRepository.findAll().toModel()
+    }
 
   fun getUserProbationTeamPreferences(user: User) =
     probationTeamRepository.findProbationTeamsByUsername(user.username).toModel()


### PR DESCRIPTION
Two new endpoints for all or enabled only courts and probation teams.

The existing enabled only endpoints for courts and probation are deprecated and will removed when UI's referencing them are changed to use the new endpoints.