### PR TITLE
BAVL-306 court email for court contact when booking amended by a prison user.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toMediumFormatStyle
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.GovNotifyEmailService
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingUserEmail
@@ -63,6 +64,7 @@ class EmailConfiguration(
   @Value("\${notify.templates.court.new-booking.prison-court-email:}") private val newCourtBookingPrisonCourtEmail: String,
   @Value("\${notify.templates.court.new-booking.prison-no-court-email:}") private val newCourtBookingPrisonNoCourtEmail: String,
   @Value("\${notify.templates.court.amended-booking.user:}") private val amendedCourtBookingUser: String,
+  @Value("\${notify.templates.court.amended-booking.court:}") private val amendedCourtBookingCourtEmail: String,
   @Value("\${notify.templates.court.amended-booking.prison-court-email:}") private val amendedCourtBookingPrisonCourtEmail: String,
   @Value("\${notify.templates.court.amended-booking.prison-no-court-email:}") private val amendedCourtBookingPrisonNoCourtEmail: String,
   @Value("\${notify.templates.court.cancelled-booking.user:}") private val cancelledCourtBookingUser: String,
@@ -117,6 +119,7 @@ class EmailConfiguration(
     newCourtBookingPrisonCourtEmail = newCourtBookingPrisonCourtEmail,
     newCourtBookingPrisonNoCourtEmail = newCourtBookingPrisonNoCourtEmail,
     amendedCourtBookingUser = amendedCourtBookingUser,
+    amendedCourtBookingCourtEmail = amendedCourtBookingCourtEmail,
     amendedCourtBookingPrisonCourtEmail = amendedCourtBookingPrisonCourtEmail,
     amendedCourtBookingPrisonNoCourtEmail = amendedCourtBookingPrisonNoCourtEmail,
     cancelledCourtBookingUser = cancelledCourtBookingUser,
@@ -190,6 +193,7 @@ data class EmailTemplates(
   val newCourtBookingPrisonCourtEmail: String,
   val newCourtBookingPrisonNoCourtEmail: String,
   val amendedCourtBookingUser: String,
+  val amendedCourtBookingCourtEmail: String,
   val amendedCourtBookingPrisonCourtEmail: String,
   val amendedCourtBookingPrisonNoCourtEmail: String,
   val cancelledCourtBookingUser: String,
@@ -232,6 +236,7 @@ data class EmailTemplates(
     NewCourtBookingPrisonCourtEmail::class.java to newCourtBookingPrisonCourtEmail,
     NewCourtBookingPrisonNoCourtEmail::class.java to newCourtBookingPrisonNoCourtEmail,
     AmendedCourtBookingUserEmail::class.java to amendedCourtBookingUser,
+    AmendedCourtBookingCourtEmail::class.java to amendedCourtBookingCourtEmail,
     AmendedCourtBookingPrisonCourtEmail::class.java to amendedCourtBookingPrisonCourtEmail,
     AmendedCourtBookingPrisonNoCourtEmail::class.java to amendedCourtBookingPrisonNoCourtEmail,
     CancelledCourtBookingUserEmail::class.java to cancelledCourtBookingUser,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactory.kt
@@ -115,39 +115,62 @@ object CourtEmailFactory {
         comments = booking.comments,
       )
 
-      BookingAction.AMEND -> null // TODO: Inform court when the prison amends a booking
-
-      BookingAction.CANCEL -> null // TODO: Inform court when the prison cancels a booking
-
-      BookingAction.RELEASED -> ReleasedCourtBookingCourtEmail(
+      BookingAction.AMEND -> AmendedCourtBookingCourtEmail(
         address = contact.email!!,
-        court = booking.court!!.description,
-        prison = prison.name,
         prisonerFirstName = prisoner.firstName,
         prisonerLastName = prisoner.lastName,
-        dateOfBirth = prisoner.dateOfBirth,
         prisonerNumber = prisoner.prisonerNumber,
-        date = main.appointmentDate,
+        appointmentDate = main.appointmentDate,
+        court = booking.court!!.description,
+        prison = prison.name,
         preAppointmentInfo = pre?.appointmentInformation(locations),
         mainAppointmentInfo = main.appointmentInformation(locations),
         postAppointmentInfo = post?.appointmentInformation(locations),
         comments = booking.comments,
       )
 
-      BookingAction.TRANSFERRED -> TransferredCourtBookingCourtEmail(
-        address = contact.email!!,
-        court = booking.court!!.description,
-        prison = prison.name,
-        prisonerFirstName = prisoner.firstName,
-        prisonerLastName = prisoner.lastName,
-        dateOfBirth = prisoner.dateOfBirth,
-        prisonerNumber = prisoner.prisonerNumber,
-        date = main.appointmentDate,
-        preAppointmentInfo = pre?.appointmentInformation(locations),
-        mainAppointmentInfo = main.appointmentInformation(locations),
-        postAppointmentInfo = post?.appointmentInformation(locations),
-        comments = booking.comments,
-      )
+      BookingAction.CANCEL -> {
+        // TODO: Inform court when the prison cancels a booking
+        null
+      }
+
+      BookingAction.RELEASED -> {
+        booking.requireIsCancelled()
+
+        ReleasedCourtBookingCourtEmail(
+          address = contact.email!!,
+          court = booking.court!!.description,
+          prison = prison.name,
+          prisonerFirstName = prisoner.firstName,
+          prisonerLastName = prisoner.lastName,
+          dateOfBirth = prisoner.dateOfBirth,
+          prisonerNumber = prisoner.prisonerNumber,
+          date = main.appointmentDate,
+          preAppointmentInfo = pre?.appointmentInformation(locations),
+          mainAppointmentInfo = main.appointmentInformation(locations),
+          postAppointmentInfo = post?.appointmentInformation(locations),
+          comments = booking.comments,
+        )
+      }
+
+      BookingAction.TRANSFERRED -> {
+        booking.requireIsCancelled()
+
+        TransferredCourtBookingCourtEmail(
+          address = contact.email!!,
+          court = booking.court!!.description,
+          prison = prison.name,
+          prisonerFirstName = prisoner.firstName,
+          prisonerLastName = prisoner.lastName,
+          dateOfBirth = prisoner.dateOfBirth,
+          prisonerNumber = prisoner.prisonerNumber,
+          date = main.appointmentDate,
+          preAppointmentInfo = pre?.appointmentInformation(locations),
+          mainAppointmentInfo = main.appointmentInformation(locations),
+          postAppointmentInfo = post?.appointmentInformation(locations),
+          comments = booking.comments,
+        )
+      }
     }
   }
 
@@ -273,7 +296,9 @@ object CourtEmailFactory {
         }
       }
 
-      BookingAction.RELEASED ->
+      BookingAction.RELEASED -> {
+        booking.requireIsCancelled()
+
         if (primaryCourtContact != null) {
           // Note: primary contact is only used to determine which template to use, it is not used in the template.
           ReleasedCourtBookingPrisonCourtEmail(
@@ -306,8 +331,11 @@ object CourtEmailFactory {
             comments = booking.comments,
           )
         }
+      }
 
-      BookingAction.TRANSFERRED ->
+      BookingAction.TRANSFERRED -> {
+        booking.requireIsCancelled()
+
         // Note: primary contact is only used to determine which template to use, it is not used in the template.
         if (primaryCourtContact != null) {
           TransferredCourtBookingPrisonCourtEmail(
@@ -340,6 +368,7 @@ object CourtEmailFactory {
             comments = booking.comments,
           )
         }
+      }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmails.kt
@@ -167,6 +167,32 @@ class AmendedCourtBookingUserEmail(
   comments = comments,
 )
 
+class AmendedCourtBookingCourtEmail(
+  address: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  prisonerNumber: String,
+  appointmentDate: LocalDate = LocalDate.now(),
+  court: String,
+  prison: String,
+  preAppointmentInfo: String?,
+  mainAppointmentInfo: String,
+  postAppointmentInfo: String?,
+  comments: String?,
+) : CourtEmail(
+  address = address,
+  prisonerFirstName = prisonerFirstName,
+  prisonerLastName = prisonerLastName,
+  prisonerNumber = prisonerNumber,
+  appointmentDate = appointmentDate,
+  court = court,
+  prison = prison,
+  preAppointmentInfo = preAppointmentInfo,
+  mainAppointmentInfo = mainAppointmentInfo,
+  postAppointmentInfo = postAppointmentInfo,
+  comments = comments,
+)
+
 class AmendedCourtBookingPrisonCourtEmail(
   address: String,
   prisonerFirstName: String,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -119,6 +119,7 @@ notify:
         prison-no-court-email: "d555929e-c8a5-4771-911b-4538ba259eba"
       amended-booking:
         user: "443760a3-e644-4228-8c60-ecb76fb39664"
+        court: "9507f9ee-670d-4715-b2ad-62eaa945e25b"
         prison-court-email: "9edef9a6-df69-462a-995c-010c2b4f2cbf"
         prison-no-court-email: "d756d798-bf1b-4651-85e5-6f42c741e33b"
       cancelled-booking:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailTemplatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailTemplatesTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingUserEmail
@@ -51,6 +52,7 @@ class EmailTemplatesTest {
     NewCourtBookingPrisonCourtEmail::class.java to "newCourtBookingPrisonCourtEmail",
     NewCourtBookingPrisonNoCourtEmail::class.java to "newCourtBookingPrisonNoCourtEmail",
     AmendedCourtBookingUserEmail::class.java to "amendedCourtBookingUser",
+    AmendedCourtBookingCourtEmail::class.java to "amendedCourtBookingCourtEmail",
     AmendedCourtBookingPrisonCourtEmail::class.java to "amendedCourtBookingPrisonCourtEmail",
     AmendedCourtBookingPrisonNoCourtEmail::class.java to "amendedCourtBookingPrisonNoCourtEmail",
     CancelledCourtBookingUserEmail::class.java to "cancelledCourtBookingUser",
@@ -93,6 +95,7 @@ class EmailTemplatesTest {
     newCourtBookingPrisonCourtEmail = "newCourtBookingPrisonCourtEmail",
     newCourtBookingPrisonNoCourtEmail = "newCourtBookingPrisonNoCourtEmail",
     amendedCourtBookingUser = "amendedCourtBookingUser",
+    amendedCourtBookingCourtEmail = "amendedCourtBookingCourtEmail",
     amendedCourtBookingPrisonCourtEmail = "amendedCourtBookingPrisonCourtEmail",
     amendedCourtBookingPrisonNoCourtEmail = "amendedCourtBookingPrisonNoCourtEmail",
     cancelledCourtBookingUser = "cancelledCourtBookingUser",
@@ -180,6 +183,7 @@ class EmailTemplatesTest {
       "11",
       "12",
       "13",
+      "14",
     )
 
     val error = assertThrows<IllegalArgumentException> {
@@ -221,6 +225,7 @@ class EmailTemplatesTest {
         "9",
         "10",
         "11",
+        "12",
         "duplicate",
         "duplicate",
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/SqsIntegrationTestBase.kt
@@ -49,7 +49,7 @@ abstract class SqsIntegrationTestBase : IntegrationTestBase() {
   }
 
   protected fun waitForMessagesOnQueue(numberOfMessages: Int) {
-    await untilCallTo { countAllMessagesOnQueue().also { println("number messages a q $it") } } matches { it == numberOfMessages }
+    await untilCallTo { countAllMessagesOnQueue().also { println("number messages on queue - $it") } } matches { it == numberOfMessages }
   }
 
   protected fun countAllMessagesOnQueue(): Int = eventsClient.countAllMessagesOnQueue(eventsQueue.queueUrl).get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -62,6 +62,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.Notificati
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingUserEmail
@@ -1652,6 +1653,7 @@ class TestEmailConfiguration {
         is NewCourtBookingPrisonCourtEmail -> Result.success(UUID.randomUUID() to "new court booking prison template id with email address")
         is NewCourtBookingPrisonNoCourtEmail -> Result.success(UUID.randomUUID() to "new court booking prison template id no email address")
         is AmendedCourtBookingUserEmail -> Result.success(UUID.randomUUID() to "amended court booking user template id")
+        is AmendedCourtBookingCourtEmail -> Result.success(UUID.randomUUID() to "amended court booking court template id")
         is AmendedCourtBookingPrisonCourtEmail -> Result.success(UUID.randomUUID() to "amended court booking prison template id with email address")
         is AmendedCourtBookingPrisonNoCourtEmail -> Result.success(UUID.randomUUID() to "amended court booking prison template id no email address")
         is CancelledCourtBookingUserEmail -> Result.success(UUID.randomUUID() to "cancelled court booking user template id")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/GovNotifyEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/GovNotifyEmailServiceTest.kt
@@ -48,6 +48,7 @@ class GovNotifyEmailServiceTest {
     newCourtBookingPrisonCourtEmail = "newCourtBookingPrisonCourtEmail",
     newCourtBookingPrisonNoCourtEmail = "newCourtBookingPrisonNoCourtEmail",
     amendedCourtBookingUser = "amendedCourtBookingUser",
+    amendedCourtBookingCourtEmail = "amendedCourtBookingCourtEmail",
     amendedCourtBookingPrisonCourtEmail = "amendedCourtBookingPrisonCourtEmail",
     amendedCourtBookingPrisonNoCourtEmail = "amendedCourtBookingPrisonNoCourtEmail",
     cancelledCourtBookingUser = "cancelledCourtBookingUser",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactoryTest.kt
@@ -80,9 +80,6 @@ class CourtEmailFactoryTest {
 
     @JvmStatic
     fun supportedCourtBookingActions() = setOf(BookingAction.CREATE, BookingAction.RELEASED, BookingAction.TRANSFERRED)
-
-    @JvmStatic
-    fun unsupportedCourtBookingActions() = setOf(BookingAction.AMEND, BookingAction.CANCEL)
   }
 
   private val userEmails = mapOf(
@@ -93,6 +90,7 @@ class CourtEmailFactoryTest {
 
   private val courtEmails = mapOf(
     BookingAction.CREATE to NewCourtBookingCourtEmail::class.java,
+    BookingAction.AMEND to AmendedCourtBookingCourtEmail::class.java,
     BookingAction.RELEASED to ReleasedCourtBookingCourtEmail::class.java,
     BookingAction.TRANSFERRED to TransferredCourtBookingCourtEmail::class.java,
   )
@@ -178,7 +176,7 @@ class CourtEmailFactoryTest {
       action = action,
       contact = courtBookingContact,
       prisoner = prisoner,
-      booking = courtBooking,
+      booking = if (action == BookingAction.RELEASED || action == BookingAction.TRANSFERRED) courtBooking.apply { cancel(COURT_USER) } else courtBooking,
       prison = prison,
       pre = null,
       main = courtBooking.appointments().single(),
@@ -187,24 +185,6 @@ class CourtEmailFactoryTest {
     )
 
     email isInstanceOf courtEmails[action]!!
-  }
-
-  @ParameterizedTest
-  @MethodSource("unsupportedCourtBookingActions")
-  fun `should return no email for unsupported court based actions`(action: BookingAction) {
-    val email = CourtEmailFactory.court(
-      action = action,
-      contact = courtBookingContact,
-      prisoner = prisoner,
-      booking = courtBooking,
-      prison = prison,
-      pre = null,
-      main = courtBooking.appointments().single(),
-      post = null,
-      locations = mapOf(moorlandLocation.key to moorlandLocation),
-    )
-
-    email isEqualTo null
   }
 
   @Test


### PR DESCRIPTION
This change adds another email to be sent to the court contact when a booking is amended by a prison user (in A&A).