### PR TITLE
BAVL-43 change migration process to use prison-api instead of prisoner-search for prisoner lookup, prisoner-search does not return inactive bookings when looking up by booking id.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/CacheConfiguration.kt
@@ -21,7 +21,8 @@ class CacheConfiguration {
 
     const val VIDEO_LINK_LOCATIONS_CACHE_NAME: String = "video_link_locations"
     const val NON_RESIDENTIAL_LOCATIONS_CACHE_NAME: String = "non_residential_locations"
-    const val LOCATIONS_BY_INTERNAL_ID: String = "locations_by_internal_id"
+    const val MIGRATION_LOCATIONS_CACHE_NAME: String = "locations_by_internal_id"
+    const val MIGRATION_PRISONERS_CACHE_NAME: String = "prisoners_by_booking_id"
   }
 
   @Bean
@@ -29,7 +30,8 @@ class CacheConfiguration {
     ConcurrentMapCacheManager(
       VIDEO_LINK_LOCATIONS_CACHE_NAME,
       NON_RESIDENTIAL_LOCATIONS_CACHE_NAME,
-      LOCATIONS_BY_INTERNAL_ID,
+      MIGRATION_LOCATIONS_CACHE_NAME,
+      MIGRATION_PRISONERS_CACHE_NAME,
     )
 
   @CacheEvict(value = [VIDEO_LINK_LOCATIONS_CACHE_NAME])
@@ -44,9 +46,17 @@ class CacheConfiguration {
     log.info("Evicting cache: $NON_RESIDENTIAL_LOCATIONS_CACHE_NAME after 12 hours")
   }
 
-  @CacheEvict(value = [LOCATIONS_BY_INTERNAL_ID])
-  @Scheduled(fixedDelay = 12, timeUnit = TimeUnit.HOURS)
+  @Deprecated(message = "Can be removed when migration is completed")
+  @CacheEvict(value = [MIGRATION_LOCATIONS_CACHE_NAME])
+  @Scheduled(fixedDelay = 3, timeUnit = TimeUnit.HOURS)
   fun cacheEvictLocationsById() {
-    log.info("Evicting cache: $LOCATIONS_BY_INTERNAL_ID after 12 hours")
+    log.info("Evicting cache: $MIGRATION_LOCATIONS_CACHE_NAME after 3 hours")
+  }
+
+  @Deprecated(message = "Can be removed when migration is completed")
+  @CacheEvict(value = [MIGRATION_PRISONERS_CACHE_NAME])
+  @Scheduled(fixedDelay = 3, timeUnit = TimeUnit.HOURS)
+  fun cacheEvictPrisonersByBookingId() {
+    log.info("Evicting cache: $MIGRATION_PRISONERS_CACHE_NAME after 3 hours")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateMappingService.kt
@@ -13,7 +13,7 @@ class MigrateMappingService(
   private val courtRepository: CourtRepository,
 ) {
   fun mapBookingIdToPrisonerNumber(bookingId: Long): String? =
-    migrationClient.getPrisoner(bookingId)?.prisonerNumber
+    migrationClient.getPrisonerByBookingId(bookingId)?.offenderNo
 
   fun mapInternalLocationIdToLocation(id: Long) = migrationClient.getLocationByInternalId(id)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/MigrateBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/MigrateBookingIntegrationTest.kt
@@ -102,7 +102,7 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
       ),
     )
 
-    prisonSearchApi().stubPostGetPrisonerByBookingId(1, "ABC123", MOORLAND)
+    prisonerApi().stubGetPrisonerByBookingId(1, "ABC123")
 
     // Mapping NOMIS internal location ID's to locations to ultimately extract the location business keys
     UUID.randomUUID().also { dpsLocationId ->
@@ -316,7 +316,7 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
       ),
     )
 
-    prisonSearchApi().stubPostGetPrisonerByBookingId(1, "ABC123", MOORLAND)
+    prisonerApi().stubGetPrisonerByBookingId(1, "ABC123")
 
     // Mapping NOMIS internal location ID's to locations to ultimately extract the location business keys
     UUID.randomUUID().also { dpsLocationId ->
@@ -426,7 +426,7 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
       ),
     )
 
-    prisonSearchApi().stubPostGetPrisonerByBookingId(2, "DEF123", WERRINGTON)
+    prisonerApi().stubGetPrisonerByBookingId(2, "DEF123")
 
     // Mapping NOMIS internal location ID's to locations to ultimately extract the location business keys
     UUID.randomUUID().also { dpsLocationId ->
@@ -591,7 +591,7 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
       ),
     )
 
-    prisonSearchApi().stubPostGetPrisonerByBookingId(2, "DEF123", WERRINGTON)
+    prisonerApi().stubGetPrisonerByBookingId(2, "DEF123")
 
     // Mapping NOMIS internal location ID's to locations to ultimately extract the location business keys
     UUID.randomUUID().also { dpsLocationId ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.MigrationClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonerSchedule
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.ScheduledEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.VIDEO_LINK_BOOKING
@@ -18,6 +19,20 @@ import java.time.LocalDate
 import java.time.LocalTime
 
 class PrisonApiMockServer : MockServer(8094) {
+
+  @Suppress("DeprecatedCallableAddReplaceWith")
+  @Deprecated(message = "Can be removed when migration is completed")
+  fun stubGetPrisonerByBookingId(bookingId: Long, prisonerNumber: String) {
+    stubFor(
+      get("/api/bookings/$bookingId?basicInfo=true")
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(mapper.writeValueAsString(MigrationClient.Prisoner(prisonerNumber)))
+            .withStatus(200),
+        ),
+    )
+  }
 
   fun stubGetInternalLocationByKey(key: String, prisonCode: String, description: String = "location description") {
     stubFor(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonerSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonerSearchApiMockServer.kt
@@ -1,41 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock
 
-import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.BookingIds
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonerSearchPrisoner
 
 class PrisonerSearchApiMockServer : MockServer(8092) {
-
-  @Suppress("DeprecatedCallableAddReplaceWith")
-  @Deprecated(message = "Can be removed when migration is completed")
-  fun stubPostGetPrisonerByBookingId(bookingId: Long, prisonerNumber: String, prisonCode: String) {
-    stubFor(
-      WireMock.post("/prisoner-search/booking-ids")
-        .withRequestBody(WireMock.equalToJson(mapper.writeValueAsString(BookingIds(listOf(bookingId)))))
-        .willReturn(
-          aResponse()
-            .withHeader("Content-Type", "application/json")
-            .withBody(
-              mapper.writeValueAsString(
-                listOf(
-                  prisonerSearchPrisoner(
-                    prisonerNumber = prisonerNumber,
-                    prisonCode = prisonCode,
-                    lastPrisonCode = null,
-                  ),
-                ),
-              ),
-            )
-            .withStatus(200),
-        ),
-    )
-  }
 
   fun stubGetPrisoner(prisonerNumber: String, prisonCode: String = "MDI", lastPrisonCode: String? = null) {
     stubFor(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateMappingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateMappingServiceTest.kt
@@ -5,12 +5,10 @@ import org.mockito.Mockito.mock
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.stub
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.migration.MigrationClient
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.moorlandLocation
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonerSearchPrisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.werringtonLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.CourtRepository
@@ -26,9 +24,9 @@ class MigrateMappingServiceTest {
   @Test
   fun `should map prisoner booking id to prisoner number`() {
     migrationClient.stub {
-      on { getPrisoner(1) } doReturn prisonerSearchPrisoner("ABC123", MOORLAND)
-      on { getPrisoner(2) } doReturn prisonerSearchPrisoner("DEF456", MOORLAND)
-      on { getPrisoner(3) } doReturn prisonerSearchPrisoner("GHI789", MOORLAND)
+      on { getPrisonerByBookingId(1) } doReturn MigrationClient.Prisoner("ABC123")
+      on { getPrisonerByBookingId(2) } doReturn MigrationClient.Prisoner("DEF456")
+      on { getPrisonerByBookingId(3) } doReturn MigrationClient.Prisoner("GHI789")
     }
 
     service.mapBookingIdToPrisonerNumber(1) isEqualTo "ABC123"


### PR DESCRIPTION
We learnt when running migrations looking up inactive bookings by booking ID to get a prisoners number `prisoner-search-api` does not return anything.

To get the desired behavior (that is to find both active and inactive bookings by booking ID) we have had to change to use `prison-api` instead.