### PR TITLE
BAVL-43 handle OTHER court code and trim history comments to 1000 characters.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/migration/MigrationClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/migration/MigrationClient.kt
@@ -89,7 +89,9 @@ data class VideoBookingMigrateResponse(
   val main: AppointmentLocationTimeSlot,
   val post: AppointmentLocationTimeSlot?,
   val events: List<VideoBookingMigrateEvent> = emptyList(),
-)
+) {
+  fun isOtherCourt() = courtCode != null && courtCode.uppercase() == "OTHER"
+}
 
 data class VideoBookingMigrateEvent(
   val eventId: Long,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateMappingService.kt
@@ -18,5 +18,6 @@ class MigrateMappingService(
   fun mapInternalLocationIdToLocation(id: Long) = migrationClient.getLocationByInternalId(id)
 
   fun mapCourtCodeToCourt(code: String) = courtRepository.findByCode(code)
+
   fun mapProbationTeamCodeToProbationTeam(code: String) = probationTeamRepository.findByCode(code)
 }


### PR DESCRIPTION
A trial migration raised a couple of issues:

- `other` court codes
- `comments` too long for booking history