### PR TITLE
BAVL-362 view for events used for CSV extraction should not restrict to just enabled courts and probation teams, we need to be able to view both enabled and disabled.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingEvent.kt
@@ -65,6 +65,4 @@ data class VideoBookingEvent(
   val postEndTime: LocalTime? = null,
 
   val courtBooking: Boolean,
-) {
-  fun isCourtBooking() = courtBooking
-}
+)

--- a/src/main/resources/migrations/common/R__v_video_booking_event.sql
+++ b/src/main/resources/migrations/common/R__v_video_booking_event.sql
@@ -32,7 +32,7 @@ from video_booking vlb
   join booking_history_appointment bha_main on bha_main.booking_history_id = bh.booking_history_id and bha_main.appointment_type = 'VLB_COURT_MAIN'
   left join booking_history_appointment bha_pre on bha_pre.booking_history_id = bh.booking_history_id and bha_pre.appointment_type = 'VLB_COURT_PRE'
   left join booking_history_appointment bha_post on bha_post.booking_history_id = bh.booking_history_id and bha_post.appointment_type = 'VLB_COURT_POST'
-  join court c on c.court_id = vlb.court_id and c.enabled = true
+  join court c on c.court_id = vlb.court_id
 where vlb.court_id is not null
 UNION
 select
@@ -63,5 +63,5 @@ select
 from video_booking vlb
   join booking_history bh on bh.video_booking_id = vlb.video_booking_id
   join booking_history_appointment bha_main on bha_main.booking_history_id = bh.booking_history_id and bha_main.appointment_type = 'VLB_PROBATION'
-  join probation_team p on p.probation_team_id = vlb.probation_team_id and p.enabled = true
+  join probation_team p on p.probation_team_id = vlb.probation_team_id
 where vlb.probation_team_id is not null;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CsvDataExtractionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CsvDataExtractionIntegrationTest.kt
@@ -51,11 +51,12 @@ class CsvDataExtractionIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:integration-test-data/seed-probation-events-by-meeting-date-data.sql")
   @Test
   fun `should download probation events by meeting date`() {
-    val probationResponse = webTestClient.downloadProbationDataByMeetingDate(LocalDate.of(2099, 1, 24), 365)
+    val probationResponse = webTestClient.downloadProbationDataByMeetingDate(LocalDate.of(2099, 1, 25), 365)
 
-    probationResponse contains "video-links-by-probation-meeting-date-from-2099-01-24-for-365-days.csv"
+    probationResponse contains "video-links-by-probation-meeting-date-from-2099-01-25-for-365-days.csv"
     probationResponse contains "eventId,timestamp,videoLinkBookingId,eventType,agencyId,probationTeam,probationTeamId,madeByProbation,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName\n" +
-      "-4000,2024-01-01T01:00:00,-4000,CREATE,PVI,\"Blackpool Magistrates - Probation\",BLKPPP,true,2099-01-24T16:00:00,2099-01-24T17:00:00,,,,,\"PVI PVI-ABCDEFG\",,"
+      "-4100,2024-01-01T01:00:00,-4100,CREATE,PVI,\"Unknown Probation Team\",UNKNOWN,true,2099-01-25T16:00:00,2099-01-25T17:00:00,,,,,\"PVI PVI-ABCDEFG\",,\n" +
+      "-4000,2024-01-01T01:00:00,-4000,CREATE,PVI,\"Blackpool Magistrates - Probation\",BLKPPP,true,2099-01-25T16:00:00,2099-01-25T17:00:00,,,,,\"PVI PVI-ABCDEFG\",,\n"
   }
 
   @Test

--- a/src/test/resources/integration-test-data/seed-probation-events-by-meeting-date-data.sql
+++ b/src/test/resources/integration-test-data/seed-probation-events-by-meeting-date-data.sql
@@ -3,10 +3,22 @@ insert into video_booking (video_booking_id, booking_type, status_code, probatio
 values (-4000, 'PROBATION', 'ACTIVE', 1, 'PSR', 'comments about the meeting', 'test_user', '2024-01-01T01:00:00');
 
 insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_loc_key, appointment_date,  start_time, end_time)
-values (-4000, 1, 'ABCDEF', 'VLB_PROBATION', 'comments about the meeting', 'PVI-ABCDEFG', '2099-01-24', '16:00', '17:00');
+values (-4000, 1, 'ABCDEF', 'VLB_PROBATION', 'comments about the meeting', 'PVI-ABCDEFG', '2099-01-25', '16:00', '17:00');
 
 insert into booking_history(booking_history_id, video_booking_id, history_type, probation_team_id, probation_meeting_type, comments, created_by, created_time)
 values (-4000, -4000, 'CREATE', 1, 'PSR','comments about the meeting', 'test_user', '2024-01-01T01:00:00');
 
 insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_loc_key, start_time, end_time)
-values (-4000, 'PVI', 'ABCDEF', '2099-01-24', 'VLB_PROBATION', 'PVI-ABCDEFG', '16:00', '17:00');
+values (-4000, 'PVI', 'ABCDEF', '2099-01-25', 'VLB_PROBATION', 'PVI-ABCDEFG', '16:00', '17:00');
+
+insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, comments, created_by, created_time)
+values (-4100, 'PROBATION', 'ACTIVE', 28, 'PSR', 'comments about the meeting', 'test_user', '2024-01-01T01:00:00');
+
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_loc_key, appointment_date,  start_time, end_time)
+values (-4100, 1, 'DEFGHI', 'VLB_PROBATION', 'comments about the meeting', 'PVI-ABCDEFG', '2099-01-25', '16:00', '17:00');
+
+insert into booking_history(booking_history_id, video_booking_id, history_type, probation_team_id, probation_meeting_type, comments, created_by, created_time)
+values (-4100, -4100, 'CREATE', 28, 'PSR','comments about the meeting', 'test_user', '2024-01-01T01:00:00');
+
+insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_loc_key, start_time, end_time)
+values (-4100, 'PVI', 'ABCDEF', '2099-01-25', 'VLB_PROBATION', 'PVI-ABCDEFG', '16:00', '17:00');


### PR DESCRIPTION
This change fixes an issue noticed during migration testing.

The number of events (used for CSV extraction) in BVLS did not match up with the numbers in old BVL.  This is because we were filtering out disabled courts and probation team events in our view DDL.