### PR TITLE
BAVL-371 carry through the migrated description if present (to the UI) for migrated bookings.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsService.kt
@@ -37,9 +37,6 @@ class VideoLinkBookingsService(
       ?.let { referenceCodeRepository.findByProbationMeetingType(booking.probationMeetingType!!) }
 
     return booking.toModel(
-      prisonAppointments = booking.appointments(),
-      courtDescription = booking.court?.description,
-      probationTeamDescription = booking.probationTeam?.description,
       courtHearingTypeDescription = hearingType?.description,
       probationMeetingTypeDescription = meetingType?.description,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/VideoLinkBookingMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/VideoLinkBookingMappers.kt
@@ -1,31 +1,26 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping
 
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CourtHearingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.VideoLinkBooking
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment as PrisonAppointmentEntity
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking as VideoBookingEntity
 
 fun VideoBookingEntity.toModel(
-  prisonAppointments: List<PrisonAppointmentEntity>,
-  courtDescription: String? = null,
-  probationTeamDescription: String? = null,
   courtHearingTypeDescription: String? = null,
   probationMeetingTypeDescription: String? = null,
 ) = VideoLinkBooking(
   videoLinkBookingId = videoBookingId,
   bookingType = BookingType.valueOf(bookingType),
   statusCode = BookingStatus.valueOf(statusCode.name),
-  prisonAppointments = prisonAppointments.toModel(),
+  prisonAppointments = appointments().toModel(),
   courtCode = court?.code,
-  courtDescription = court?.code?.let { courtDescription },
+  courtDescription = court?.let { migratedDescription ?: it.description },
   courtHearingType = hearingType?.let { CourtHearingType.valueOf(hearingType!!) },
   courtHearingTypeDescription = hearingType?.let { courtHearingTypeDescription },
-  probationTeamCode = probationTeam?.code.let { probationTeam?.code },
-  probationTeamDescription = probationTeam?.code?.let { probationTeamDescription },
+  probationTeamCode = probationTeam?.code,
+  probationTeamDescription = probationTeam?.let { migratedDescription ?: it.description },
   probationMeetingType = probationMeetingType?.let { ProbationMeetingType.valueOf(probationMeetingType!!) },
   probationMeetingTypeDescription = probationMeetingType?.let { probationMeetingTypeDescription },
   comments = comments,
@@ -36,6 +31,3 @@ fun VideoBookingEntity.toModel(
   amendedBy = amendedBy,
   amendedAt = amendedTime,
 )
-
-fun List<VideoBookingEntity>.toModel(prisonAppointments: List<PrisonAppointment>) =
-  map { it.toModel(prisonAppointments = prisonAppointments) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -19,7 +19,7 @@ val courtAppealReferenceCode = ReferenceCode(1, "COURT_HEARING_TYPE", "APPEAL", 
 fun court(code: String = DERBY_JUSTICE_CENTRE, enabled: Boolean = true) = Court(
   courtId = 0,
   code = code,
-  description = DERBY_JUSTICE_CENTRE,
+  description = code,
   enabled = enabled,
   notes = null,
   createdBy = "Test",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsServiceTest.kt
@@ -269,8 +269,6 @@ class VideoLinkBookingsServiceTest {
       whenever(videoBookingRepository.findById(booking.videoBookingId)) doReturn Optional.of(booking)
 
       service.findMatchingVideoLinkBooking(searchRequest, COURT_USER) isEqualTo booking.toModel(
-        prisonAppointments = booking.appointments(),
-        courtDescription = DERBY_JUSTICE_CENTRE,
         courtHearingTypeDescription = "Tribunal",
       )
     }
@@ -319,8 +317,6 @@ class VideoLinkBookingsServiceTest {
 
       assertThrows<CaseloadAccessException> {
         service.findMatchingVideoLinkBooking(searchRequest, PRISON_USER.copy(activeCaseLoadId = RISLEY)) isEqualTo booking.toModel(
-          prisonAppointments = booking.appointments(),
-          courtDescription = DERBY_JUSTICE_CENTRE,
           courtHearingTypeDescription = "Tribunal",
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/VideoLinkBookingMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/VideoLinkBookingMappersTest.kt
@@ -1,0 +1,91 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.UNKNOWN_PROBATION_TEAM_CODE
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.CHESTERFIELD_JUSTICE_CENTRE
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.daysAgo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CourtHearingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingStatus
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.VideoLinkBooking
+
+class VideoLinkBookingMappersTest {
+
+  @Test
+  fun `should map known court booking entity to model`() {
+    val booking = VideoBooking.newCourtBooking(
+      court(code = CHESTERFIELD_JUSTICE_CENTRE),
+      CourtHearingType.TRIBUNAL.name,
+      comments = "some comments for the court booking",
+      videoUrl = "court video url",
+      createdBy = "test",
+      createdByPrison = false,
+    )
+
+    booking.toModel(courtHearingTypeDescription = "hearing type description") isEqualTo VideoLinkBooking(
+      videoLinkBookingId = booking.videoBookingId,
+      statusCode = BookingStatus.ACTIVE,
+      bookingType = BookingType.COURT,
+      prisonAppointments = emptyList(),
+      courtCode = CHESTERFIELD_JUSTICE_CENTRE,
+      courtDescription = CHESTERFIELD_JUSTICE_CENTRE,
+      courtHearingType = CourtHearingType.TRIBUNAL,
+      courtHearingTypeDescription = "hearing type description",
+      probationTeamCode = null,
+      probationMeetingType = null,
+      probationTeamDescription = null,
+      probationMeetingTypeDescription = null,
+      createdByPrison = false,
+      videoLinkUrl = "court video url",
+      createdBy = "test",
+      createdAt = booking.createdTime,
+      comments = "some comments for the court booking",
+      amendedAt = null,
+      amendedBy = null,
+    )
+  }
+
+  @Test
+  fun `should map migrated unknown probation booking entity to model`() {
+    val booking = VideoBooking.migratedProbationBooking(
+      probationTeam = probationTeam(code = UNKNOWN_PROBATION_TEAM_CODE),
+      createdBy = "migrated probation user",
+      createdTime = 3.daysAgo().atStartOfDay(),
+      createdByPrison = false,
+      comments = "migrated probation comments",
+      migratedVideoBookingId = 100,
+      cancelledBy = null,
+      cancelledAt = null,
+      updatedAt = null,
+      updatedBy = null,
+      migratedDescription = "Free text probation team description",
+    )
+
+    booking.toModel(courtHearingTypeDescription = "hearing type description") isEqualTo VideoLinkBooking(
+      videoLinkBookingId = booking.videoBookingId,
+      statusCode = BookingStatus.ACTIVE,
+      bookingType = BookingType.PROBATION,
+      prisonAppointments = emptyList(),
+      courtCode = null,
+      courtDescription = null,
+      courtHearingType = null,
+      courtHearingTypeDescription = null,
+      probationTeamCode = UNKNOWN_PROBATION_TEAM_CODE,
+      probationMeetingType = ProbationMeetingType.UNKNOWN,
+      probationTeamDescription = "Free text probation team description",
+      probationMeetingTypeDescription = null,
+      createdByPrison = false,
+      videoLinkUrl = null,
+      createdBy = "migrated probation user",
+      createdAt = 3.daysAgo().atStartOfDay(),
+      comments = "migrated probation comments",
+      amendedAt = null,
+      amendedBy = null,
+    )
+  }
+}


### PR DESCRIPTION
When a migrated booking has a free text description for the court or probation team this needs to be carried through to callers of the API e.g. front end.

Previously this would just have had a description of 'uknown'.