### PR TITLE
BAVL-302 removed end date from call to activities API, it has been removed from the activities API. Behaviour should be the same.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
@@ -86,7 +86,6 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
         AppointmentSearchRequest(
           appointmentType = AppointmentSearchRequest.AppointmentType.INDIVIDUAL,
           startDate = onDate,
-          endDate = onDate,
           categoryCode = VIDEO_LINK_BOOKING,
           prisonerNumbers = listOf(prisonerNumber),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ActivitiesAppointmentsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ActivitiesAppointmentsApiMockServer.kt
@@ -138,7 +138,6 @@ class ActivitiesAppointmentsApiMockServer : MockServer(8089) {
               AppointmentSearchRequest(
                 appointmentType = AppointmentSearchRequest.AppointmentType.INDIVIDUAL,
                 startDate = date,
-                endDate = date,
                 categoryCode = VIDEO_LINK_BOOKING,
                 prisonerNumbers = listOf(prisonerNumber),
               ),


### PR DESCRIPTION
This change is needed on the back of this change to the Activities API [here](https://github.com/ministryofjustice/hmpps-activities-management-api/pull/1004).