### PR TITLE
BAVL-306 court email for court contact when booking cancelled by a prison user.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingUserEmail
@@ -68,6 +69,7 @@ class EmailConfiguration(
   @Value("\${notify.templates.court.amended-booking.prison-court-email:}") private val amendedCourtBookingPrisonCourtEmail: String,
   @Value("\${notify.templates.court.amended-booking.prison-no-court-email:}") private val amendedCourtBookingPrisonNoCourtEmail: String,
   @Value("\${notify.templates.court.cancelled-booking.user:}") private val cancelledCourtBookingUser: String,
+  @Value("\${notify.templates.court.cancelled-booking.court:}") private val cancelledCourtBookingCourtEmail: String,
   @Value("\${notify.templates.court.cancelled-booking.prison-court-email:}") private val cancelledCourtBookingPrisonCourtEmail: String,
   @Value("\${notify.templates.court.cancelled-booking.prison-no-court-email:}") private val cancelledCourtBookingPrisonNoCourtEmail: String,
   @Value("\${notify.templates.court.booking-request.user:}") private val courtBookingRequestUser: String,
@@ -154,6 +156,7 @@ class EmailConfiguration(
     transferProbationBookingProbation = transferProbationBookingProbation,
     transferProbationBookingPrisonProbationEmail = transferProbationBookingPrisonProbationEmail,
     transferProbationBookingPrisonNoProbationEmail = transferProbationBookingPrisonNoProbationEmail,
+    cancelledCourtBookingCourtEmail = cancelledCourtBookingCourtEmail,
   )
 }
 
@@ -197,6 +200,7 @@ data class EmailTemplates(
   val amendedCourtBookingPrisonCourtEmail: String,
   val amendedCourtBookingPrisonNoCourtEmail: String,
   val cancelledCourtBookingUser: String,
+  val cancelledCourtBookingCourtEmail: String,
   val cancelledCourtBookingPrisonCourtEmail: String,
   val cancelledCourtBookingPrisonNoCourtEmail: String,
   val courtBookingRequestUser: String,
@@ -240,6 +244,7 @@ data class EmailTemplates(
     AmendedCourtBookingPrisonCourtEmail::class.java to amendedCourtBookingPrisonCourtEmail,
     AmendedCourtBookingPrisonNoCourtEmail::class.java to amendedCourtBookingPrisonNoCourtEmail,
     CancelledCourtBookingUserEmail::class.java to cancelledCourtBookingUser,
+    CancelledCourtBookingCourtEmail::class.java to cancelledCourtBookingCourtEmail,
     CancelledCourtBookingPrisonCourtEmail::class.java to cancelledCourtBookingPrisonCourtEmail,
     CancelledCourtBookingPrisonNoCourtEmail::class.java to cancelledCourtBookingPrisonNoCourtEmail,
     CourtBookingRequestUserEmail::class.java to courtBookingRequestUser,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactory.kt
@@ -130,8 +130,21 @@ object CourtEmailFactory {
       )
 
       BookingAction.CANCEL -> {
-        // TODO: Inform court when the prison cancels a booking
-        null
+        booking.requireIsCancelled()
+
+        CancelledCourtBookingCourtEmail(
+          address = contact.email!!,
+          prisonerFirstName = prisoner.firstName,
+          prisonerLastName = prisoner.lastName,
+          prisonerNumber = prisoner.prisonerNumber,
+          appointmentDate = main.appointmentDate,
+          court = booking.court!!.description,
+          prison = prison.name,
+          preAppointmentInfo = pre?.appointmentInformation(locations),
+          mainAppointmentInfo = main.appointmentInformation(locations),
+          postAppointmentInfo = post?.appointmentInformation(locations),
+          comments = booking.comments,
+        )
       }
 
       BookingAction.RELEASED -> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmails.kt
@@ -275,6 +275,32 @@ class CancelledCourtBookingUserEmail(
   comments = comments,
 )
 
+class CancelledCourtBookingCourtEmail(
+  address: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  prisonerNumber: String,
+  appointmentDate: LocalDate = LocalDate.now(),
+  court: String,
+  prison: String,
+  preAppointmentInfo: String?,
+  mainAppointmentInfo: String,
+  postAppointmentInfo: String?,
+  comments: String?,
+) : CourtEmail(
+  address = address,
+  prisonerFirstName = prisonerFirstName,
+  prisonerLastName = prisonerLastName,
+  prisonerNumber = prisonerNumber,
+  appointmentDate = appointmentDate,
+  court = court,
+  prison = prison,
+  preAppointmentInfo = preAppointmentInfo,
+  mainAppointmentInfo = mainAppointmentInfo,
+  postAppointmentInfo = postAppointmentInfo,
+  comments = comments,
+)
+
 class CancelledCourtBookingPrisonCourtEmail(
   address: String,
   prisonerFirstName: String,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -124,6 +124,7 @@ notify:
         prison-no-court-email: "d756d798-bf1b-4651-85e5-6f42c741e33b"
       cancelled-booking:
         user: "946a129a-ed09-40ca-b0ac-a39ec6c1bc2b"
+        court: "cfac8ef0-dc03-403b-bf8b-bea6356561ff"
         prison-court-email: "9c80bb57-abed-4316-8404-cbdcd48b8f25"
         prison-no-court-email: "602981eb-cc7f-4a85-aba3-577167f1ee83"
       booking-request:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailTemplatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailTemplatesTest.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingUserEmail
@@ -56,6 +57,7 @@ class EmailTemplatesTest {
     AmendedCourtBookingPrisonCourtEmail::class.java to "amendedCourtBookingPrisonCourtEmail",
     AmendedCourtBookingPrisonNoCourtEmail::class.java to "amendedCourtBookingPrisonNoCourtEmail",
     CancelledCourtBookingUserEmail::class.java to "cancelledCourtBookingUser",
+    CancelledCourtBookingCourtEmail::class.java to "cancelledCourtBookingCourtEmail",
     CancelledCourtBookingPrisonCourtEmail::class.java to "cancelledCourtBookingPrisonCourtEmail",
     CancelledCourtBookingPrisonNoCourtEmail::class.java to "cancelledCourtBookingPrisonNoCourtEmail",
     CourtBookingRequestUserEmail::class.java to "courtBookingRequestUser",
@@ -99,6 +101,7 @@ class EmailTemplatesTest {
     amendedCourtBookingPrisonCourtEmail = "amendedCourtBookingPrisonCourtEmail",
     amendedCourtBookingPrisonNoCourtEmail = "amendedCourtBookingPrisonNoCourtEmail",
     cancelledCourtBookingUser = "cancelledCourtBookingUser",
+    cancelledCourtBookingCourtEmail = "cancelledCourtBookingCourtEmail",
     cancelledCourtBookingPrisonCourtEmail = "cancelledCourtBookingPrisonCourtEmail",
     cancelledCourtBookingPrisonNoCourtEmail = "cancelledCourtBookingPrisonNoCourtEmail",
     courtBookingRequestUser = "courtBookingRequestUser",
@@ -184,6 +187,7 @@ class EmailTemplatesTest {
       "12",
       "13",
       "14",
+      "15",
     )
 
     val error = assertThrows<IllegalArgumentException> {
@@ -226,6 +230,7 @@ class EmailTemplatesTest {
         "10",
         "11",
         "12",
+        "13",
         "duplicate",
         "duplicate",
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -66,6 +66,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingUserEmail
@@ -1657,6 +1658,7 @@ class TestEmailConfiguration {
         is AmendedCourtBookingPrisonCourtEmail -> Result.success(UUID.randomUUID() to "amended court booking prison template id with email address")
         is AmendedCourtBookingPrisonNoCourtEmail -> Result.success(UUID.randomUUID() to "amended court booking prison template id no email address")
         is CancelledCourtBookingUserEmail -> Result.success(UUID.randomUUID() to "cancelled court booking user template id")
+        is CancelledCourtBookingCourtEmail -> Result.success(UUID.randomUUID() to "cancelled court booking user template id")
         is CancelledCourtBookingPrisonCourtEmail -> Result.success(UUID.randomUUID() to "cancelled court booking prison template id with email address")
         is CancelledCourtBookingPrisonNoCourtEmail -> Result.success(UUID.randomUUID() to "cancelled court booking prison template id no email address")
         is CourtBookingRequestUserEmail -> Result.success(UUID.randomUUID() to "requested court booking user template id")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/GovNotifyEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/GovNotifyEmailServiceTest.kt
@@ -52,6 +52,7 @@ class GovNotifyEmailServiceTest {
     amendedCourtBookingPrisonCourtEmail = "amendedCourtBookingPrisonCourtEmail",
     amendedCourtBookingPrisonNoCourtEmail = "amendedCourtBookingPrisonNoCourtEmail",
     cancelledCourtBookingUser = "cancelledCourtBookingUser",
+    cancelledCourtBookingCourtEmail = "cancelledCourtBookingCourtEmail",
     cancelledCourtBookingPrisonCourtEmail = "cancelledCourtBookingPrisonCourtEmail",
     cancelledCourtBookingPrisonNoCourtEmail = "cancelledCourtBookingPrisonNoCourtEmail",
     courtBookingRequestUser = "courtBookingRequestUser",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactoryTest.kt
@@ -79,7 +79,7 @@ class CourtEmailFactoryTest {
     fun unsupportedUserBookingActions() = setOf(BookingAction.RELEASED, BookingAction.TRANSFERRED)
 
     @JvmStatic
-    fun supportedCourtBookingActions() = setOf(BookingAction.CREATE, BookingAction.RELEASED, BookingAction.TRANSFERRED)
+    fun supportedCourtBookingActions() = setOf(BookingAction.CREATE, BookingAction.CANCEL, BookingAction.RELEASED, BookingAction.TRANSFERRED)
   }
 
   private val userEmails = mapOf(
@@ -91,6 +91,7 @@ class CourtEmailFactoryTest {
   private val courtEmails = mapOf(
     BookingAction.CREATE to NewCourtBookingCourtEmail::class.java,
     BookingAction.AMEND to AmendedCourtBookingCourtEmail::class.java,
+    BookingAction.CANCEL to CancelledCourtBookingCourtEmail::class.java,
     BookingAction.RELEASED to ReleasedCourtBookingCourtEmail::class.java,
     BookingAction.TRANSFERRED to TransferredCourtBookingCourtEmail::class.java,
   )
@@ -176,7 +177,7 @@ class CourtEmailFactoryTest {
       action = action,
       contact = courtBookingContact,
       prisoner = prisoner,
-      booking = if (action == BookingAction.RELEASED || action == BookingAction.TRANSFERRED) courtBooking.apply { cancel(COURT_USER) } else courtBooking,
+      booking = if (action == BookingAction.CANCEL || action == BookingAction.RELEASED || action == BookingAction.TRANSFERRED) courtBooking.apply { cancel(COURT_USER) } else courtBooking,
       prison = prison,
       pre = null,
       main = courtBooking.appointments().single(),


### PR DESCRIPTION
This change adds another email to be sent to the court contact when a booking is cancelled by a prison user (in A&A).