### PR TITLE
BAVL-280 restrict access to get bookings for prison users enforced by their active caseload.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/HmppsBookAVideoLinkApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/HmppsBookAVideoLinkApiExceptionHandler.kt
@@ -71,10 +71,10 @@ class HmppsBookAVideoLinkApiExceptionHandler : ResponseEntityExceptionHandler() 
   fun handleCaseLoadAccessException(e: CaseloadAccessException): ResponseEntity<ErrorResponse> {
     log.info("Case load access exception: {}", e.message)
     return ResponseEntity
-      .status(HttpStatus.FORBIDDEN)
+      .status(NOT_FOUND)
       .body(
         ErrorResponse(
-          status = HttpStatus.FORBIDDEN.value(),
+          status = NOT_FOUND.value(),
           userMessage = "Not found: ${e.message}",
           developerMessage = e.message,
         ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/HmppsBookAVideoLinkApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/HmppsBookAVideoLinkApiExceptionHandler.kt
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security.CaseloadAccessException
 
 @RestControllerAdvice
 class HmppsBookAVideoLinkApiExceptionHandler : ResponseEntityExceptionHandler() {
@@ -61,6 +62,20 @@ class HmppsBookAVideoLinkApiExceptionHandler : ResponseEntityExceptionHandler() 
         ErrorResponse(
           status = BAD_REQUEST,
           userMessage = "Exception: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(CaseloadAccessException::class)
+  fun handleCaseLoadAccessException(e: CaseloadAccessException): ResponseEntity<ErrorResponse> {
+    log.info("Case load access exception: {}", e.message)
+    return ResponseEntity
+      .status(HttpStatus.FORBIDDEN)
+      .body(
+        ErrorResponse(
+          status = HttpStatus.FORBIDDEN.value(),
+          userMessage = "Not found: ${e.message}",
           developerMessage = e.message,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
@@ -64,10 +64,15 @@ class VideoBooking private constructor(
 
   fun isCourtBooking() = bookingType == "COURT"
 
+  fun isProbationBooking() = isCourtBooking().not()
+
   fun appointments() = prisonAppointments.toList()
 
   // TODO: Assumes one person per booking, so revisit for co-defendant cases
   fun prisoner() = appointments().map { it.prisonerNumber }.distinct().single()
+
+  // TODO: Assumes one person per booking, so revisit for co-defendant cases
+  fun prisonCode() = appointments().map { it.prisonCode }.distinct().single()
 
   fun isStatus(status: StatusCode) = statusCode == status
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/ReferenceCodeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/ReferenceCodeRepository.kt
@@ -9,3 +9,9 @@ interface ReferenceCodeRepository : JpaRepository<ReferenceCode, Long> {
   fun findAllByGroupCodeEquals(groupCode: String): List<ReferenceCode>
   fun findByGroupCodeAndCode(groupCode: String, code: String): ReferenceCode?
 }
+
+fun ReferenceCodeRepository.findByCourtHearingType(hearingType: String) =
+  findByGroupCodeAndCode("COURT_HEARING_TYPE", hearingType)
+
+fun ReferenceCodeRepository.findByProbationMeetingType(meetingType: String) =
+  findByGroupCodeAndCode("PROBATION_MEETING_TYPE", meetingType)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/CaseloadAccess.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/CaseloadAccess.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security
+
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.getBvlsRequestContext
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserType
+
+/**
+ * Caseload access checks are only relevant for prison users. If the current user is not a prison user then it will just
+ * be ignored.
+ */
+fun checkCaseLoadAccess(prisonCode: String) {
+  val httpRequest =
+    if (RequestContextHolder.getRequestAttributes() != null) {
+      (RequestContextHolder.getRequestAttributes() as ServletRequestAttributes).request
+    } else {
+      throw NullPointerException("Unable to determine user from request context.")
+    }
+
+  httpRequest.getBvlsRequestContext().user.takeIf { it.isUserType(UserType.PRISON) }?.run {
+    if (prisonCode != activeCaseLoadId) {
+      throw CaseloadAccessException()
+    }
+  }
+}
+
+class CaseloadAccessException : RuntimeException()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/UserService.kt
@@ -40,11 +40,12 @@ class UserService(private val manageUsersClient: ManageUsersClient) {
         userType = userType,
         name = userDetails.name,
         email = if (username.isEmail()) username.lowercase() else manageUsersClient.getUsersEmail(username)?.email?.lowercase(),
+        activeCaseLoadId = userDetails.activeCaseLoadId?.takeIf { userType == UserType.PRISON },
       )
     }
 }
 
-data class User(val username: String, private val userType: UserType, val name: String, val email: String? = null) {
+data class User(val username: String, private val userType: UserType, val name: String, val email: String? = null, val activeCaseLoadId: String? = null) {
   fun isUserType(vararg types: UserType) = types.contains(userType)
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -13,6 +13,8 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import java.time.LocalDate
 import java.time.LocalTime
 
+val courtAppealReferenceCode = ReferenceCode(1, "COURT_HEARING_TYPE", "APPEAL", "Appeal", "TEST")
+
 fun court(code: String = DERBY_JUSTICE_CENTRE, enabled: Boolean = true) = Court(
   courtId = 0,
   code = code,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -34,6 +34,7 @@ val courtUser = user(userType = UserType.EXTERNAL, name = "Court User", email = 
 val prisonUser = user(userType = UserType.PRISON, name = "Prison User", email = "prison.user@prison.com")
 val probationUser = user(userType = UserType.EXTERNAL, name = "Probation User", email = "probation.user@probation.com")
 val serviceUser = user(userType = UserType.SERVICE, name = "service user")
+val externalUser = user(userType = UserType.EXTERNAL, name = "External User", email = "external.user@external.com")
 
 fun location(prisonCode: String, locationKeySuffix: String, active: Boolean = true, localName: String? = null) = Location(
   id = UUID.randomUUID(),
@@ -74,13 +75,14 @@ fun prisonerSearchPrisoner(
 
 fun userEmailAddress(username: String, email: String, verified: Boolean = true) = EmailAddressDto(username, verified, email)
 
-fun userDetails(username: String, name: String = "Test User", authSource: AuthSource = AuthSource.auth) =
+fun userDetails(username: String, name: String = "Test User", authSource: AuthSource = AuthSource.auth, activeCaseLoadId: String? = null) =
   UserDetailsDto(
     userId = "TEST",
     username = username,
     active = true,
     name = name,
     authSource = authSource,
+    activeCaseLoadId = activeCaseLoadId,
   )
 
 fun user(username: String = "user", userType: UserType = UserType.EXTERNAL, name: String = "Test User", email: String? = null) =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
@@ -229,7 +229,7 @@ class VideoLinkBookingControllerTest {
       requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(prisonUser.copy(activeCaseLoadId = RISLEY), LocalDateTime.now()))
     }
       .andExpect {
-        status { isForbidden() }
+        status { isNotFound() }
       }.andReturn()
 
     response.resolvedException isInstanceOf CaseloadAccessException::class.java

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
@@ -5,12 +5,15 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithMockUser
@@ -19,18 +22,36 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.context.web.WebAppConfiguration
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.BvlsRequestContext
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.HmppsBookAVideoLinkApiExceptionHandler
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.contains
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtAppealReferenceCode
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.externalUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isInstanceOf
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.moorlandLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.user
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ReferenceCodeRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security.CaseloadAccessException
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingFacade
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.RequestBookingService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.VideoLinkBookingsService
 import uk.gov.justice.hmpps.kotlin.auth.HmppsResourceServerConfiguration
 import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.Optional
 
 /**
  * As a general guideline we primarily test controllers in integration tests. This is an exception due to wanting to get
@@ -38,11 +59,12 @@ import java.time.LocalDateTime
  */
 @ExtendWith(SpringExtension::class)
 @AutoConfigureMockMvc
-@Import(HmppsResourceServerConfiguration::class)
+@Import(HmppsResourceServerConfiguration::class, HmppsBookAVideoLinkApiExceptionHandler::class)
 @ActiveProfiles("test")
 @WebAppConfiguration
 @WebMvcTest(controllers = [VideoLinkBookingController::class])
 @ContextConfiguration(classes = [VideoLinkBookingController::class])
+@WithMockUser(roles = ["BOOK_A_VIDEO_LINK_ADMIN"])
 class VideoLinkBookingControllerTest {
 
   @MockBean
@@ -51,8 +73,17 @@ class VideoLinkBookingControllerTest {
   @MockBean
   private lateinit var requestBookingService: RequestBookingService
 
-  @MockBean
+  @SpyBean
   private lateinit var videoLinkBookingsService: VideoLinkBookingsService
+
+  @MockBean
+  private lateinit var videoBookingRepository: VideoBookingRepository
+
+  @MockBean
+  private lateinit var referenceCodeRepository: ReferenceCodeRepository
+
+  @MockBean
+  private lateinit var videoAppointmentRepository: VideoAppointmentRepository
 
   @Autowired
   private lateinit var context: WebApplicationContext
@@ -61,6 +92,17 @@ class VideoLinkBookingControllerTest {
 
   private lateinit var mockMvc: MockMvc
 
+  private val moorlandPrisonCourtBooking = courtBooking()
+    .addAppointment(
+      prisonCode = MOORLAND,
+      prisonerNumber = "ABCDEF",
+      appointmentType = AppointmentType.VLB_COURT_MAIN.name,
+      locationKey = moorlandLocation.key,
+      date = tomorrow(),
+      startTime = LocalTime.MIDNIGHT.plusHours(1),
+      endTime = LocalTime.MIDNIGHT.plusHours(2),
+    )
+
   @BeforeEach
   fun before() {
     mockMvc = MockMvcBuilders
@@ -68,7 +110,6 @@ class VideoLinkBookingControllerTest {
       .build()
   }
 
-  @WithMockUser(username = "FRED", roles = ["BOOK_A_VIDEO_LINK_ADMIN"])
   @Test
   fun `should fail to accept invalid appointment date provided when date leniency is disabled in configuration`() {
     val json = """
@@ -110,7 +151,6 @@ class VideoLinkBookingControllerTest {
     verifyNoInteractions(bookingFacade)
   }
 
-  @WithMockUser(username = "FRED", roles = ["BOOK_A_VIDEO_LINK_ADMIN"])
   @Test
   fun `should succeed when valid appointment date provided`() {
     val json = """
@@ -148,5 +188,50 @@ class VideoLinkBookingControllerTest {
       }
 
     verify(bookingFacade).create(objectMapper.readValue(json, CreateVideoBookingRequest::class.java), user())
+  }
+
+  @Test
+  fun `should get Moorland prison court video booking for external user`() {
+    whenever(videoBookingRepository.findById(1)) doReturn Optional.of(moorlandPrisonCourtBooking)
+    whenever(referenceCodeRepository.findByGroupCodeAndCode("COURT_HEARING_TYPE", moorlandPrisonCourtBooking.hearingType!!)) doReturn courtAppealReferenceCode
+
+    mockMvc.get("/video-link-booking/id/1") {
+      contentType = MediaType.APPLICATION_JSON
+      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(externalUser, LocalDateTime.now()))
+    }
+      .andExpect {
+        status { isOk() }
+      }
+  }
+
+  @WithMockUser(roles = ["BOOK_A_VIDEO_LINK_ADMIN"])
+  @Test
+  fun `should get Moorland prison court video booking for Moorland prison user`() {
+    whenever(videoBookingRepository.findById(1)) doReturn Optional.of(moorlandPrisonCourtBooking)
+    whenever(referenceCodeRepository.findByGroupCodeAndCode("COURT_HEARING_TYPE", moorlandPrisonCourtBooking.hearingType!!)) doReturn courtAppealReferenceCode
+
+    mockMvc.get("/video-link-booking/id/1") {
+      contentType = MediaType.APPLICATION_JSON
+      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(prisonUser.copy(activeCaseLoadId = MOORLAND), LocalDateTime.now()))
+    }
+      .andExpect {
+        status { isOk() }
+      }
+  }
+
+  @Test
+  fun `should fail to get Moorland prison court video booking for Risley prison user`() {
+    whenever(videoBookingRepository.findById(1)) doReturn Optional.of(moorlandPrisonCourtBooking)
+    whenever(referenceCodeRepository.findByGroupCodeAndCode("COURT_HEARING_TYPE", moorlandPrisonCourtBooking.hearingType!!)) doReturn courtAppealReferenceCode
+
+    val response = mockMvc.get("/video-link-booking/id/1") {
+      contentType = MediaType.APPLICATION_JSON
+      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(prisonUser.copy(activeCaseLoadId = RISLEY), LocalDateTime.now()))
+    }
+      .andExpect {
+        status { isForbidden() }
+      }.andReturn()
+
+    response.resolvedException isInstanceOf CaseloadAccessException::class.java
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/CaseloadAccessKtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/CaseloadAccessKtTest.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.springframework.web.context.request.RequestContextHolder
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.externalUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isNotEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonUser
+
+class CaseloadAccessKtTest {
+
+  @BeforeEach
+  fun before() {
+    RequestContextHolder.resetRequestAttributes()
+  }
+
+  @Test
+  fun `should fail caseload check when missing request attributes`() {
+    RequestContextHolder.getRequestAttributes() isEqualTo null
+
+    val error = assertThrows<NullPointerException> { checkCaseLoadAccess("DONT_CARE") }
+
+    error.message isEqualTo "Unable to determine user from request context."
+  }
+
+  @Test
+  fun `should fail caseload check when does not match that of prison user`() {
+    addUserToRequestForCaseloadCheck(prisonUser.copy(activeCaseLoadId = "THIS"))
+
+    RequestContextHolder.getRequestAttributes() isNotEqualTo null
+
+    assertThrows<CaseloadAccessException> { checkCaseLoadAccess("THAT") }
+  }
+
+  @Test
+  fun `should succeed caseload check when does match that of prison user`() {
+    addUserToRequestForCaseloadCheck(prisonUser.copy(activeCaseLoadId = "MATCH"))
+
+    RequestContextHolder.getRequestAttributes() isNotEqualTo null
+
+    assertDoesNotThrow { checkCaseLoadAccess("MATCH") }
+  }
+
+  @Test
+  fun `should succeed caseload check when user is external user`() {
+    addUserToRequestForCaseloadCheck(externalUser)
+
+    RequestContextHolder.getRequestAttributes() isNotEqualTo null
+
+    assertDoesNotThrow { checkCaseLoadAccess("DONT_CARE") }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/MockUserAndCaseload.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/MockUserAndCaseload.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security
+
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.BvlsRequestContext
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
+
+fun addUserToRequestForCaseloadCheck(user: User) {
+  val mockRequest = MockHttpServletRequest()
+  mockRequest.setAttribute(BvlsRequestContext::class.simpleName!!, BvlsRequestContext(user))
+  RequestContextHolder.setRequestAttributes(ServletRequestAttributes(mockRequest))
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/UserServiceTest.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.security.access.AccessDeniedException
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.manageusers.ManageUsersClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.manageusers.model.UserDetailsDto.AuthSource
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.userDetails
@@ -42,44 +43,32 @@ class UserServiceTest {
 
   @Test
   fun `getUser should return user with PRISON type when authSource is nomis`() {
-    val username = "testUser"
-    whenever(manageUsersClient.getUsersDetails(username)) doReturn userDetails(username, "Test User", authSource = AuthSource.nomis)
+    whenever(manageUsersClient.getUsersDetails("testUser")) doReturn userDetails("testUser", "Test User", authSource = AuthSource.nomis, activeCaseLoadId = BIRMINGHAM)
 
-    with(userService.getUser(username)!!) {
-      username isEqualTo "testUser"
-      isUserType(UserType.PRISON) isBool true
-      name isEqualTo "Test User"
-    }
+    userService.getUser("testUser") isEqualTo User(username = "testUser", userType = UserType.PRISON, name = "Test User", activeCaseLoadId = BIRMINGHAM)
   }
 
   @Test
   fun `getUser should return user with EXTERNAL type when authSource is auth`() {
-    val username = "testUser"
-    whenever(manageUsersClient.getUsersDetails(username)) doReturn userDetails(username, "Test User", authSource = AuthSource.auth)
+    whenever(manageUsersClient.getUsersDetails("testUser")) doReturn userDetails("testUser", "Test User", authSource = AuthSource.auth, activeCaseLoadId = BIRMINGHAM)
 
-    with(userService.getUser(username)!!) {
-      username isEqualTo "testUser"
-      isUserType(UserType.EXTERNAL) isBool true
-      name isEqualTo "Test User"
-    }
+    userService.getUser("testUser") isEqualTo User(username = "testUser", userType = UserType.EXTERNAL, name = "Test User")
   }
 
   @Test
   fun `getUser should throw AccessDeniedException for unsupported authSource`() {
-    val username = "testUser"
-    whenever(manageUsersClient.getUsersDetails(username)) doReturn userDetails(username, "Test User", authSource = AuthSource.delius)
+    whenever(manageUsersClient.getUsersDetails("testUser")) doReturn userDetails("testUser", "Test User", authSource = AuthSource.delius)
 
-    val exception = assertThrows<AccessDeniedException> { userService.getUser(username) }
+    val exception = assertThrows<AccessDeniedException> { userService.getUser("testUser") }
 
     exception.message isEqualTo "Users with auth source delius are not supported by this service"
   }
 
   @Test
   fun `getUser should return null when the user is not found`() {
-    val username = "testUser"
-    whenever(manageUsersClient.getUsersDetails(username)) doReturn null
+    whenever(manageUsersClient.getUsersDetails("testUser")) doReturn null
 
-    userService.getUser(username) isEqualTo null
+    userService.getUser("testUser") isEqualTo null
   }
 
   @Test
@@ -93,7 +82,7 @@ class UserServiceTest {
   @Test
   fun `getUser should set email from manageUsersClient when username is not an email`() {
     val username = "testUser"
-    whenever(manageUsersClient.getUsersDetails(username)) doReturn userDetails(username, "Test User")
+    whenever(manageUsersClient.getUsersDetails("testUser")) doReturn userDetails(username, "Test User")
     whenever(manageUsersClient.getUsersEmail(username)) doReturn userEmailAddress(username, "test@example.com")
 
     userService.getUser(username)?.email isEqualTo "test@example.com"


### PR DESCRIPTION
Changes to limit access when getting bookings for prison users.

Access is forbidden if the prison users active caseload does not match the prison code for the booking.  Will return a 404 not a 403.