### PR TITLE
BAVL-309 removing allowable values attribute from open api docs on enum, not needed.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/ScheduleItem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/ScheduleItem.kt
@@ -20,7 +20,7 @@ data class ScheduleItem(
   @Schema(description = "The booking type", example = "COURT")
   val bookingType: BookingType,
 
-  @Schema(description = "The booking status", allowableValues = ["ACTIVE", "CANCELLED"], example = "ACTIVE")
+  @Schema(description = "The booking status", example = "ACTIVE")
   val statusCode: BookingStatus,
 
   @Schema(description = "The video link URL to attend this event", example = "https://video.link.url")


### PR DESCRIPTION
Allowable values is not needed on enums types. Having allowable values on an enum causes the docs to double up when generated e.g.

![image](https://github.com/user-attachments/assets/d4ea2718-bbe8-43a8-a762-31f6c42229a8)
