### PR TITLE
BAVL-371 first part of 2 changes. The carries through free text court/probation team descriptions and stores on the migrated bookings for migrated records.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/Court.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/Court.kt
@@ -57,6 +57,6 @@ class Court(
 
   @Override
   override fun toString(): String {
-    return this::class.simpleName + "(courtId = $courtId)"
+    return this::class.simpleName + "(courtId = $courtId, code = $code)"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
@@ -51,6 +51,8 @@ class VideoBooking private constructor(
   val createdTime: LocalDateTime = now(),
 
   val migratedVideoBookingId: Long? = null,
+
+  val migratedDescription: String? = null,
 ) {
 
   @OneToMany(mappedBy = "videoBooking", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
@@ -191,6 +193,7 @@ class VideoBooking private constructor(
       cancelledAt: LocalDateTime?,
       updatedBy: String?,
       updatedAt: LocalDateTime?,
+      migratedDescription: String?,
     ): VideoBooking = VideoBooking(
       bookingType = "COURT",
       court = court,
@@ -202,6 +205,7 @@ class VideoBooking private constructor(
       createdTime = createdTime,
       createdByPrison = createdByPrison,
       migratedVideoBookingId = migratedVideoBookingId,
+      migratedDescription = migratedDescription.takeIf { court.isUnknown() },
     ).apply {
       if (cancelledBy != null && cancelledAt != null) {
         statusCode = StatusCode.CANCELLED
@@ -224,6 +228,7 @@ class VideoBooking private constructor(
       cancelledAt: LocalDateTime?,
       updatedBy: String?,
       updatedAt: LocalDateTime?,
+      migratedDescription: String?,
     ): VideoBooking =
       VideoBooking(
         bookingType = "PROBATION",
@@ -236,6 +241,7 @@ class VideoBooking private constructor(
         createdTime = createdTime,
         createdByPrison = createdByPrison,
         migratedVideoBookingId = migratedVideoBookingId,
+        migratedDescription = migratedDescription.takeIf { probationTeam.isUnknown() },
       ).apply {
         if (cancelledBy != null && cancelledAt != null) {
           statusCode = StatusCode.CANCELLED

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateVideoBookingService.kt
@@ -74,7 +74,7 @@ class MigrateVideoBookingService(
 
     val migratedBooking = VideoBooking.migratedCourtBooking(
       court = court,
-      comments = if (court.isUnknown()) "Court ${bookingToMigrate.courtName ?: "UNKNOWN"}\n".plus(bookingToMigrate.comment) else bookingToMigrate.comment,
+      comments = bookingToMigrate.comment,
       createdBy = bookingToMigrate.createdByUsername,
       createdTime = bookingToMigrate.createdAt(),
       createdByPrison = bookingToMigrate.madeByTheCourt.not(),
@@ -83,6 +83,7 @@ class MigrateVideoBookingService(
       cancelledAt = bookingToMigrate.cancelledAt(),
       updatedBy = bookingToMigrate.updatedBy(),
       updatedAt = bookingToMigrate.updatedAt(),
+      migratedDescription = bookingToMigrate.courtName,
     ).apply {
       if (bookingToMigrate.pre != null) {
         addAppointment(
@@ -145,7 +146,7 @@ class MigrateVideoBookingService(
 
     val migratedBooking = VideoBooking.migratedProbationBooking(
       probationTeam = probationTeam,
-      comments = if (probationTeam.isUnknown()) "Probation team ${bookingToMigrate.courtName ?: "UNKNOWN"}\n".plus(bookingToMigrate.comment) else bookingToMigrate.comment,
+      comments = bookingToMigrate.comment,
       createdBy = bookingToMigrate.createdByUsername,
       createdTime = bookingToMigrate.createdAt(),
       createdByPrison = bookingToMigrate.madeByTheCourt.not(),
@@ -154,6 +155,7 @@ class MigrateVideoBookingService(
       cancelledAt = bookingToMigrate.cancelledAt(),
       updatedBy = bookingToMigrate.updatedBy(),
       updatedAt = bookingToMigrate.updatedAt(),
+      migratedDescription = bookingToMigrate.courtName,
     ).addAppointment(
       prison = prison,
       prisonerNumber = prisonerNumber,

--- a/src/main/resources/migrations/common/V2024.04.22__baseline_tables.sql
+++ b/src/main/resources/migrations/common/V2024.04.22__baseline_tables.sql
@@ -190,7 +190,8 @@ CREATE TABLE video_booking
     created_time              timestamp    NOT NULL,
     amended_by                varchar(100),
     amended_time              timestamp,
-    migrated_video_booking_id bigint
+    migrated_video_booking_id bigint,
+    migrated_description      varchar(50)
 );
 
 CREATE INDEX idx_video_booking_type ON video_booking(booking_type);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingTest.kt
@@ -104,6 +104,7 @@ class VideoBookingTest {
       cancelledAt = null,
       updatedAt = null,
       updatedBy = null,
+      migratedDescription = "Free text court description",
     )
 
     with(migratedBooking) {
@@ -117,6 +118,38 @@ class VideoBookingTest {
       comments isEqualTo "migrated court comments"
       hearingType isEqualTo "UNKNOWN"
       migratedVideoBookingId isEqualTo 100
+      migratedDescription isEqualTo null
+    }
+  }
+
+  @Test
+  fun `should create a migrated (unknown) court booking`() {
+    val migratedBooking = VideoBooking.migratedCourtBooking(
+      court = court(code = UNKNOWN_COURT_CODE),
+      createdBy = "migrated court user",
+      createdTime = yesterday().atStartOfDay(),
+      createdByPrison = false,
+      comments = "migrated court comments",
+      migratedVideoBookingId = 100,
+      cancelledBy = null,
+      cancelledAt = null,
+      updatedAt = null,
+      updatedBy = null,
+      migratedDescription = "Free text court description",
+    )
+
+    with(migratedBooking) {
+      isMigrated() isBool true
+      isCourtBooking() isBool true
+      isProbationBooking() isBool false
+      court isEqualTo court(code = UNKNOWN_COURT_CODE)
+      createdBy isEqualTo "migrated court user"
+      createdTime isEqualTo yesterday().atStartOfDay()
+      createdByPrison isBool false
+      comments isEqualTo "migrated court comments"
+      hearingType isEqualTo "UNKNOWN"
+      migratedVideoBookingId isEqualTo 100
+      migratedDescription isEqualTo "Free text court description"
     }
   }
 
@@ -133,6 +166,7 @@ class VideoBookingTest {
       cancelledAt = 1.daysAgo().atStartOfDay(),
       updatedAt = 2.daysAgo().atStartOfDay().plusHours(1),
       updatedBy = "COURT UPDATE USER",
+      migratedDescription = null,
     )
 
     with(migratedBooking) {
@@ -165,6 +199,7 @@ class VideoBookingTest {
       cancelledAt = null,
       updatedAt = 2.daysAgo().atStartOfDay().plusHours(1),
       updatedBy = "COURT UPDATE USER",
+      migratedDescription = null,
     )
 
     with(migratedBooking) {
@@ -197,6 +232,7 @@ class VideoBookingTest {
       cancelledAt = null,
       updatedAt = null,
       updatedBy = null,
+      migratedDescription = null,
     )
 
     migratedBooking.comments?.length isEqualTo 1000
@@ -215,6 +251,7 @@ class VideoBookingTest {
       cancelledAt = null,
       updatedAt = null,
       updatedBy = null,
+      migratedDescription = "Free text probation team description",
     )
 
     with(migratedBooking) {
@@ -228,6 +265,38 @@ class VideoBookingTest {
       comments isEqualTo "migrated probation comments"
       probationMeetingType isEqualTo "UNKNOWN"
       migratedVideoBookingId isEqualTo 100
+      migratedDescription isEqualTo null
+    }
+  }
+
+  @Test
+  fun `should create a migrated (unknown) probation booking`() {
+    val migratedBooking = VideoBooking.migratedProbationBooking(
+      probationTeam = probationTeam(code = UNKNOWN_PROBATION_TEAM_CODE),
+      createdBy = "migrated probation user",
+      createdTime = 3.daysAgo().atStartOfDay(),
+      createdByPrison = false,
+      comments = "migrated probation comments",
+      migratedVideoBookingId = 100,
+      cancelledBy = null,
+      cancelledAt = null,
+      updatedAt = null,
+      updatedBy = null,
+      migratedDescription = "Free text probation team description",
+    )
+
+    with(migratedBooking) {
+      isMigrated() isBool true
+      isProbationBooking() isBool true
+      isCourtBooking() isBool false
+      probationTeam isEqualTo probationTeam(code = UNKNOWN_PROBATION_TEAM_CODE)
+      createdBy isEqualTo "migrated probation user"
+      createdTime isEqualTo 3.daysAgo().atStartOfDay()
+      createdByPrison isBool false
+      comments isEqualTo "migrated probation comments"
+      probationMeetingType isEqualTo "UNKNOWN"
+      migratedVideoBookingId isEqualTo 100
+      migratedDescription isEqualTo "Free text probation team description"
     }
   }
 
@@ -244,6 +313,7 @@ class VideoBookingTest {
       cancelledAt = 2.daysAgo().atStartOfDay(),
       updatedAt = 3.daysAgo().atStartOfDay(),
       updatedBy = "PROBATION UPDATE USER",
+      migratedDescription = null,
     )
 
     with(migratedBooking) {
@@ -276,6 +346,7 @@ class VideoBookingTest {
       cancelledAt = null,
       updatedAt = 3.daysAgo().atStartOfDay(),
       updatedBy = "PROBATION UPDATE USER",
+      migratedDescription = null,
     )
 
     with(migratedBooking) {
@@ -308,6 +379,7 @@ class VideoBookingTest {
       cancelledAt = null,
       updatedAt = null,
       updatedBy = null,
+      migratedDescription = null,
     )
 
     migratedBooking.comments?.length isEqualTo 1000

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/MigrateBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/MigrateBookingIntegrationTest.kt
@@ -132,6 +132,7 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
       createdTime isEqualTo yesterday().atStartOfDay()
       createdByPrison isBool false
       migratedVideoBookingId isEqualTo 1
+      migratedDescription isEqualTo null
       amendedBy isEqualTo "MIGRATION COURT UPDATE USER"
       amendedTime isEqualTo yesterday().atTime(4, 0)
     }
@@ -340,6 +341,7 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
       createdTime isEqualTo yesterday().atStartOfDay()
       createdByPrison isBool false
       migratedVideoBookingId isEqualTo 1
+      migratedDescription isEqualTo "Unknown court name"
     }
 
     // Assertions on the migrated court bookings appointments
@@ -352,7 +354,7 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
       .isOnDate(yesterday())
       .startsAt(10, 0)
       .endsAt(11, 0)
-      .hasComments("Court Unknown court name\nMigrated court comments")
+      .hasComments("Migrated court comments")
 
     val migratedBookingHistory = bookingHistoryRepository.findAllByVideoBookingIdOrderByCreatedTime(migratedCourtBooking.videoBookingId).single()
 
@@ -456,6 +458,7 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
       createdTime isEqualTo 3.daysAgo().atStartOfDay()
       createdByPrison isBool false
       migratedVideoBookingId isEqualTo 2
+      migratedDescription isEqualTo null
       amendedBy isEqualTo "MIGRATION PROBATION UPDATE USER"
       amendedTime isEqualTo 3.daysAgo().atTime(7, 0)
     }
@@ -615,6 +618,7 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
       createdTime isEqualTo 3.daysAgo().atStartOfDay()
       createdByPrison isBool false
       migratedVideoBookingId isEqualTo 2
+      migratedDescription isEqualTo "Unknown probation team"
     }
 
     val migratedPrisonAppointment = migratedProbationBooking.appointments().sortedBy(PrisonAppointment::prisonAppointmentId).single()
@@ -627,7 +631,7 @@ class MigrateBookingIntegrationTest : IntegrationTestBase() {
       .isOnDate(2.daysAgo())
       .startsAt(10, 0)
       .endsAt(11, 0)
-      .hasComments("Probation team Unknown probation team\nMigrated probation comments")
+      .hasComments("Migrated probation comments")
 
     // Assertions on the migrated booking history and booking history appointment entries
     val migratedBookingHistory = bookingHistoryRepository.findAllByVideoBookingIdOrderByCreatedTime(migratedProbationBooking.videoBookingId).single()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateVideoBookingServiceTest.kt
@@ -180,9 +180,10 @@ class MigrateVideoBookingServiceTest {
       bookingType isEqualTo "COURT"
       hearingType isEqualTo "UNKNOWN"
       court isEqualTo court(UNKNOWN_COURT_CODE)
-      comments isEqualTo "Court Unknown court\nMigrated court comments"
+      comments isEqualTo "Migrated court comments"
       createdBy isEqualTo "MIGRATION COURT USER"
       migratedVideoBookingId isEqualTo 1
+      migratedDescription isEqualTo "Unknown court"
     }
 
     with(videoBookingCaptor.firstValue.appointments().single()) {
@@ -193,7 +194,7 @@ class MigrateVideoBookingServiceTest {
       startTime isEqualTo LocalTime.MIDNIGHT
       endTime isEqualTo LocalTime.MIDNIGHT.plusHours(1)
       prisonLocKey isEqualTo wandsworthLocation.key
-      comments isEqualTo "Court Unknown court\nMigrated court comments"
+      comments isEqualTo "Migrated court comments"
     }
   }
 
@@ -213,7 +214,7 @@ class MigrateVideoBookingServiceTest {
         offenderBookingId = 1,
         prisonCode = WANDSWORTH,
         courtCode = "other",
-        courtName = null,
+        courtName = "Free text court name",
         probation = false,
         createdByUsername = "MIGRATION COURT USER",
         madeByTheCourt = true,
@@ -229,7 +230,7 @@ class MigrateVideoBookingServiceTest {
             eventType = VideoLinkBookingEventType.CREATE,
             comment = "Court booking create event comments",
             courtCode = "other",
-            courtName = null,
+            courtName = "Free text court name",
             pre = null,
             main = AppointmentLocationTimeSlot(1, today(), LocalTime.of(9, 0), LocalTime.of(10, 0)),
             post = null,
@@ -247,9 +248,10 @@ class MigrateVideoBookingServiceTest {
       bookingType isEqualTo "COURT"
       hearingType isEqualTo "UNKNOWN"
       court isEqualTo court(UNKNOWN_COURT_CODE)
-      comments isEqualTo "Court UNKNOWN\nMigrated court comments"
+      comments isEqualTo "Migrated court comments"
       createdBy isEqualTo "MIGRATION COURT USER"
       migratedVideoBookingId isEqualTo 1
+      migratedDescription isEqualTo "Free text court name"
     }
 
     with(videoBookingCaptor.firstValue.appointments().single()) {
@@ -260,7 +262,7 @@ class MigrateVideoBookingServiceTest {
       startTime isEqualTo LocalTime.MIDNIGHT
       endTime isEqualTo LocalTime.MIDNIGHT.plusHours(1)
       prisonLocKey isEqualTo wandsworthLocation.key
-      comments isEqualTo "Court UNKNOWN\nMigrated court comments"
+      comments isEqualTo "Migrated court comments"
     }
   }
 
@@ -636,9 +638,10 @@ class MigrateVideoBookingServiceTest {
       bookingType isEqualTo "PROBATION"
       probationMeetingType isEqualTo "UNKNOWN"
       probationTeam isEqualTo probationTeam(UNKNOWN_PROBATION_TEAM_CODE)
-      comments isEqualTo "Probation team Unknown probation team\nMigrated probation comments"
+      comments isEqualTo "Migrated probation comments"
       createdBy isEqualTo "MIGRATION PROBATION USER"
       migratedVideoBookingId isEqualTo 5
+      migratedDescription isEqualTo "Unknown probation team"
     }
 
     with(videoBookingCaptor.firstValue.appointments().single()) {
@@ -649,7 +652,7 @@ class MigrateVideoBookingServiceTest {
       startTime isEqualTo LocalTime.MIDNIGHT
       endTime isEqualTo LocalTime.MIDNIGHT.plusHours(1)
       prisonLocKey isEqualTo pentonvilleLocation.key
-      comments isEqualTo "Probation team Unknown probation team\nMigrated probation comments"
+      comments isEqualTo "Migrated probation comments"
     }
   }
 
@@ -669,7 +672,7 @@ class MigrateVideoBookingServiceTest {
         offenderBookingId = 1,
         prisonCode = PENTONVILLE,
         courtCode = "OTHER",
-        courtName = null,
+        courtName = "Free text probation team name",
         probation = true,
         createdByUsername = "MIGRATION PROBATION USER",
         madeByTheCourt = true,
@@ -690,7 +693,7 @@ class MigrateVideoBookingServiceTest {
             post = null,
             prisonCode = PENTONVILLE,
             createdByUsername = "MIGRATION PROBATION CREATE USER",
-            courtName = null,
+            courtName = "Free text probation team name",
             madeByTheCourt = true,
           ),
         ),
@@ -703,9 +706,10 @@ class MigrateVideoBookingServiceTest {
       bookingType isEqualTo "PROBATION"
       probationMeetingType isEqualTo "UNKNOWN"
       probationTeam isEqualTo probationTeam(UNKNOWN_PROBATION_TEAM_CODE)
-      comments isEqualTo "Probation team UNKNOWN\nMigrated probation comments"
+      comments isEqualTo "Migrated probation comments"
       createdBy isEqualTo "MIGRATION PROBATION USER"
       migratedVideoBookingId isEqualTo 5
+      migratedDescription isEqualTo "Free text probation team name"
     }
 
     with(videoBookingCaptor.firstValue.appointments().single()) {
@@ -716,7 +720,7 @@ class MigrateVideoBookingServiceTest {
       startTime isEqualTo LocalTime.MIDNIGHT
       endTime isEqualTo LocalTime.MIDNIGHT.plusHours(1)
       prisonLocKey isEqualTo pentonvilleLocation.key
-      comments isEqualTo "Probation team UNKNOWN\nMigrated probation comments"
+      comments isEqualTo "Migrated probation comments"
     }
   }
 


### PR DESCRIPTION
The is the first of 2 PR's.

This change adds a new migration field to video bookings to capture free text court and probation team names for those cases where we do not have a matching court or probation team.

This new field needs to be included in the CSV extract when present (and not UNKNOWN which is what we are currently showing).  This will be dealt with in the next PR.