### PR TITLE
BAVL-280 restrict access to create bookings for prison users enforced by their active caseload.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.CourtRepos
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security.checkCaseLoadAccess
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toPrisonerDetails
 
 @Service
@@ -39,6 +40,8 @@ class CreateVideoBookingService(
     }
 
   private fun createCourt(request: CreateVideoBookingRequest, createdBy: User): Pair<VideoBooking, Prisoner> {
+    checkCaseLoadAccess(request.prisoner().prisonCode!!)
+
     val court = courtRepository.findByCode(request.courtCode!!)
       ?.also { if (!createdBy.isUserType(UserType.PRISON)) require(it.enabled) { "Court with code ${it.code} is not enabled" } }
       ?: throw EntityNotFoundException("Court with code ${request.courtCode} not found")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -30,12 +30,6 @@ val moorlandLocation = location(prisonCode = MOORLAND, locationKeySuffix = "ABCE
 val werringtonLocation = location(prisonCode = WERRINGTON, locationKeySuffix = "ABCDEFG")
 val norwichLocation = location(prisonCode = NORWICH, locationKeySuffix = "ABCDEFG")
 
-val courtUser = user(userType = UserType.EXTERNAL, name = "Court User", email = "court.user@court.com")
-val prisonUser = user(userType = UserType.PRISON, name = "Prison User", email = "prison.user@prison.com")
-val probationUser = user(userType = UserType.EXTERNAL, name = "Probation User", email = "probation.user@probation.com")
-val serviceUser = user(userType = UserType.SERVICE, name = "service user")
-val externalUser = user(userType = UserType.EXTERNAL, name = "External User", email = "external.user@external.com")
-
 fun location(prisonCode: String, locationKeySuffix: String, active: Boolean = true, localName: String? = null) = Location(
   id = UUID.randomUUID(),
   prisonId = prisonCode,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/Users.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/Users.kt
@@ -2,5 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper
 
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserType
 
-val EXTERNAL_USER = user("TEST USER")
-val PRISON_USER = user(username = "PRISON USER", userType = UserType.PRISON)
+val COURT_USER = user(username = "court_user", userType = UserType.EXTERNAL, name = "Court User", email = "court.user@court.com")
+val EXTERNAL_USER = user(username = "external_user", userType = UserType.EXTERNAL, name = "External User", email = "external.user@external.com")
+val PRISON_USER = user(username = "prison_user", userType = UserType.PRISON, name = "Prison User", email = "prison.user@prison.com")
+val PROBATION_USER = user(username = "probation_user", userType = UserType.EXTERNAL, name = "Probation User", email = "probation.user@probation.com")
+val SERVICE_USER = user(username = "service_user", userType = UserType.SERVICE, name = "service user")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/BookingContactsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/BookingContactsResourceIntegrationTest.kt
@@ -8,6 +8,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ContactType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.EXTERNAL_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WERRINGTON
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
@@ -17,7 +18,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.moorlandLocati
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.werringtonLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.TEST_EXTERNAL_USER_EMAIL
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.BookingContact
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
@@ -59,7 +59,7 @@ class BookingContactsResourceIntegrationTest : IntegrationTestBase() {
     assertThat(listOfContacts).extracting("contactType").contains(ContactType.USER)
     assertThat(listOfContacts).extracting("contactType").doesNotContain(ContactType.PROBATION)
     assertThat(listOfContacts).hasSize(7)
-    assertThat(listOfContacts).extracting("email").containsAll(listOf("m@m.com", "t@t.com", "s@s.com", TEST_EXTERNAL_USER_EMAIL))
+    assertThat(listOfContacts).extracting("email").containsAll(listOf("m@m.com", "t@t.com", "s@s.com", EXTERNAL_USER.email!!))
   }
 
   @Test
@@ -92,7 +92,7 @@ class BookingContactsResourceIntegrationTest : IntegrationTestBase() {
     assertThat(listOfContacts).extracting("contactType").contains(ContactType.USER)
     assertThat(listOfContacts).extracting("contactType").doesNotContain(ContactType.COURT)
     assertThat(listOfContacts).hasSize(7)
-    assertThat(listOfContacts).extracting("email").containsAll(listOf("m@m.com", "t@t.com", "s@s.com", TEST_EXTERNAL_USER_EMAIL))
+    assertThat(listOfContacts).extracting("email").containsAll(listOf("m@m.com", "t@t.com", "s@s.com", EXTERNAL_USER.email!!))
   }
 
   @Test
@@ -189,13 +189,13 @@ class BookingContactsResourceIntegrationTest : IntegrationTestBase() {
 
     // Check that the contact addresses are present
     assertThat(listOfContacts).extracting("email").containsAll(
-      listOf("m@m.com", "t@t.com", "s@s.com", TEST_EXTERNAL_USER_EMAIL),
+      listOf("m@m.com", "t@t.com", "s@s.com", EXTERNAL_USER.email!!),
     )
 
     // Check the user email and name are as expected
     val userObject = listOfContacts.find { it.contactType == ContactType.USER }
-    assertThat(userObject?.email).isEqualTo(TEST_EXTERNAL_USER_EMAIL)
-    assertThat(userObject?.name).isEqualTo("Test Users Name")
+    assertThat(userObject?.email).isEqualTo(EXTERNAL_USER.email!!)
+    assertThat(userObject?.name).isEqualTo(EXTERNAL_USER.name)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CourtsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CourtsResourceIntegrationTest.kt
@@ -7,11 +7,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.EXTERNAL_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.TEST_EXTERNAL_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.SetCourtPreferencesRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.SetCourtPreferencesResponse
@@ -121,7 +121,7 @@ class CourtsResourceIntegrationTest : IntegrationTestBase() {
       .expectBodyList(Court::class.java)
       .returnResult().responseBody!!
 
-  private fun WebTestClient.getUserPreferenceCourts(username: String = TEST_EXTERNAL_USER) =
+  private fun WebTestClient.getUserPreferenceCourts(username: String = EXTERNAL_USER.username) =
     get()
       .uri("/courts/user-preferences")
       .accept(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationTeamsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationTeamsResourceIntegrationTest.kt
@@ -7,11 +7,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.EXTERNAL_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.TEST_EXTERNAL_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.ProbationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.SetProbationTeamPreferencesRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.SetProbationTeamPreferencesResponse
@@ -119,7 +119,7 @@ class ProbationTeamsResourceIntegrationTest : IntegrationTestBase() {
       .expectBodyList(ProbationTeam::class.java)
       .returnResult().responseBody!!
 
-  private fun WebTestClient.getUserPreferenceTeams(username: String = TEST_EXTERNAL_USER) =
+  private fun WebTestClient.getUserPreferenceTeams(username: String = EXTERNAL_USER.username) =
     get()
       .uri("/probation-teams/user-preferences")
       .accept(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/HmppsAuthMockServer.kt
@@ -10,11 +10,6 @@ import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 
-const val TEST_EXTERNAL_USER = "external_user"
-const val TEST_EXTERNAL_USER_EMAIL = "user@external.com"
-const val TEST_PRISON_USER = "prison_user"
-const val TEST_PRISON_USER_EMAIL = "user@prison.com"
-
 class HmppsAuthMockServer : MockServer(8090, "/auth") {
 
   fun stubGrantToken() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ManageUsersApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ManageUsersApiMockServer.kt
@@ -7,25 +7,26 @@ import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.manageusers.model.UserDetailsDto.AuthSource
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.EXTERNAL_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.userDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.userEmailAddress
 import java.net.URLEncoder
 
 class ManageUsersApiMockServer : MockServer(8093) {
 
-  fun stubGetUserDetails(username: String = TEST_EXTERNAL_USER, authSource: AuthSource = AuthSource.auth, name: String) {
+  fun stubGetUserDetails(username: String = EXTERNAL_USER.username, authSource: AuthSource = AuthSource.auth, name: String, activeCaseload: String? = null) {
     stubFor(
       get("/users/${username.urlEncode()}")
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
-            .withBody(mapper.writeValueAsString(userDetails(username, name, authSource)))
+            .withBody(mapper.writeValueAsString(userDetails(username, name, authSource, activeCaseload)))
             .withStatus(200),
         ),
     )
   }
 
-  fun stubGetUserEmail(username: String = TEST_EXTERNAL_USER, email: String = TEST_EXTERNAL_USER_EMAIL, verified: Boolean = true) {
+  fun stubGetUserEmail(username: String = EXTERNAL_USER.username, email: String = EXTERNAL_USER.email!!, verified: Boolean = true) {
     stubFor(
       get("/users/${username.urlEncode()}/email?unverified=false")
         .willReturn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
@@ -28,15 +28,15 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.BvlsRequestContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.HmppsBookAVideoLinkApiExceptionHandler
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.EXTERNAL_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.contains
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtAppealReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.externalUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isInstanceOf
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.moorlandLocation
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.user
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
@@ -197,7 +197,7 @@ class VideoLinkBookingControllerTest {
 
     mockMvc.get("/video-link-booking/id/1") {
       contentType = MediaType.APPLICATION_JSON
-      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(externalUser, LocalDateTime.now()))
+      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(EXTERNAL_USER, LocalDateTime.now()))
     }
       .andExpect {
         status { isOk() }
@@ -212,7 +212,7 @@ class VideoLinkBookingControllerTest {
 
     mockMvc.get("/video-link-booking/id/1") {
       contentType = MediaType.APPLICATION_JSON
-      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(prisonUser.copy(activeCaseLoadId = MOORLAND), LocalDateTime.now()))
+      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(PRISON_USER.copy(activeCaseLoadId = MOORLAND), LocalDateTime.now()))
     }
       .andExpect {
         status { isOk() }
@@ -226,7 +226,7 @@ class VideoLinkBookingControllerTest {
 
     val response = mockMvc.get("/video-link-booking/id/1") {
       contentType = MediaType.APPLICATION_JSON
-      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(prisonUser.copy(activeCaseLoadId = RISLEY), LocalDateTime.now()))
+      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(PRISON_USER.copy(activeCaseLoadId = RISLEY), LocalDateTime.now()))
     }
       .andExpect {
         status { isNotFound() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/CaseloadAccessKtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/CaseloadAccessKtTest.kt
@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.springframework.web.context.request.RequestContextHolder
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.externalUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.EXTERNAL_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isNotEqualTo
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonUser
 
 class CaseloadAccessKtTest {
 
@@ -28,7 +28,7 @@ class CaseloadAccessKtTest {
 
   @Test
   fun `should fail caseload check when does not match that of prison user`() {
-    addUserToRequestForCaseloadCheck(prisonUser.copy(activeCaseLoadId = "THIS"))
+    addUserToRequestForCaseloadCheck(PRISON_USER.copy(activeCaseLoadId = "THIS"))
 
     RequestContextHolder.getRequestAttributes() isNotEqualTo null
 
@@ -37,7 +37,7 @@ class CaseloadAccessKtTest {
 
   @Test
   fun `should succeed caseload check when does match that of prison user`() {
-    addUserToRequestForCaseloadCheck(prisonUser.copy(activeCaseLoadId = "MATCH"))
+    addUserToRequestForCaseloadCheck(PRISON_USER.copy(activeCaseLoadId = "MATCH"))
 
     RequestContextHolder.getRequestAttributes() isNotEqualTo null
 
@@ -46,7 +46,7 @@ class CaseloadAccessKtTest {
 
   @Test
   fun `should succeed caseload check when user is external user`() {
-    addUserToRequestForCaseloadCheck(externalUser)
+    addUserToRequestForCaseloadCheck(EXTERNAL_USER)
 
     RequestContextHolder.getRequestAttributes() isNotEqualTo null
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsServiceTest.kt
@@ -12,13 +12,13 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_CENTRE
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.EXTERNAL_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.externalUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.moorlandLocation
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.videoAppointment
@@ -49,7 +49,7 @@ class VideoLinkBookingsServiceTest {
 
   @BeforeEach
   fun before() {
-    addUserToRequestForCaseloadCheck(externalUser)
+    addUserToRequestForCaseloadCheck(EXTERNAL_USER)
 
     val courtHearingTypeRefCode = ReferenceCode(
       referenceCodeId = 1L,
@@ -127,7 +127,7 @@ class VideoLinkBookingsServiceTest {
 
   @Test
   fun `should fail to get a Moorland court video link booking by ID for a Birmingham prison user`() {
-    addUserToRequestForCaseloadCheck(prisonUser.copy(activeCaseLoadId = BIRMINGHAM))
+    addUserToRequestForCaseloadCheck(PRISON_USER.copy(activeCaseLoadId = BIRMINGHAM))
 
     val courtBookingAtMoorlandPrison = courtBooking(createdBy = "test_user")
       .addAppointment(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactoryTest.kt
@@ -6,10 +6,10 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ContactType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.bookingContact
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isInstanceOf
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.moorlandLocation
@@ -104,7 +104,7 @@ class CourtEmailFactoryTest {
       action = action,
       contact = userBookingContact,
       prisoner = prisoner,
-      booking = if (action == BookingAction.CANCEL) courtBooking.cancel(courtUser) else courtBooking,
+      booking = if (action == BookingAction.CANCEL) courtBooking.cancel(COURT_USER) else courtBooking,
       prison = prison,
       pre = null,
       main = courtBooking.appointments().single(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmailFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmailFactoryTest.kt
@@ -6,18 +6,18 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ContactType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.bookingContact
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isInstanceOf
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.moorlandLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingAction
 import java.time.LocalDate
 import java.time.LocalTime
@@ -124,7 +124,7 @@ class ProbationEmailFactoryTest {
       action = action,
       contact = userBookingContact,
       prisoner = prisoner,
-      booking = if (action == BookingAction.CANCEL) probationBooking.apply { cancel(courtUser) } else probationBooking,
+      booking = if (action == BookingAction.CANCEL) probationBooking.apply { cancel(COURT_USER) } else probationBooking,
       prison = prison,
       appointment = probationBooking.appointments().single(),
       location = moorlandLocation,
@@ -208,7 +208,7 @@ class ProbationEmailFactoryTest {
       action = action,
       contact = probationBookingContact,
       prisoner = prisoner,
-      booking = if (action == BookingAction.CANCEL || action == BookingAction.RELEASED || action == BookingAction.TRANSFERRED) probationBooking.apply { cancel(probationUser) } else probationBooking,
+      booking = if (action == BookingAction.CANCEL || action == BookingAction.RELEASED || action == BookingAction.TRANSFERRED) probationBooking.apply { cancel(PROBATION_USER) } else probationBooking,
       prison = prison,
       appointment = probationBooking.appointments().single(),
       location = moorlandLocation,
@@ -240,7 +240,7 @@ class ProbationEmailFactoryTest {
       action = action,
       contact = prisonBookingContact,
       prisoner = prisoner,
-      booking = if (action == BookingAction.CANCEL || action == BookingAction.RELEASED || action == BookingAction.TRANSFERRED) probationBooking.apply { cancel(probationUser) } else probationBooking,
+      booking = if (action == BookingAction.CANCEL || action == BookingAction.RELEASED || action == BookingAction.TRANSFERRED) probationBooking.apply { cancel(PROBATION_USER) } else probationBooking,
       prison = prison,
       appointment = probationBooking.appointments().single(),
       location = moorlandLocation,


### PR DESCRIPTION
Apologies this PR ballooned a little with some refactoring around use of users in the unit tests.

Essentially the core change prevents prison users from creating bookings not in their current active caseload.