### PR TITLE
BAVL-317 prevent changing of court and probation team, attributes are not updatable once created.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
@@ -30,13 +30,13 @@ class VideoBooking private constructor(
 
   @OneToOne
   @JoinColumn(name = "court_id")
-  var court: Court?,
+  val court: Court?,
 
   var hearingType: String?,
 
   @OneToOne
   @JoinColumn(name = "probation_team_id")
-  var probationTeam: ProbationTeam?,
+  val probationTeam: ProbationTeam?,
 
   var probationMeetingType: String?,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AmendVideoBookingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AmendVideoBookingRequest.kt
@@ -9,6 +9,12 @@ import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import java.net.URI
 
+@Schema(
+  description =
+  """
+  Amend an existing court or probation team meeting video link booking.
+  """,
+)
 data class AmendVideoBookingRequest(
 
   @field:NotNull(message = "The video link booking type is mandatory")
@@ -17,23 +23,31 @@ data class AmendVideoBookingRequest(
 
   @field:Valid
   @field:NotEmpty(message = "At least one prisoner must be supplied for a video link booking")
-  @Schema(description = "The prisoner or prisoners associated with the video link booking")
+  @Schema(
+    description = """
+    One or more prisoners associated with the video link booking.
+    
+    A probation booking should only ever have one prisoner whilst a court booking can have multiple e.g. for co-defendants.
+     
+    NOTE: CO-DEFENDANTS ARE NOT YET SUPPORTED BY THE SERVICE.
+  """,
+  )
   val prisoners: List<PrisonerDetails>,
-
-  @Schema(description = "The court code is needed if booking type is COURT, otherwise null. This cannot be changed by prison users.", example = "DRBYMC")
-  val courtCode: String? = null,
 
   @Schema(description = "The court hearing type is needed if booking type is COURT, otherwise null", example = "APPEAL")
   val courtHearingType: CourtHearingType? = null,
 
-  @Schema(description = "The probation team code is needed if booking type is PROBATION, otherwise null", example = "BLKPPP")
-  val probationTeamCode: String? = null,
-
-  @Schema(description = "The probation meeting type is needed if booking type is PROBATION, otherwise null", example = "PSR")
+  @Schema(
+    description = "The probation meeting type is needed if booking type is PROBATION, otherwise null",
+    example = "PSR",
+  )
   val probationMeetingType: ProbationMeetingType? = null,
 
   @field:Size(max = 400, message = "Comments for the video link booking cannot not exceed {max} characters")
-  @Schema(description = "Free text comments for the video link booking", example = "Waiting to hear on legal representation")
+  @Schema(
+    description = "Free text comments for the video link booking",
+    example = "Waiting to hear on legal representation",
+  )
   val comments: String?,
 
   @field:Size(max = 120, message = "The video link should not exceed {max} characters")
@@ -41,12 +55,12 @@ data class AmendVideoBookingRequest(
   val videoLinkUrl: String?,
 ) {
   @JsonIgnore
-  @AssertTrue(message = "The court code and court hearing type are mandatory for court bookings")
-  private fun isInvalidCourtBooking() = (BookingType.COURT != bookingType) || (courtCode != null && courtHearingType != null)
+  @AssertTrue(message = "The court hearing type is mandatory for court bookings")
+  private fun isInvalidCourtBooking() = (BookingType.COURT != bookingType) || (courtHearingType != null)
 
   @JsonIgnore
-  @AssertTrue(message = "The probation team code and probation meeting type are mandatory for probation bookings")
-  private fun isInvalidProbationBooking() = (BookingType.PROBATION != bookingType) || (probationTeamCode != null && probationMeetingType != null)
+  @AssertTrue(message = "The probation probation meeting type is mandatory for probation bookings")
+  private fun isInvalidProbationBooking() = (BookingType.PROBATION != bookingType) || (probationMeetingType != null)
 
   @JsonIgnore
   @AssertTrue(message = "The supplied video link for the appointment is not a valid URL")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
@@ -16,6 +16,12 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 
+@Schema(
+  description =
+  """
+  Create a court or probation team meeting video link booking.
+  """,
+)
 data class CreateVideoBookingRequest(
 
   @field:NotNull(message = "The video link booking type is mandatory")
@@ -24,7 +30,15 @@ data class CreateVideoBookingRequest(
 
   @field:Valid
   @field:NotEmpty(message = "At least one prisoner must be supplied for a video link booking")
-  @Schema(description = "The prisoner or prisoners associated with the video link booking")
+  @Schema(
+    description = """
+    One or more prisoners associated with the video link booking.
+    
+    A probation booking should only ever have one prisoner whilst a court booking can have multiple e.g.for co-defendants.
+     
+    NOTE: CO-DEFENDANTS ARE NOT YET SUPPORTED BY THE SERVICE.
+  """,
+  )
   val prisoners: List<PrisonerDetails>,
 
   @Schema(description = "The court code is needed if booking type is COURT, otherwise null", example = "DRBYMC")
@@ -33,14 +47,23 @@ data class CreateVideoBookingRequest(
   @Schema(description = "The court hearing type is needed if booking type is COURT, otherwise null", example = "APPEAL")
   val courtHearingType: CourtHearingType? = null,
 
-  @Schema(description = "The probation team code is needed if booking type is PROBATION, otherwise null", example = "BLKPPP")
+  @Schema(
+    description = "The probation team code is needed if booking type is PROBATION, otherwise null",
+    example = "BLKPPP",
+  )
   val probationTeamCode: String? = null,
 
-  @Schema(description = "The probation meeting type is needed if booking type is PROBATION, otherwise null", example = "PSR")
+  @Schema(
+    description = "The probation meeting type is needed if booking type is PROBATION, otherwise null",
+    example = "PSR",
+  )
   val probationMeetingType: ProbationMeetingType? = null,
 
   @field:Size(max = 400, message = "Comments for the video link booking cannot not exceed {max} characters")
-  @Schema(description = "Free text comments for the video link booking", example = "Waiting to hear on legal representation")
+  @Schema(
+    description = "Free text comments for the video link booking",
+    example = "Waiting to hear on legal representation",
+  )
   val comments: String?,
 
   @field:Size(max = 120, message = "The video link should not exceed {max} characters")
@@ -49,11 +72,13 @@ data class CreateVideoBookingRequest(
 ) {
   @JsonIgnore
   @AssertTrue(message = "The court code and court hearing type are mandatory for court bookings")
-  private fun isInvalidCourtBooking() = (BookingType.COURT != bookingType) || (courtCode != null && courtHearingType != null)
+  private fun isInvalidCourtBooking() =
+    (BookingType.COURT != bookingType) || (courtCode != null && courtHearingType != null)
 
   @JsonIgnore
   @AssertTrue(message = "The probation team code and probation meeting type are mandatory for probation bookings")
-  private fun isInvalidProbationBooking() = (BookingType.PROBATION != bookingType) || (probationTeamCode != null && probationMeetingType != null)
+  private fun isInvalidProbationBooking() =
+    (BookingType.PROBATION != bookingType) || (probationTeamCode != null && probationMeetingType != null)
 
   @JsonIgnore
   @AssertTrue(message = "The supplied video link for the appointment is not a valid URL")
@@ -155,12 +180,19 @@ data class Appointment(
   val endTime: LocalTime?,
 ) {
   @JsonIgnore
-  @AssertTrue(message = "The end time must be after the start time for the appointment", groups = [DateValidationExtension::class])
+  @AssertTrue(
+    message = "The end time must be after the start time for the appointment",
+    groups = [DateValidationExtension::class],
+  )
   private fun isInvalidTime() = (startTime == null || endTime == null) || startTime.isBefore(endTime)
 
   @JsonIgnore
-  @AssertTrue(message = "The combination of date and start time for the appointment must be in the future", groups = [DateValidationExtension::class])
-  private fun isInvalidStart() = (date == null || startTime == null) || date.atTime(startTime).isAfter(LocalDateTime.now())
+  @AssertTrue(
+    message = "The combination of date and start time for the appointment must be in the future",
+    groups = [DateValidationExtension::class],
+  )
+  private fun isInvalidStart() =
+    (date == null || startTime == null) || date.atTime(startTime).isAfter(LocalDateTime.now())
 }
 
 private interface DateValidationExtension

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingHistoryService.kt
@@ -34,9 +34,7 @@ class BookingHistoryService(private val bookingHistoryRepository: BookingHistory
       createdBy = booking.createdBy,
     ).apply {
       addBookingHistoryAppointments(getAppointmentsForHistory(this, booking))
-    }.apply {
-      bookingHistoryRepository.saveAndFlush(this)
-    }
+    }.also(bookingHistoryRepository::saveAndFlush)
 
   private fun getAppointmentsForHistory(history: BookingHistory, booking: VideoBooking) =
     booking.appointments().map { appointment ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -308,7 +308,6 @@ fun amendCourtBookingRequest(
 
   return AmendVideoBookingRequest(
     bookingType = BookingType.COURT,
-    courtCode = courtCode,
     courtHearingType = CourtHearingType.TRIBUNAL,
     prisoners = listOf(prisoner),
     comments = comments,
@@ -317,10 +316,9 @@ fun amendCourtBookingRequest(
 }
 
 fun amendProbationBookingRequest(
-  probationTeamCode: String = "BLKPPP",
   probationMeetingType: ProbationMeetingType = ProbationMeetingType.PSR,
   videoLinkUrl: String = "https://video.link.com",
-  prisonCode: String = "MDI",
+  prisonCode: String = MOORLAND,
   prisonerNumber: String = "123456",
   locationSuffix: String = "A-1-001",
   location: Location? = null,
@@ -346,7 +344,6 @@ fun amendProbationBookingRequest(
 
   return AmendVideoBookingRequest(
     bookingType = BookingType.PROBATION,
-    probationTeamCode = probationTeamCode,
     probationMeetingType = probationMeetingType,
     prisoners = listOf(prisoner),
     comments = comments,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -1091,7 +1091,6 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     val bookingId = webTestClient.createBooking(probationBookingRequest, PROBATION_USER)
 
     val amendBookingRequest = amendProbationBookingRequest(
-      probationTeamCode = BLACKPOOL_MC_PPOC,
       probationMeetingType = ProbationMeetingType.PSR,
       videoLinkUrl = "https://probation.videolink.com",
       prisonCode = BIRMINGHAM,
@@ -1168,7 +1167,6 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     val videoBookingId = webTestClient.createBooking(probationBookingRequest2, PROBATION_USER)
 
     val clashingBookingRequest = amendProbationBookingRequest(
-      probationTeamCode = BLACKPOOL_MC_PPOC,
       probationMeetingType = ProbationMeetingType.PSR,
       videoLinkUrl = "https://probation.videolink.com",
       prisonCode = BIRMINGHAM,
@@ -1224,7 +1222,6 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     locationsInsidePrisonApi().stubGetLocationByKey(birminghamLocation.key, BIRMINGHAM)
 
     val amendBookingRequest = amendProbationBookingRequest(
-      probationTeamCode = BLACKPOOL_MC_PPOC,
       probationMeetingType = ProbationMeetingType.PSR,
       videoLinkUrl = "https://probation.videolink.com",
       prisonCode = BIRMINGHAM,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingServiceTest.kt
@@ -9,16 +9,13 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationValidator
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerValidator
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toMinutePrecision
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ProbationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.CHESTERFIELD_JUSTICE_CENTRE
@@ -41,7 +38,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonerSearchPrisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.werringtonLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withMainCourtPrisonAppointment
@@ -49,10 +45,8 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withProbationP
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AmendVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Appointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.CourtRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security.CaseloadAccessException
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security.VideoBookingAccessException
@@ -62,8 +56,6 @@ import java.util.Optional
 
 class AmendVideoBookingServiceTest {
 
-  private val courtRepository: CourtRepository = mock()
-  private val probationTeamRepository: ProbationTeamRepository = mock()
   private val videoBookingRepository: VideoBookingRepository = mock()
   private val prisonRepository: PrisonRepository = mock()
   private val bookingHistoryService: BookingHistoryService = mock()
@@ -76,8 +68,6 @@ class AmendVideoBookingServiceTest {
   private val appointmentsService = AppointmentsService(prisonAppointmentRepository, locationValidator)
 
   private val service = AmendVideoBookingService(
-    courtRepository,
-    probationTeamRepository,
     videoBookingRepository,
     prisonRepository,
     appointmentsService,
@@ -121,7 +111,6 @@ class AmendVideoBookingServiceTest {
     )
 
     withBookingFixture(1, courtBooking)
-    withCourtFixture(court(amendCourtBookingRequest.courtCode!!))
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
 
     val (booking, prisoner) = service.amend(1, amendCourtBookingRequest, COURT_USER)
@@ -134,7 +123,6 @@ class AmendVideoBookingServiceTest {
 
     with(amendedBookingCaptor.firstValue) {
       bookingType isEqualTo "COURT"
-      court isEqualTo court(CHESTERFIELD_JUSTICE_CENTRE)
       hearingType isEqualTo amendCourtBookingRequest.courtHearingType?.name
       comments isEqualTo "court booking comments"
       videoUrl isEqualTo amendCourtBookingRequest.videoLinkUrl
@@ -224,8 +212,8 @@ class AmendVideoBookingServiceTest {
       ),
     )
 
-    withBookingFixture(1, courtBooking().withMainCourtPrisonAppointment())
-    withCourtFixture(court(amendCourtBookingRequest.courtCode!!))
+    val courtBooking = courtBooking().withMainCourtPrisonAppointment()
+    withBookingFixture(1, courtBooking)
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
 
     val error = assertThrows<IllegalArgumentException> { service.amend(1, amendCourtBookingRequest, COURT_USER) }
@@ -257,8 +245,8 @@ class AmendVideoBookingServiceTest {
       ),
     )
 
-    withBookingFixture(1, courtBooking().withMainCourtPrisonAppointment())
-    withCourtFixture(court(amendCourtBookingRequest.courtCode!!))
+    val courtBooking = courtBooking().withMainCourtPrisonAppointment()
+    withBookingFixture(1, courtBooking)
     withPrisonPrisonerFixture(WERRINGTON, prisonerNumber)
 
     val error = assertThrows<IllegalArgumentException> { service.amend(1, amendCourtBookingRequest, COURT_USER) }
@@ -290,8 +278,8 @@ class AmendVideoBookingServiceTest {
       ),
     )
 
-    withBookingFixture(1, courtBooking().withMainCourtPrisonAppointment())
-    withCourtFixture(court(amendCourtBookingRequest.courtCode!!))
+    val courtBooking = courtBooking().withMainCourtPrisonAppointment()
+    withBookingFixture(1, courtBooking)
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
 
     val error = assertThrows<IllegalArgumentException> { service.amend(1, amendCourtBookingRequest, COURT_USER) }
@@ -323,8 +311,8 @@ class AmendVideoBookingServiceTest {
       ),
     )
 
-    withBookingFixture(1, courtBooking().withMainCourtPrisonAppointment())
-    withCourtFixture(court(amendCourtBookingRequest.courtCode!!))
+    val courtBooking = courtBooking().withMainCourtPrisonAppointment()
+    withBookingFixture(1, courtBooking)
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
 
     val error = assertThrows<IllegalArgumentException> { service.amend(1, amendCourtBookingRequest, COURT_USER) }
@@ -363,8 +351,8 @@ class AmendVideoBookingServiceTest {
       ),
     )
 
-    withBookingFixture(1, courtBooking().withMainCourtPrisonAppointment())
-    withCourtFixture(court(amendCourtBookingRequest.courtCode!!))
+    val courtBooking = courtBooking().withMainCourtPrisonAppointment()
+    withBookingFixture(1, courtBooking)
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
 
     val error = assertThrows<IllegalArgumentException> { service.amend(1, amendCourtBookingRequest, COURT_USER) }
@@ -403,8 +391,8 @@ class AmendVideoBookingServiceTest {
       ),
     )
 
-    withBookingFixture(1, courtBooking().withMainCourtPrisonAppointment())
-    withCourtFixture(court(amendCourtBookingRequest.courtCode!!))
+    val courtBooking = courtBooking().withMainCourtPrisonAppointment()
+    withBookingFixture(1, courtBooking)
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
 
     val error = assertThrows<IllegalArgumentException> { service.amend(1, amendCourtBookingRequest, COURT_USER) }
@@ -443,42 +431,13 @@ class AmendVideoBookingServiceTest {
       ),
     )
 
-    withBookingFixture(1, courtBooking().withMainCourtPrisonAppointment())
-    withCourtFixture(court(amendCourtBookingRequest.courtCode!!))
+    val courtBooking = courtBooking().withMainCourtPrisonAppointment()
+    withBookingFixture(1, courtBooking)
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
 
     val error = assertThrows<IllegalArgumentException> { service.amend(1, amendCourtBookingRequest, COURT_USER) }
 
     error.message isEqualTo "Court bookings can only have one pre-conference, one hearing and one post-conference."
-  }
-
-  @Test
-  fun `should fail to amend a court video booking when prison user changes the court for prison user`() {
-    val courtBooking = courtBooking(court = court(DERBY_JUSTICE_CENTRE)).withMainCourtPrisonAppointment()
-    val prisonerNumber = "123456"
-    val amendCourtBookingRequest = amendCourtBookingRequest(
-      courtCode = CHESTERFIELD_JUSTICE_CENTRE,
-      prisonCode = BIRMINGHAM,
-      prisonerNumber = prisonerNumber,
-      appointments = listOf(
-        Appointment(
-          type = AppointmentType.VLB_COURT_MAIN,
-          locationKey = birminghamLocation.key,
-          date = tomorrow(),
-          startTime = LocalTime.of(9, 30),
-          endTime = LocalTime.of(10, 0),
-        ),
-      ),
-    )
-
-    whenever(videoBookingRepository.findById(1)) doReturn Optional.of(courtBooking)
-    withCourtFixture(court(amendCourtBookingRequest.courtCode!!))
-
-    val error = assertThrows<IllegalArgumentException> { service.amend(1, amendCourtBookingRequest, PRISON_USER.copy(activeCaseLoadId = courtBooking.prisonCode())) }
-
-    error.message isEqualTo "Prison users cannot change the court on a booking."
-
-    verify(videoBookingRepository, never()).saveAndFlush(any())
   }
 
   @Test
@@ -510,8 +469,8 @@ class AmendVideoBookingServiceTest {
       on { endTime } doReturn LocalTime.of(10, 0)
     }
 
-    withBookingFixture(1, courtBooking().withMainCourtPrisonAppointment())
-    withCourtFixture(court(amendCourtBookingRequest.courtCode!!))
+    val courtBooking = courtBooking().withMainCourtPrisonAppointment()
+    withBookingFixture(1, courtBooking)
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
     whenever(prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(BIRMINGHAM, birminghamLocation.key, tomorrow())) doReturn listOf(overlappingAppointment)
 
@@ -542,8 +501,8 @@ class AmendVideoBookingServiceTest {
       on { endTime } doReturn LocalTime.of(10, 0)
     }
 
-    withBookingFixture(1, courtBooking().withMainCourtPrisonAppointment())
-    withCourtFixture(court(amendCourtBookingRequest.courtCode!!))
+    val courtBooking = courtBooking().withMainCourtPrisonAppointment()
+    withBookingFixture(1, courtBooking)
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
     whenever(prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(BIRMINGHAM, birminghamLocation.key, tomorrow())) doReturn listOf(overlappingAppointment)
 
@@ -551,23 +510,10 @@ class AmendVideoBookingServiceTest {
   }
 
   @Test
-  fun `should fail to amend a court video booking when court not enabled for court user`() {
-    val amendCourtBookingRequest = amendCourtBookingRequest()
-
-    whenever(videoBookingRepository.findById(1)) doReturn Optional.of(courtBooking().withMainCourtPrisonAppointment())
-    withCourtFixture(court(amendCourtBookingRequest.courtCode!!, enabled = false))
-
-    val error = assertThrows<IllegalArgumentException> { service.amend(1, amendCourtBookingRequest, COURT_USER) }
-
-    error.message isEqualTo "Court with code ${amendCourtBookingRequest.courtCode} is not enabled"
-  }
-
-  @Test
   fun `should fail to amend a court video booking when prison not found for court user`() {
     val amendCourtBookingRequest = amendCourtBookingRequest(prisonCode = MOORLAND)
-
-    whenever(videoBookingRepository.findById(1)) doReturn Optional.of(courtBooking().withMainCourtPrisonAppointment())
-    withCourtFixture(court(amendCourtBookingRequest.courtCode!!))
+    val courtBooking = courtBooking().withMainCourtPrisonAppointment()
+    whenever(videoBookingRepository.findById(1)) doReturn Optional.of(courtBooking)
     whenever(prisonRepository.findByCode(MOORLAND)) doReturn null
 
     val error = assertThrows<EntityNotFoundException> { service.amend(1, amendCourtBookingRequest, COURT_USER) }
@@ -576,26 +522,12 @@ class AmendVideoBookingServiceTest {
   }
 
   @Test
-  fun `should fail to amend a court video booking when court not found for court user`() {
-    val amendCourtBookingRequest = amendCourtBookingRequest()
-
-    whenever(videoBookingRepository.findById(1)) doReturn Optional.of(courtBooking().withMainCourtPrisonAppointment())
-    whenever(courtRepository.findByCode(amendCourtBookingRequest.courtCode!!)) doReturn null
-
-    val error = assertThrows<EntityNotFoundException> { service.amend(1, amendCourtBookingRequest, COURT_USER) }
-
-    error.message isEqualTo "Court with code ${amendCourtBookingRequest.courtCode} not found"
-  }
-
-  @Test
   fun `should amend a probation video booking for probation user`() {
     val probationBooking = probationBooking().withProbationPrisonAppointment()
     val prisonerNumber = "123456"
     val probationBookingRequest = amendProbationBookingRequest(prisonCode = BIRMINGHAM, prisonerNumber = prisonerNumber, location = birminghamLocation)
-    val requestedProbationTeam = probationTeam(probationBookingRequest.probationTeamCode!!)
 
     withBookingFixture(2, probationBooking)
-    withProbationTeamFixture(requestedProbationTeam)
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
 
     val (booking, prisoner) = service.amend(2, probationBookingRequest, PROBATION_USER)
@@ -608,7 +540,7 @@ class AmendVideoBookingServiceTest {
 
     with(amendedBookingCaptor.firstValue) {
       bookingType isEqualTo "PROBATION"
-      probationTeam isEqualTo requestedProbationTeam
+      probationTeam isEqualTo probationBooking.probationTeam!!
       probationMeetingType isEqualTo probationBookingRequest.probationMeetingType?.name
       comments isEqualTo "probation booking comments"
       videoUrl isEqualTo probationBookingRequest.videoLinkUrl
@@ -651,8 +583,8 @@ class AmendVideoBookingServiceTest {
       on { endTime } doReturn LocalTime.of(10, 0)
     }
 
-    withBookingFixture(2, probationBooking().withProbationPrisonAppointment())
-    withProbationTeamFixture(probationTeam(probationBookingRequest.probationTeamCode!!))
+    val probationBooking = probationBooking().withProbationPrisonAppointment()
+    withBookingFixture(2, probationBooking)
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
     whenever(prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(BIRMINGHAM, "$BIRMINGHAM-B-2-001", tomorrow())) doReturn listOf(overlappingAppointment)
 
@@ -679,7 +611,6 @@ class AmendVideoBookingServiceTest {
     }
 
     withBookingFixture(2, probationBooking)
-    withProbationTeamFixture(probationTeam(probationBookingRequest.probationTeamCode!!))
     whenever(prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(BIRMINGHAM, "$BIRMINGHAM-B-2-001", tomorrow())) doReturn listOf(overlappingAppointment)
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
 
@@ -689,23 +620,10 @@ class AmendVideoBookingServiceTest {
   }
 
   @Test
-  fun `should fail to amend a probation video booking when team not found for probation user`() {
-    val probationBookingRequest = amendProbationBookingRequest()
-
-    withBookingFixture(2, probationBooking().withProbationPrisonAppointment())
-    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn null
-
-    val error = assertThrows<EntityNotFoundException> { service.amend(2, probationBookingRequest, PROBATION_USER) }
-
-    error.message isEqualTo "Probation team with code ${probationBookingRequest.probationTeamCode} not found"
-  }
-
-  @Test
   fun `should fail to amend a probation video booking when prison not found for probation user`() {
     val probationBookingRequest = amendProbationBookingRequest(prisonCode = BIRMINGHAM)
-
-    withBookingFixture(2, probationBooking().withProbationPrisonAppointment())
-    withProbationTeamFixture(probationTeam(probationBookingRequest.probationTeamCode!!))
+    val probationBooking = probationBooking().withProbationPrisonAppointment()
+    withBookingFixture(2, probationBooking)
     whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn null
 
     val error = assertThrows<EntityNotFoundException> { service.amend(2, probationBookingRequest, PROBATION_USER) }
@@ -714,25 +632,12 @@ class AmendVideoBookingServiceTest {
   }
 
   @Test
-  fun `should fail to amend a probation video booking when team not enabled for probation user`() {
-    val probationBookingRequest = amendProbationBookingRequest()
-    val disabledProbationTeam = probationTeam(probationBookingRequest.probationTeamCode!!, false)
-
-    withBookingFixture(2, probationBooking().withProbationPrisonAppointment())
-    withProbationTeamFixture(disabledProbationTeam)
-
-    val error = assertThrows<IllegalArgumentException> { service.amend(2, probationBookingRequest, PROBATION_USER) }
-
-    error.message isEqualTo "Probation team with code ${probationBookingRequest.probationTeamCode} is not enabled"
-  }
-
-  @Test
   fun `should fail to amend a probation video booking when appointment type not probation specific for probation user`() {
     val prisonerNumber = "123456"
     val amendRequest = amendProbationBookingRequest(prisonCode = BIRMINGHAM, prisonerNumber = prisonerNumber, appointmentType = AppointmentType.VLB_COURT_MAIN)
 
-    withBookingFixture(1, probationBooking().withProbationPrisonAppointment())
-    withProbationTeamFixture(probationTeam(amendRequest.probationTeamCode!!))
+    val probationBooking = probationBooking().withProbationPrisonAppointment()
+    withBookingFixture(1, probationBooking)
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
 
     val error = assertThrows<IllegalArgumentException> { service.amend(1, amendRequest, PROBATION_USER) }
@@ -757,14 +662,6 @@ class AmendVideoBookingServiceTest {
   private fun withBookingFixture(bookingId: Long, booking: VideoBooking) {
     whenever(videoBookingRepository.findById(bookingId)) doReturn Optional.of(booking)
     whenever(videoBookingRepository.saveAndFlush(booking)) doReturn persistedVideoBooking
-  }
-
-  private fun withProbationTeamFixture(team: ProbationTeam) {
-    whenever(probationTeamRepository.findByCode(team.code)) doReturn team
-  }
-
-  private fun withCourtFixture(court: Court) {
-    whenever(courtRepository.findByCode(court.code)) doReturn court
   }
 
   private fun withPrisonPrisonerFixture(prisonCode: String, prisonerNumber: String) {


### PR DESCRIPTION
Removing the court code and probation team attributes from the amend journey.

Because the attributes were marked as optional on the amend request object, removal of them should not impact the UI's calling this endpoint 🤞