### PR TITLE
BAVL-372 external users can no longer see UNKNOWN courts/probation bookings created by prison users.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/VideoBookingAccess.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/VideoBookingAccess.kt
@@ -15,11 +15,14 @@ fun checkVideoBookingAccess(externalUser: User, booking: VideoBooking) {
       throw VideoBookingAccessException("Prison with code ${booking.prisonCode()} for booking with id ${booking.videoBookingId} is not self service")
     }
 
-    if (externalUser.isCourtUser && booking.isCourtBooking()) return
-    if (externalUser.isProbationUser && booking.isProbationBooking()) return
+    if (externalUser.isCourtUser && booking.isCourtBooking() && booking.isAccessibleBy(externalUser)) return
+    if (externalUser.isProbationUser && booking.isProbationBooking() && booking.isAccessibleBy(externalUser)) return
 
     throw VideoBookingAccessException("Required role to view a ${booking.bookingType} booking is missing")
   }
 }
+
+// Unknown courts or probation teams cannot be accessed by external users, they will only ever be set up by prison users
+private fun VideoBooking.isAccessibleBy(user: User) = (user.isCourtUser && court?.isUnknown() == false) || (user.isProbationUser && probationTeam?.isUnknown() == false)
 
 class VideoBookingAccessException(message: String) : RuntimeException(message)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -81,8 +81,8 @@ fun VideoBooking.withMainCourtPrisonAppointment(
     endTime = LocalTime.of(10, 0),
   )
 
-fun probationBooking() = VideoBooking.newProbationBooking(
-  probationTeam = probationTeam(),
+fun probationBooking(probationTeam: ProbationTeam = probationTeam()) = VideoBooking.newProbationBooking(
+  probationTeam = probationTeam,
   probationMeetingType = "PSR",
   comments = "Probation meeting comments",
   videoUrl = "https://probation.meeting.link",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/VideoBookingAccessKtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/VideoBookingAccessKtTest.kt
@@ -3,11 +3,15 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.UNKNOWN_COURT_CODE
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.UNKNOWN_PROBATION_TEAM_CODE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.SERVICE_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationUser
 
 class VideoBookingAccessKtTest {
@@ -19,6 +23,16 @@ class VideoBookingAccessKtTest {
   @Test
   fun `should fail booking check for probation user accessing a court booking`() {
     assertThrows<VideoBookingAccessException> { checkVideoBookingAccess(probationUser(), courtBooking()) }
+  }
+
+  @Test
+  fun `should fail booking check for court user accessing an unknown court booking`() {
+    assertThrows<VideoBookingAccessException> { checkVideoBookingAccess(courtUser(), courtBooking(court = court(code = UNKNOWN_COURT_CODE))) }
+  }
+
+  @Test
+  fun `should fail booking check for probation user accessing an unknown probation booking`() {
+    assertThrows<VideoBookingAccessException> { checkVideoBookingAccess(probationUser(), probationBooking(probationTeam = probationTeam(code = UNKNOWN_PROBATION_TEAM_CODE))) }
   }
 
   @Test


### PR DESCRIPTION
After running a migration it became apparent by tweaking the URL when viewing a booking external users can see UNKNOWN bookings made by prison users.  This change now prevents that from happening.