### PR TITLE
BAVL-342 ensuring we keep created at and amended at inline with historic (migrated) bookings.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/migration/MigrationClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/migration/MigrationClient.kt
@@ -106,6 +106,15 @@ data class VideoBookingEvent(
   val postEndTime: LocalDateTime?,
 )
 
+fun VideoBookingMigrateResponse.createdAt() =
+  events.single { it.eventType == VideoLinkBookingEventType.CREATE }.eventTime
+
+fun VideoBookingMigrateResponse.updatedAt() =
+  events.sortedBy(VideoBookingEvent::eventId).lastOrNull { it.eventType != VideoLinkBookingEventType.CREATE }?.eventTime
+
+fun VideoBookingMigrateResponse.updatedBy() =
+  events.sortedBy(VideoBookingEvent::eventId).lastOrNull { it.eventType != VideoLinkBookingEventType.CREATE }?.createdByUsername
+
 fun VideoBookingMigrateResponse.cancelledAt(): LocalDateTime? =
   if (cancelled) {
     events

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
@@ -182,10 +182,13 @@ class VideoBooking private constructor(
       court: Court,
       comments: String?,
       createdBy: String,
+      createdTime: LocalDateTime,
       createdByPrison: Boolean,
       migratedVideoBookingId: Long,
       cancelledBy: String?,
       cancelledAt: LocalDateTime?,
+      updatedBy: String?,
+      updatedAt: LocalDateTime?,
     ): VideoBooking = VideoBooking(
       bookingType = "COURT",
       court = court,
@@ -196,6 +199,7 @@ class VideoBooking private constructor(
       // TODO comments size needs sorting ...
       comments = comments?.take(400),
       createdBy = createdBy,
+      createdTime = createdTime,
       createdByPrison = createdByPrison,
       migratedVideoBookingId = migratedVideoBookingId,
     ).apply {
@@ -203,6 +207,9 @@ class VideoBooking private constructor(
         statusCode = StatusCode.CANCELLED
         amendedBy = cancelledBy
         amendedTime = cancelledAt
+      } else {
+        amendedBy = updatedBy
+        amendedTime = updatedAt
       }
     }
 
@@ -210,10 +217,13 @@ class VideoBooking private constructor(
       probationTeam: ProbationTeam,
       comments: String?,
       createdBy: String,
+      createdTime: LocalDateTime,
       createdByPrison: Boolean,
       migratedVideoBookingId: Long,
       cancelledBy: String?,
       cancelledAt: LocalDateTime?,
+      updatedBy: String?,
+      updatedAt: LocalDateTime?,
     ): VideoBooking =
       VideoBooking(
         bookingType = "PROBATION",
@@ -225,6 +235,7 @@ class VideoBooking private constructor(
         // TODO comments size needs sorting ...
         comments = comments?.take(400),
         createdBy = createdBy,
+        createdTime = createdTime,
         createdByPrison = createdByPrison,
         migratedVideoBookingId = migratedVideoBookingId,
       ).apply {
@@ -232,6 +243,9 @@ class VideoBooking private constructor(
           statusCode = StatusCode.CANCELLED
           amendedBy = cancelledBy
           amendedTime = cancelledAt
+        } else {
+          amendedBy = updatedBy
+          amendedTime = updatedAt
         }
       }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateVideoBookingService.kt
@@ -7,9 +7,12 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.Vide
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.VideoLinkBookingEventType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.cancelledAt
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.cancelledBy
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.createdAt
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.mainAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.postAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.preAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.updatedAt
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.updatedBy
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.APPOINTMENT_TYPE_COURT_MAIN
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.APPOINTMENT_TYPE_COURT_POST
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.APPOINTMENT_TYPE_COURT_PRE
@@ -66,10 +69,13 @@ class MigrateVideoBookingService(
       court = court,
       comments = bookingToMigrate.comments,
       createdBy = bookingToMigrate.createdBy,
+      createdTime = bookingToMigrate.createdAt(),
       createdByPrison = bookingToMigrate.madeByTheCourt.not(),
       migratedVideoBookingId = bookingToMigrate.videoBookingId,
       cancelledBy = bookingToMigrate.cancelledBy(),
       cancelledAt = bookingToMigrate.cancelledAt(),
+      updatedBy = bookingToMigrate.updatedBy(),
+      updatedAt = bookingToMigrate.updatedAt(),
     ).apply {
       if (bookingToMigrate.pre != null) {
         addAppointment(
@@ -126,10 +132,13 @@ class MigrateVideoBookingService(
       probationTeam = probationTeam,
       comments = bookingToMigrate.comments,
       createdBy = bookingToMigrate.createdBy,
+      createdTime = bookingToMigrate.createdAt(),
       createdByPrison = bookingToMigrate.madeByTheCourt.not(),
       migratedVideoBookingId = bookingToMigrate.videoBookingId,
       cancelledBy = bookingToMigrate.cancelledBy(),
       cancelledAt = bookingToMigrate.cancelledAt(),
+      updatedBy = bookingToMigrate.updatedBy(),
+      updatedAt = bookingToMigrate.updatedAt(),
     ).addAppointment(
       prisonCode = bookingToMigrate.prisonCode,
       prisonerNumber = prisonerNumber,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingTest.kt
@@ -95,11 +95,14 @@ class VideoBookingTest {
     val migratedBooking = VideoBooking.migratedCourtBooking(
       court = court(code = "migrated_court_code"),
       createdBy = "migrated court user",
+      createdTime = yesterday().atStartOfDay(),
       createdByPrison = false,
       comments = "migrated court comments",
       migratedVideoBookingId = 100,
       cancelledBy = null,
       cancelledAt = null,
+      updatedAt = null,
+      updatedBy = null,
     )
 
     with(migratedBooking) {
@@ -108,6 +111,7 @@ class VideoBookingTest {
       isProbationBooking() isBool false
       court isEqualTo court(code = "migrated_court_code")
       createdBy isEqualTo "migrated court user"
+      createdTime isEqualTo yesterday().atStartOfDay()
       createdByPrison isBool false
       comments isEqualTo "migrated court comments"
       hearingType isEqualTo "UNKNOWN"
@@ -120,11 +124,14 @@ class VideoBookingTest {
     val migratedBooking = VideoBooking.migratedCourtBooking(
       court = court(code = "migrated_court_code"),
       createdBy = "migrated court user",
+      createdTime = 2.daysAgo().atStartOfDay(),
       createdByPrison = false,
       comments = "migrated court comments",
       migratedVideoBookingId = 100,
       cancelledBy = "COURT CANCELLATION USER",
       cancelledAt = 1.daysAgo().atStartOfDay(),
+      updatedAt = 2.daysAgo().atStartOfDay().plusHours(1),
+      updatedBy = "COURT UPDATE USER",
     )
 
     with(migratedBooking) {
@@ -133,6 +140,7 @@ class VideoBookingTest {
       isProbationBooking() isBool false
       court isEqualTo court(code = "migrated_court_code")
       createdBy isEqualTo "migrated court user"
+      createdTime isEqualTo 2.daysAgo().atStartOfDay()
       createdByPrison isBool false
       comments isEqualTo "migrated court comments"
       hearingType isEqualTo "UNKNOWN"
@@ -144,15 +152,50 @@ class VideoBookingTest {
   }
 
   @Test
+  fun `should create an updated migrated court booking`() {
+    val migratedBooking = VideoBooking.migratedCourtBooking(
+      court = court(code = "migrated_court_code"),
+      createdBy = "migrated court user",
+      createdTime = 2.daysAgo().atStartOfDay(),
+      createdByPrison = false,
+      comments = "migrated court comments",
+      migratedVideoBookingId = 100,
+      cancelledBy = null,
+      cancelledAt = null,
+      updatedAt = 2.daysAgo().atStartOfDay().plusHours(1),
+      updatedBy = "COURT UPDATE USER",
+    )
+
+    with(migratedBooking) {
+      isMigrated() isBool true
+      isCourtBooking() isBool true
+      isProbationBooking() isBool false
+      court isEqualTo court(code = "migrated_court_code")
+      createdBy isEqualTo "migrated court user"
+      createdTime isEqualTo 2.daysAgo().atStartOfDay()
+      createdByPrison isBool false
+      comments isEqualTo "migrated court comments"
+      hearingType isEqualTo "UNKNOWN"
+      migratedVideoBookingId isEqualTo 100
+      statusCode isEqualTo StatusCode.ACTIVE
+      amendedBy isEqualTo "COURT UPDATE USER"
+      amendedTime isEqualTo 2.daysAgo().atStartOfDay().plusHours(1)
+    }
+  }
+
+  @Test
   fun `should create a migrated probation booking`() {
     val migratedBooking = VideoBooking.migratedProbationBooking(
       probationTeam = probationTeam(code = "migrated_team_code"),
       createdBy = "migrated probation user",
+      createdTime = 3.daysAgo().atStartOfDay(),
       createdByPrison = false,
       comments = "migrated probation comments",
       migratedVideoBookingId = 100,
       cancelledBy = null,
       cancelledAt = null,
+      updatedAt = null,
+      updatedBy = null,
     )
 
     with(migratedBooking) {
@@ -161,6 +204,7 @@ class VideoBookingTest {
       isCourtBooking() isBool false
       probationTeam isEqualTo probationTeam(code = "migrated_team_code")
       createdBy isEqualTo "migrated probation user"
+      createdTime isEqualTo 3.daysAgo().atStartOfDay()
       createdByPrison isBool false
       comments isEqualTo "migrated probation comments"
       probationMeetingType isEqualTo "UNKNOWN"
@@ -173,11 +217,14 @@ class VideoBookingTest {
     val migratedBooking = VideoBooking.migratedProbationBooking(
       probationTeam = probationTeam(code = "migrated_team_code"),
       createdBy = "migrated probation user",
+      createdTime = 4.daysAgo().atStartOfDay(),
       createdByPrison = false,
       comments = "migrated probation comments",
       migratedVideoBookingId = 100,
       cancelledBy = "PROBATION CANCELLATION USER",
       cancelledAt = 2.daysAgo().atStartOfDay(),
+      updatedAt = 3.daysAgo().atStartOfDay(),
+      updatedBy = "PROBATION UPDATE USER",
     )
 
     with(migratedBooking) {
@@ -186,6 +233,7 @@ class VideoBookingTest {
       isCourtBooking() isBool false
       probationTeam isEqualTo probationTeam(code = "migrated_team_code")
       createdBy isEqualTo "migrated probation user"
+      createdTime isEqualTo 4.daysAgo().atStartOfDay()
       createdByPrison isBool false
       comments isEqualTo "migrated probation comments"
       probationMeetingType isEqualTo "UNKNOWN"
@@ -193,6 +241,38 @@ class VideoBookingTest {
       statusCode isEqualTo StatusCode.CANCELLED
       amendedBy isEqualTo "PROBATION CANCELLATION USER"
       amendedTime isEqualTo 2.daysAgo().atStartOfDay()
+    }
+  }
+
+  @Test
+  fun `should create an updated migrated probation booking`() {
+    val migratedBooking = VideoBooking.migratedProbationBooking(
+      probationTeam = probationTeam(code = "migrated_team_code"),
+      createdBy = "migrated probation user",
+      createdTime = 4.daysAgo().atStartOfDay(),
+      createdByPrison = false,
+      comments = "migrated probation comments",
+      migratedVideoBookingId = 100,
+      cancelledBy = null,
+      cancelledAt = null,
+      updatedAt = 3.daysAgo().atStartOfDay(),
+      updatedBy = "PROBATION UPDATE USER",
+    )
+
+    with(migratedBooking) {
+      isMigrated() isBool true
+      isProbationBooking() isBool true
+      isCourtBooking() isBool false
+      probationTeam isEqualTo probationTeam(code = "migrated_team_code")
+      createdBy isEqualTo "migrated probation user"
+      createdTime isEqualTo 4.daysAgo().atStartOfDay()
+      createdByPrison isBool false
+      comments isEqualTo "migrated probation comments"
+      probationMeetingType isEqualTo "UNKNOWN"
+      migratedVideoBookingId isEqualTo 100
+      statusCode isEqualTo StatusCode.ACTIVE
+      amendedBy isEqualTo "PROBATION UPDATE USER"
+      amendedTime isEqualTo 3.daysAgo().atStartOfDay()
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/MigrateBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/MigrateBookingIntegrationTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.Vide
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.VideoBookingMigrateResponse
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.VideoLinkBookingEventType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingHistoryAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.StatusCode
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
@@ -19,10 +20,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WERRINGTON
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.daysAgo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.moorlandLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.moorlandLocation2
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.moorlandLocation3
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.yesterday
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.BookingHistoryRepository
@@ -31,7 +32,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBooki
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.InboundEventsService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.MigrateVideoBookingEvent
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.LocalTime
 import java.util.UUID
 
@@ -52,7 +52,7 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
 
   @Test
   @Transactional
-  fun `should migrate court booking`() {
+  fun `should migrate court booking with an update event`() {
     whereaboutsApi().stubGetVideoBookingToMigrate(
       1,
       VideoBookingMigrateResponse(
@@ -65,7 +65,7 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
         madeByTheCourt = true,
         comments = "Migrated court comments",
         pre = AppointmentLocationTimeSlot(1, yesterday(), LocalTime.of(9, 0), LocalTime.of(10, 0)),
-        main = AppointmentLocationTimeSlot(1, yesterday(), LocalTime.of(10, 0), LocalTime.of(11, 0)),
+        main = AppointmentLocationTimeSlot(2, yesterday(), LocalTime.of(10, 0), LocalTime.of(11, 0)),
         post = AppointmentLocationTimeSlot(1, yesterday(), LocalTime.of(11, 0), LocalTime.of(12, 0)),
         cancelled = false,
         events = listOf(
@@ -89,15 +89,42 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
             mainLocationId = 1,
             postLocationId = 1,
           ),
+          VideoBookingEvent(
+            eventId = 2,
+            eventTime = yesterday().atTime(4, 0),
+            eventType = VideoLinkBookingEventType.UPDATE,
+            comment = "Court main meeting changed event comments",
+            courtCode = DERBY_JUSTICE_CENTRE,
+            preStartTime = yesterday().atTime(9, 0),
+            preEndTime = yesterday().atTime(10, 0),
+            mainStartTime = yesterday().atTime(10, 0),
+            mainEndTime = yesterday().atTime(11, 0),
+            postStartTime = yesterday().atTime(11, 0),
+            postEndTime = yesterday().atTime(12, 0),
+            prisonCode = MOORLAND,
+            createdByUsername = "MIGRATION COURT UPDATE USER",
+            courtName = null,
+            madeByTheCourt = true,
+            preLocationId = 1,
+            mainLocationId = 2,
+            postLocationId = 1,
+          ),
         ),
       ),
     )
 
     prisonSearchApi().stubPostGetPrisonerByBookingId(1, "ABC123", MOORLAND)
 
+    // Mapping NOMIS internal location ID's to locations to ultimately extract the location business keys
     UUID.randomUUID().also { dpsLocationId ->
       nomisMappingApi().stubGetNomisToDpsLocationMapping(1, dpsLocationId.toString())
       locationsInsidePrisonApi().stubGetLocationById(dpsLocationId, moorlandLocation)
+    }
+
+    // Mapping NOMIS internal location ID's to locations to ultimately extract the location business keys
+    UUID.randomUUID().also { dpsLocationId ->
+      nomisMappingApi().stubGetNomisToDpsLocationMapping(2, dpsLocationId.toString())
+      locationsInsidePrisonApi().stubGetLocationById(dpsLocationId, moorlandLocation2)
     }
 
     videoBookingRepository.findAll().filter(VideoBooking::isCourtBooking) hasSize 0
@@ -106,17 +133,20 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
 
     val migratedCourtBooking = videoBookingRepository.findAll().single(VideoBooking::isCourtBooking)
 
+    // Assertions on the migrated probation booking
     with(migratedCourtBooking) {
       bookingType isEqualTo "COURT"
       statusCode isEqualTo StatusCode.ACTIVE
       hearingType isEqualTo "UNKNOWN"
       createdBy isEqualTo "MIGRATION COURT USER"
-      createdTime isCloseTo LocalDateTime.now()
+      createdTime isEqualTo yesterday().atStartOfDay()
       createdByPrison isBool false
       migratedVideoBookingId isEqualTo 1
-      // TODO if there is an update/amend should the amended attrs be set?
+      amendedBy isEqualTo "MIGRATION COURT UPDATE USER"
+      amendedTime isEqualTo yesterday().atTime(4, 0)
     }
 
+    // Assertions on the migrated court bookings appointments
     val migratedPrisonAppointments = migratedCourtBooking.appointments().sortedBy(PrisonAppointment::prisonAppointmentId).also { it hasSize 3 }
 
     migratedPrisonAppointments.component1()
@@ -146,37 +176,74 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
       .endsAt(12, 0)
       .hasComments("Migrated court comments")
 
-    val migratedBookingHistory = bookingHistoryRepository.findAllByVideoBookingIdOrderByCreatedTime(migratedCourtBooking.videoBookingId).single()
+    val migratedBookingHistory = bookingHistoryRepository.findAllByVideoBookingIdOrderByCreatedTime(migratedCourtBooking.videoBookingId).also { it hasSize 2 }
 
-    val bookingHistoryAppointments = migratedBookingHistory.appointments()
-      .sortedBy(BookingHistoryAppointment::startTime)
-      .also { it hasSize 3 }
-      .onEach { appointment ->
-        appointment
-          .isAtPrison(MOORLAND)
-          .isForPrisoner("ABC123")
-          .isAtLocation(moorlandLocation)
-          .isOnDate(yesterday())
-      }
+    with(migratedBookingHistory.component1()) {
+      historyType isEqualTo HistoryType.CREATE
+      comments isEqualTo "Court booking create event comments"
 
-    bookingHistoryAppointments.component1()
-      .isForAppointmentType("VLB_COURT_PRE")
-      .startsAt(9, 0)
-      .endsAt(10, 0)
+      appointments()
+        .also { it hasSize 3 }
+        .onEach { appointment ->
+          appointment
+            .isAtPrison(MOORLAND)
+            .isForPrisoner("ABC123")
+            .isAtLocation(moorlandLocation)
+            .isOnDate(yesterday())
+        }
 
-    bookingHistoryAppointments.component2()
-      .isForAppointmentType("VLB_COURT_MAIN")
-      .startsAt(10, 0)
-      .endsAt(11, 0)
+      appointments().component1()
+        .isForAppointmentType("VLB_COURT_PRE")
+        .startsAt(9, 0)
+        .endsAt(10, 0)
 
-    bookingHistoryAppointments.component3()
-      .isForAppointmentType("VLB_COURT_POST")
-      .startsAt(11, 0)
-      .endsAt(12, 0)
+      appointments().component2()
+        .isForAppointmentType("VLB_COURT_MAIN")
+        .startsAt(10, 0)
+        .endsAt(11, 0)
 
-    val history = videoBookingEventRepository.findByMainDateBetween(true, yesterday(), yesterday()).toList().single()
+      appointments().component3()
+        .isForAppointmentType("VLB_COURT_POST")
+        .startsAt(11, 0)
+        .endsAt(12, 0)
+    }
 
-    with(history) {
+    with(migratedBookingHistory.component2()) {
+      historyType isEqualTo HistoryType.AMEND
+      comments isEqualTo "Court main meeting changed event comments"
+
+      appointments()
+        .also { it hasSize 3 }
+        .onEach { appointment ->
+          appointment
+            .isAtPrison(MOORLAND)
+            .isForPrisoner("ABC123")
+            .isOnDate(yesterday())
+        }
+
+      appointments().component1()
+        .isForAppointmentType("VLB_COURT_PRE")
+        .isAtLocation(moorlandLocation)
+        .startsAt(9, 0)
+        .endsAt(10, 0)
+
+      appointments().component2()
+        .isForAppointmentType("VLB_COURT_MAIN")
+        .isAtLocation(moorlandLocation2)
+        .startsAt(10, 0)
+        .endsAt(11, 0)
+
+      appointments().component3()
+        .isForAppointmentType("VLB_COURT_POST")
+        .isAtLocation(moorlandLocation)
+        .startsAt(11, 0)
+        .endsAt(12, 0)
+    }
+
+    // Assertions on the migrated event history taken from the booking that has been migrated
+    val createHistoryEvent = videoBookingEventRepository.findById(1).orElseThrow()
+
+    with(createHistoryEvent) {
       timestamp isEqualTo yesterday().atStartOfDay()
       videoBookingId isEqualTo migratedCourtBooking.videoBookingId
       eventType isEqualTo "CREATE"
@@ -196,11 +263,34 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
       postStartTime isEqualTo LocalTime.of(11, 0)
       postEndTime isEqualTo LocalTime.of(12, 0)
     }
+
+    val amendHistoryEvent = videoBookingEventRepository.findById(2).orElseThrow()
+
+    with(amendHistoryEvent) {
+      timestamp isEqualTo yesterday().atTime(4, 0)
+      videoBookingId isEqualTo migratedCourtBooking.videoBookingId
+      eventType isEqualTo "AMEND"
+      prisonCode isEqualTo MOORLAND
+      courtDescription isEqualTo "Derby Justice Centre"
+      courtCode isEqualTo DERBY_JUSTICE_CENTRE
+      courtBooking isBool true
+      createdByPrison isBool false
+      preLocationKey isEqualTo moorlandLocation.key
+      preStartTime isEqualTo LocalTime.of(9, 0)
+      preEndTime isEqualTo LocalTime.of(10, 0)
+      mainLocationKey isEqualTo moorlandLocation2.key
+      mainDate isEqualTo yesterday()
+      mainStartTime isEqualTo LocalTime.of(10, 0)
+      mainEndTime isEqualTo LocalTime.of(11, 0)
+      preLocationKey isEqualTo moorlandLocation.key
+      postStartTime isEqualTo LocalTime.of(11, 0)
+      postEndTime isEqualTo LocalTime.of(12, 0)
+    }
   }
 
   @Test
   @Transactional
-  fun `should migrate probation booking`() {
+  fun `should migrate probation booking with an update event`() {
     whereaboutsApi().stubGetVideoBookingToMigrate(
       2,
       VideoBookingMigrateResponse(
@@ -212,7 +302,7 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
         createdBy = "MIGRATION PROBATION USER",
         madeByTheCourt = true,
         comments = "Migrated probation comments",
-        main = AppointmentLocationTimeSlot(2, 2.daysAgo(), LocalTime.of(10, 0), LocalTime.of(11, 0)),
+        main = AppointmentLocationTimeSlot(3, 2.daysAgo(), LocalTime.of(10, 0), LocalTime.of(11, 0)),
         cancelled = false,
         events = listOf(
           VideoBookingEvent(
@@ -232,7 +322,27 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
             courtName = null,
             madeByTheCourt = true,
             preLocationId = null,
-            mainLocationId = 2,
+            mainLocationId = 1,
+            postLocationId = null,
+          ),
+          VideoBookingEvent(
+            eventId = 2,
+            eventTime = 3.daysAgo().atTime(7, 0),
+            eventType = VideoLinkBookingEventType.UPDATE,
+            comment = "Probation room changed event comments",
+            courtCode = BLACKPOOL_MC_PPOC,
+            preStartTime = null,
+            preEndTime = null,
+            mainStartTime = 2.daysAgo().atTime(10, 0),
+            mainEndTime = 2.daysAgo().atTime(11, 0),
+            postStartTime = null,
+            postEndTime = null,
+            prisonCode = WERRINGTON,
+            createdByUsername = "MIGRATION PROBATION UPDATE USER",
+            courtName = null,
+            madeByTheCourt = true,
+            preLocationId = null,
+            mainLocationId = 3,
             postLocationId = null,
           ),
         ),
@@ -241,9 +351,16 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
 
     prisonSearchApi().stubPostGetPrisonerByBookingId(2, "DEF123", WERRINGTON)
 
+    // Mapping NOMIS internal location ID's to locations to ultimately extract the location business keys
     UUID.randomUUID().also { dpsLocationId ->
-      nomisMappingApi().stubGetNomisToDpsLocationMapping(2, dpsLocationId.toString())
-      locationsInsidePrisonApi().stubGetLocationById(dpsLocationId, moorlandLocation2)
+      nomisMappingApi().stubGetNomisToDpsLocationMapping(1, dpsLocationId.toString())
+      locationsInsidePrisonApi().stubGetLocationById(dpsLocationId, moorlandLocation)
+    }
+
+    // Mapping NOMIS internal location ID's to locations to ultimately extract the location business keys
+    UUID.randomUUID().also { dpsLocationId ->
+      nomisMappingApi().stubGetNomisToDpsLocationMapping(3, dpsLocationId.toString())
+      locationsInsidePrisonApi().stubGetLocationById(dpsLocationId, moorlandLocation3)
     }
 
     videoBookingRepository.findAll().filter(VideoBooking::isProbationBooking) hasSize 0
@@ -252,19 +369,22 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
 
     val migratedProbationBooking = videoBookingRepository.findAll().single(VideoBooking::isProbationBooking)
 
+    // Assertions on the migrated probation booking
     with(migratedProbationBooking) {
       bookingType isEqualTo "PROBATION"
       statusCode isEqualTo StatusCode.ACTIVE
       probationMeetingType isEqualTo "UNKNOWN"
       createdBy isEqualTo "MIGRATION PROBATION USER"
-      createdTime isCloseTo LocalDateTime.now()
+      createdTime isEqualTo 3.daysAgo().atStartOfDay()
       createdByPrison isBool false
       migratedVideoBookingId isEqualTo 2
-      // TODO if there is an update/amend should the amended attrs be set?
+      amendedBy isEqualTo "MIGRATION PROBATION UPDATE USER"
+      amendedTime isEqualTo 3.daysAgo().atTime(7, 0)
     }
 
     val migratedPrisonAppointment = migratedProbationBooking.appointments().sortedBy(PrisonAppointment::prisonAppointmentId).single()
 
+    // Assertions on the migrated probation bookings appointment
     migratedPrisonAppointment
       .isAtPrison(WERRINGTON)
       .isForPrisoner("DEF123")
@@ -274,21 +394,43 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
       .endsAt(11, 0)
       .hasComments("Migrated probation comments")
 
-    val migratedBookingHistory = bookingHistoryRepository.findAllByVideoBookingIdOrderByCreatedTime(migratedProbationBooking.videoBookingId).single()
+    // Assertions on the migrated booking history and booking history appointment entries
+    val migratedBookingHistory = bookingHistoryRepository.findAllByVideoBookingIdOrderByCreatedTime(migratedProbationBooking.videoBookingId).also { it hasSize 2 }
 
-    migratedBookingHistory.appointments()
-      .single()
-      .isAtPrison(WERRINGTON)
-      .isForPrisoner("DEF123")
-      .isForAppointmentType("VLB_PROBATION")
-      .isAtLocation(moorlandLocation2)
-      .isOnDate(2.daysAgo())
-      .startsAt(10, 0)
-      .endsAt(11, 0)
+    with(migratedBookingHistory.component1()) {
+      historyType isEqualTo HistoryType.CREATE
+      comments isEqualTo "Probation booking create event comments"
 
-    val history = videoBookingEventRepository.findByMainDateBetween(false, 2.daysAgo(), 2.daysAgo()).toList().single()
+      appointments()
+        .single()
+        .isAtPrison(WERRINGTON)
+        .isForPrisoner("DEF123")
+        .isForAppointmentType("VLB_PROBATION")
+        .isAtLocation(moorlandLocation)
+        .isOnDate(2.daysAgo())
+        .startsAt(10, 0)
+        .endsAt(11, 0)
+    }
 
-    with(history) {
+    with(migratedBookingHistory.component2()) {
+      historyType isEqualTo HistoryType.AMEND
+      comments isEqualTo "Probation room changed event comments"
+
+      appointments()
+        .single()
+        .isAtPrison(WERRINGTON)
+        .isForPrisoner("DEF123")
+        .isForAppointmentType("VLB_PROBATION")
+        .isAtLocation(moorlandLocation3)
+        .isOnDate(2.daysAgo())
+        .startsAt(10, 0)
+        .endsAt(11, 0)
+    }
+
+    val createHistoryEvent = videoBookingEventRepository.findById(1).orElseThrow()
+
+    // Assertions on the migrated event history taken from the booking that has been migrated
+    with(createHistoryEvent) {
       timestamp isEqualTo 3.daysAgo().atStartOfDay()
       videoBookingId isEqualTo migratedProbationBooking.videoBookingId
       eventType isEqualTo "CREATE"
@@ -300,7 +442,30 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
       preLocationKey isEqualTo null
       preStartTime isEqualTo null
       preEndTime isEqualTo null
-      mainLocationKey isEqualTo moorlandLocation2.key
+      mainLocationKey isEqualTo moorlandLocation.key
+      mainDate isEqualTo 2.daysAgo()
+      mainStartTime isEqualTo LocalTime.of(10, 0)
+      mainEndTime isEqualTo LocalTime.of(11, 0)
+      preLocationKey isEqualTo null
+      postStartTime isEqualTo null
+      postEndTime isEqualTo null
+    }
+
+    val amendHistoryEvent = videoBookingEventRepository.findById(2).orElseThrow()
+
+    with(amendHistoryEvent) {
+      timestamp isEqualTo 3.daysAgo().atTime(7, 0)
+      videoBookingId isEqualTo migratedProbationBooking.videoBookingId
+      eventType isEqualTo "AMEND"
+      prisonCode isEqualTo WERRINGTON
+      probationTeamDescription isEqualTo "Blackpool MC (PPOC)"
+      probationTeamCode isEqualTo BLACKPOOL_MC_PPOC
+      courtBooking isBool false
+      createdByPrison isBool false
+      preLocationKey isEqualTo null
+      preStartTime isEqualTo null
+      preEndTime isEqualTo null
+      mainLocationKey isEqualTo moorlandLocation3.key
       mainDate isEqualTo 2.daysAgo()
       mainStartTime isEqualTo LocalTime.of(10, 0)
       mainEndTime isEqualTo LocalTime.of(11, 0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateVideoBookingServiceTest.kt
@@ -36,6 +36,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.today
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.werringtonLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withMainCourtPrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withProbationPrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.yesterday
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.BookingHistoryRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
@@ -59,7 +60,7 @@ class MigrateVideoBookingServiceTest {
       on { mapCourtCodeToCourt(DERBY_JUSTICE_CENTRE) } doReturn court(DERBY_JUSTICE_CENTRE)
     }
 
-    whenever(videoBookingRepository.saveAndFlush(argThat { booking -> booking.isCourtBooking() })) doReturn courtBooking()
+    whenever(videoBookingRepository.saveAndFlush(argThat { booking -> booking.isCourtBooking() })) doReturn courtBooking().withMainCourtPrisonAppointment(prisonCode = MOORLAND)
 
     service.migrate(
       VideoBookingMigrateResponse(
@@ -73,7 +74,28 @@ class MigrateVideoBookingServiceTest {
         comments = "Migrated court comments",
         main = AppointmentLocationTimeSlot(1, today(), LocalTime.MIDNIGHT, LocalTime.MIDNIGHT.plusHours(1)),
         cancelled = false,
-        events = emptyList(),
+        events = listOf(
+          VideoBookingEvent(
+            eventId = 1,
+            eventTime = yesterday().atStartOfDay(),
+            eventType = VideoLinkBookingEventType.CREATE,
+            comment = "Court booking create event comments",
+            courtCode = DERBY_JUSTICE_CENTRE,
+            preStartTime = null,
+            preEndTime = null,
+            mainStartTime = today().atTime(9, 0),
+            mainEndTime = today().atTime(10, 0),
+            postStartTime = null,
+            postEndTime = null,
+            prisonCode = MOORLAND,
+            createdByUsername = "MIGRATION COURT CREATE USER",
+            courtName = null,
+            madeByTheCourt = true,
+            preLocationId = null,
+            mainLocationId = 1,
+            postLocationId = null,
+          ),
+        ),
       ),
     )
 
@@ -109,7 +131,7 @@ class MigrateVideoBookingServiceTest {
       on { mapCourtCodeToCourt(DERBY_JUSTICE_CENTRE) } doReturn court(DERBY_JUSTICE_CENTRE)
     }
 
-    whenever(videoBookingRepository.saveAndFlush(argThat { booking -> booking.isCourtBooking() })) doReturn courtBooking()
+    whenever(videoBookingRepository.saveAndFlush(argThat { booking -> booking.isCourtBooking() })) doReturn courtBooking().withMainCourtPrisonAppointment(prisonCode = MOORLAND)
 
     service.migrate(
       VideoBookingMigrateResponse(
@@ -124,7 +146,28 @@ class MigrateVideoBookingServiceTest {
         pre = AppointmentLocationTimeSlot(1, today(), LocalTime.of(9, 0), LocalTime.of(10, 0)),
         main = AppointmentLocationTimeSlot(2, today(), LocalTime.of(10, 0), LocalTime.of(11, 0)),
         cancelled = false,
-        events = emptyList(),
+        events = listOf(
+          VideoBookingEvent(
+            eventId = 1,
+            eventTime = yesterday().atStartOfDay(),
+            eventType = VideoLinkBookingEventType.CREATE,
+            comment = "Court booking create event comments",
+            courtCode = DERBY_JUSTICE_CENTRE,
+            preStartTime = today().atTime(9, 0),
+            preEndTime = today().atTime(10, 0),
+            mainStartTime = today().atTime(10, 0),
+            mainEndTime = today().atTime(11, 0),
+            postStartTime = null,
+            postEndTime = null,
+            prisonCode = MOORLAND,
+            createdByUsername = "MIGRATION COURT CREATE USER",
+            courtName = null,
+            madeByTheCourt = true,
+            preLocationId = 1,
+            mainLocationId = 2,
+            postLocationId = null,
+          ),
+        ),
       ),
     )
 
@@ -174,7 +217,7 @@ class MigrateVideoBookingServiceTest {
       on { mapCourtCodeToCourt(DERBY_JUSTICE_CENTRE) } doReturn court(DERBY_JUSTICE_CENTRE)
     }
 
-    whenever(videoBookingRepository.saveAndFlush(argThat { booking -> booking.isCourtBooking() })) doReturn courtBooking()
+    whenever(videoBookingRepository.saveAndFlush(argThat { booking -> booking.isCourtBooking() })) doReturn courtBooking().withMainCourtPrisonAppointment(prisonCode = MOORLAND)
 
     service.migrate(
       VideoBookingMigrateResponse(
@@ -190,7 +233,28 @@ class MigrateVideoBookingServiceTest {
         main = AppointmentLocationTimeSlot(2, today(), LocalTime.of(9, 0), LocalTime.of(10, 0)),
         post = AppointmentLocationTimeSlot(3, today(), LocalTime.of(10, 0), LocalTime.of(11, 0)),
         cancelled = false,
-        events = emptyList(),
+        events = listOf(
+          VideoBookingEvent(
+            eventId = 1,
+            eventTime = yesterday().atStartOfDay(),
+            eventType = VideoLinkBookingEventType.CREATE,
+            comment = "Court booking create event comments",
+            courtCode = DERBY_JUSTICE_CENTRE,
+            preStartTime = today().atTime(8, 0),
+            preEndTime = today().atTime(9, 0),
+            mainStartTime = today().atTime(9, 0),
+            mainEndTime = today().atTime(10, 0),
+            postStartTime = today().atTime(10, 0),
+            postEndTime = today().atTime(11, 0),
+            prisonCode = MOORLAND,
+            createdByUsername = "MIGRATION COURT CREATE USER",
+            courtName = null,
+            madeByTheCourt = true,
+            preLocationId = 1,
+            mainLocationId = 2,
+            postLocationId = 3,
+          ),
+        ),
       ),
     )
 
@@ -250,7 +314,7 @@ class MigrateVideoBookingServiceTest {
       on { mapCourtCodeToCourt(DERBY_JUSTICE_CENTRE) } doReturn court(DERBY_JUSTICE_CENTRE)
     }
 
-    whenever(videoBookingRepository.saveAndFlush(argThat { booking -> booking.isCourtBooking() })) doReturn courtBooking()
+    whenever(videoBookingRepository.saveAndFlush(argThat { booking -> booking.isCourtBooking() })) doReturn courtBooking().withMainCourtPrisonAppointment(prisonCode = MOORLAND)
 
     service.migrate(
       VideoBookingMigrateResponse(
@@ -265,7 +329,28 @@ class MigrateVideoBookingServiceTest {
         main = AppointmentLocationTimeSlot(1, today(), LocalTime.of(8, 0), LocalTime.of(9, 0)),
         post = AppointmentLocationTimeSlot(2, today(), LocalTime.of(9, 0), LocalTime.of(10, 0)),
         cancelled = false,
-        events = emptyList(),
+        events = listOf(
+          VideoBookingEvent(
+            eventId = 1,
+            eventTime = yesterday().atStartOfDay(),
+            eventType = VideoLinkBookingEventType.CREATE,
+            comment = "Court booking create event comments",
+            courtCode = DERBY_JUSTICE_CENTRE,
+            preStartTime = null,
+            preEndTime = null,
+            mainStartTime = today().atTime(8, 0),
+            mainEndTime = today().atTime(9, 0),
+            postStartTime = today().atTime(9, 0),
+            postEndTime = today().atTime(10, 0),
+            prisonCode = MOORLAND,
+            createdByUsername = "MIGRATION COURT CREATE USER",
+            courtName = null,
+            madeByTheCourt = true,
+            preLocationId = null,
+            mainLocationId = 1,
+            postLocationId = 2,
+          ),
+        ),
       ),
     )
 
@@ -313,7 +398,7 @@ class MigrateVideoBookingServiceTest {
       on { mapProbationTeamCodeToProbationTeam(BLACKPOOL_MC_PPOC) } doReturn probationTeam(BLACKPOOL_MC_PPOC)
     }
 
-    whenever(videoBookingRepository.saveAndFlush(argThat { booking -> booking.isProbationBooking() })) doReturn probationBooking()
+    whenever(videoBookingRepository.saveAndFlush(argThat { booking -> booking.isProbationBooking() })) doReturn probationBooking().withProbationPrisonAppointment(prisonCode = WERRINGTON)
 
     service.migrate(
       VideoBookingMigrateResponse(
@@ -327,7 +412,28 @@ class MigrateVideoBookingServiceTest {
         comments = "Migrated probation comments",
         main = AppointmentLocationTimeSlot(1, today(), LocalTime.MIDNIGHT, LocalTime.MIDNIGHT.plusHours(1)),
         cancelled = false,
-        events = emptyList(),
+        events = listOf(
+          VideoBookingEvent(
+            eventId = 1,
+            eventTime = yesterday().atStartOfDay(),
+            eventType = VideoLinkBookingEventType.CREATE,
+            comment = "Probation booking create event comments",
+            courtCode = BLACKPOOL_MC_PPOC,
+            preStartTime = null,
+            preEndTime = null,
+            mainStartTime = today().atStartOfDay(),
+            mainEndTime = today().atStartOfDay().plusHours(1),
+            postStartTime = null,
+            postEndTime = null,
+            prisonCode = WERRINGTON,
+            createdByUsername = "MIGRATION PROBATION CREATE USER",
+            courtName = null,
+            madeByTheCourt = true,
+            preLocationId = null,
+            mainLocationId = 1,
+            postLocationId = null,
+          ),
+        ),
       ),
     )
 


### PR DESCRIPTION
These changes ensure not only do we keep the created at/by inline with the migrated records but also the amended at/by inline with the migrated bookings.

If an old booking was created a 2 months ago and amended one month ago then the new migrated booking should have the same values.  This ensure we keeps an accurate historic record on migrated records.