### PR TITLE
BAVL-374 booking access check now checks if user can see a particular court or probation teams bookings.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/HmppsBookAVideoLinkApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/HmppsBookAVideoLinkApiExceptionHandler.kt
@@ -87,11 +87,11 @@ class HmppsBookAVideoLinkApiExceptionHandler : ResponseEntityExceptionHandler() 
   fun handleVideoBookingAccessException(e: VideoBookingAccessException): ResponseEntity<ErrorResponse> {
     log.info("Video booking access exception: {}", e.message)
     return ResponseEntity
-      .status(FORBIDDEN)
+      .status(NOT_FOUND)
       .body(
         ErrorResponse(
-          status = FORBIDDEN,
-          userMessage = "Forbidden: ${e.message}",
+          status = NOT_FOUND,
+          userMessage = "Not found: ${e.message}",
           developerMessage = e.message,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/CaseloadAccess.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/CaseloadAccess.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security
 
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.PrisonUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserType
 
@@ -8,7 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserType
  * be ignored.
  */
 fun checkCaseLoadAccess(prisonUser: User, prisonCode: String) {
-  if (prisonUser.isUserType(UserType.PRISON) && prisonUser.activeCaseLoadId != prisonCode) throw CaseloadAccessException()
+  if (prisonUser.isUserType(UserType.PRISON) && (prisonUser as PrisonUser).activeCaseLoadId != prisonCode) throw CaseloadAccessException()
 }
 
 class CaseloadAccessException : RuntimeException()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/CaseloadAccess.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/CaseloadAccess.kt
@@ -2,14 +2,13 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security
 
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.PrisonUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserType
 
 /**
  * Caseload access checks are only relevant for prison users. If the current user is not a prison user then it will just
  * be ignored.
  */
 fun checkCaseLoadAccess(prisonUser: User, prisonCode: String) {
-  if (prisonUser.isUserType(UserType.PRISON) && (prisonUser as PrisonUser).activeCaseLoadId != prisonCode) throw CaseloadAccessException()
+  if (prisonUser is PrisonUser && prisonUser.activeCaseLoadId != prisonCode) throw CaseloadAccessException()
 }
 
 class CaseloadAccessException : RuntimeException()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/VideoBookingAccess.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/VideoBookingAccess.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ExternalUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserType
 
 /**
  * Video booking access checks are only relevant for external users.
@@ -11,12 +10,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserType
  * If the current user is not an external user then it will just be ignored.
  */
 fun checkVideoBookingAccess(externalUser: User, booking: VideoBooking) {
-  if (externalUser.isUserType(UserType.EXTERNAL)) {
+  if (externalUser is ExternalUser) {
     if (!booking.prisonIsEnabledForSelfService()) {
       throw VideoBookingAccessException("Prison with code ${booking.prisonCode()} for booking with id ${booking.videoBookingId} is not self service")
     }
-
-    externalUser as ExternalUser
 
     if (externalUser.isCourtUser && booking.isCourtBooking() && booking.isAccessibleBy(externalUser)) return
     if (externalUser.isProbationUser && booking.isProbationBooking() && booking.isAccessibleBy(externalUser)) return

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/VideoBookingAccess.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/VideoBookingAccess.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security
 
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ExternalUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserType
 
@@ -15,6 +16,8 @@ fun checkVideoBookingAccess(externalUser: User, booking: VideoBooking) {
       throw VideoBookingAccessException("Prison with code ${booking.prisonCode()} for booking with id ${booking.videoBookingId} is not self service")
     }
 
+    externalUser as ExternalUser
+
     if (externalUser.isCourtUser && booking.isCourtBooking() && booking.isAccessibleBy(externalUser)) return
     if (externalUser.isProbationUser && booking.isProbationBooking() && booking.isAccessibleBy(externalUser)) return
 
@@ -23,6 +26,6 @@ fun checkVideoBookingAccess(externalUser: User, booking: VideoBooking) {
 }
 
 // Unknown courts or probation teams cannot be accessed by external users, they will only ever be set up by prison users
-private fun VideoBooking.isAccessibleBy(user: User) = (user.isCourtUser && court?.isUnknown() == false) || (user.isProbationUser && probationTeam?.isUnknown() == false)
+private fun VideoBooking.isAccessibleBy(user: ExternalUser) = (user.isCourtUser && court?.isUnknown() == false) || (user.isProbationUser && probationTeam?.isUnknown() == false)
 
 class VideoBookingAccessException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/VideoBookingAccess.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/VideoBookingAccess.kt
@@ -18,7 +18,7 @@ fun checkVideoBookingAccess(externalUser: User, booking: VideoBooking) {
     if (externalUser.isCourtUser && booking.isCourtBooking() && booking.isAccessibleBy(externalUser)) return
     if (externalUser.isProbationUser && booking.isProbationBooking() && booking.isAccessibleBy(externalUser)) return
 
-    throw VideoBookingAccessException("Required role to view a ${booking.bookingType} booking is missing")
+    throw VideoBookingAccessException("Video booking ${booking.videoBookingId} is not accessible by user")
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/VideoBookingAccess.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/VideoBookingAccess.kt
@@ -26,6 +26,8 @@ fun checkVideoBookingAccess(externalUser: User, booking: VideoBooking) {
 }
 
 // Unknown courts or probation teams cannot be accessed by external users, they will only ever be set up by prison users
-private fun VideoBooking.isAccessibleBy(user: ExternalUser) = (user.isCourtUser && court?.isUnknown() == false) || (user.isProbationUser && probationTeam?.isUnknown() == false)
+private fun VideoBooking.isAccessibleBy(user: ExternalUser) =
+  (user.isCourtUser && court?.isUnknown() == false && user.hasAccessTo(court)) ||
+    (user.isProbationUser && probationTeam?.isUnknown() == false && user.hasAccessTo(probationTeam))
 
 class VideoBookingAccessException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AppointmentsService.kt
@@ -22,7 +22,7 @@ class AppointmentsService(
   fun createAppointmentsForCourt(videoBooking: VideoBooking, prisoner: PrisonerDetails, user: User) {
     checkCourtAppointments(prisoner.appointments, prisoner.prisonCode!!, user)
 
-    if (user.isUserType(UserType.PRISON)) {
+    if (user is PrisonUser) {
       prisoner.checkForDuplicateAppointment(AppointmentType.VLB_COURT_MAIN)
     }
 
@@ -49,7 +49,7 @@ class AppointmentsService(
     appointments.checkSuppliedCourtAppointmentDateAndTimesDoNotOverlap()
 
     // Prison users can have overlapping appointments
-    if (!user.isUserType(UserType.PRISON)) {
+    if (user !is PrisonUser) {
       appointments.checkExistingCourtAppointmentDateAndTimesDoNotOverlap(prisonCode)
     }
 
@@ -105,7 +105,7 @@ class AppointmentsService(
   fun createAppointmentForProbation(videoBooking: VideoBooking, prisoner: PrisonerDetails, user: User) {
     checkProbationAppointments(prisoner.appointments, prisoner.prisonCode!!, user)
 
-    if (user.isUserType(UserType.PRISON)) {
+    if (user is PrisonUser) {
       prisoner.checkForDuplicateAppointment(AppointmentType.VLB_PROBATION)
     }
 
@@ -127,7 +127,7 @@ class AppointmentsService(
   }
 
   private fun Prison.rejectIfCannotSelfServeAtPrisonFor(user: User) {
-    if (!user.isUserType(UserType.PRISON)) require(enabled) { "Prison with code $code is not enabled for self service" }
+    if (user !is PrisonUser) require(enabled) { "Prison with code $code is not enabled for self service" }
   }
 
   fun checkProbationAppointments(appointments: List<Appointment>, prisonCode: String, user: User) {
@@ -137,7 +137,7 @@ class AppointmentsService(
       }
 
       // Prison users can have overlapping appointments
-      if (!user.isUserType(UserType.PRISON)) {
+      if (user !is PrisonUser) {
         checkExistingProbationAppointmentDateAndTimesDoNotOverlap(prisonCode)
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
@@ -110,8 +110,8 @@ class BookingFacade(
 
     val emails = contacts.mapNotNull { contact ->
       when (contact.contactType) {
-        ContactType.USER -> CourtEmailFactory.user(contact, prisoner, booking, prison, main, pre, post, locations, eventType).takeIf { user.isUserType(UserType.PRISON, UserType.EXTERNAL) }
-        ContactType.COURT -> CourtEmailFactory.court(contact, prisoner, booking, prison, main, pre, post, locations, eventType).takeIf { user.isUserType(UserType.PRISON, UserType.SERVICE) }
+        ContactType.USER -> CourtEmailFactory.user(contact, prisoner, booking, prison, main, pre, post, locations, eventType).takeIf { user is PrisonUser || user is ExternalUser }
+        ContactType.COURT -> CourtEmailFactory.court(contact, prisoner, booking, prison, main, pre, post, locations, eventType).takeIf { user is PrisonUser || user is ServiceUser }
         ContactType.PRISON -> CourtEmailFactory.prison(contact, prisoner, booking, prison, contacts, main, pre, post, locations, eventType)
         else -> null
       }
@@ -128,8 +128,8 @@ class BookingFacade(
 
     val emails = contacts.mapNotNull { contact ->
       when (contact.contactType) {
-        ContactType.USER -> ProbationEmailFactory.user(contact, prisoner, booking, prison, appointment, location, eventType).takeIf { user.isUserType(UserType.PRISON, UserType.EXTERNAL) }
-        ContactType.PROBATION -> ProbationEmailFactory.probation(contact, prisoner, booking, prison, appointment, location, eventType).takeIf { user.isUserType(UserType.PRISON, UserType.SERVICE) }
+        ContactType.USER -> ProbationEmailFactory.user(contact, prisoner, booking, prison, appointment, location, eventType).takeIf { user is PrisonUser || user is ExternalUser }
+        ContactType.PROBATION -> ProbationEmailFactory.probation(contact, prisoner, booking, prison, appointment, location, eventType).takeIf { user is PrisonUser || user is ServiceUser }
         ContactType.PRISON -> ProbationEmailFactory.prison(contact, prisoner, booking, prison, appointment, location, eventType, contacts)
         else -> null
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ContactsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ContactsService.kt
@@ -57,19 +57,17 @@ class ContactsService(
     }
   }
 
-  fun getPrimaryBookingContacts(videoBookingId: Long, user: User?): List<BookingContact> {
+  fun getPrimaryBookingContacts(videoBookingId: Long, user: User): List<BookingContact> {
     videoBookingRepository.findById(videoBookingId).orElseThrow { EntityNotFoundException("Video booking with ID $videoBookingId not found") }
 
-    val userContact = user?.takeIf { !it.isUserType(UserType.SERVICE) }?.let {
-      it.mayBeEmail()?.let { email ->
-        BookingContact(
-          videoBookingId = videoBookingId,
-          contactType = ContactType.USER,
-          name = it.name,
-          email = email,
-          primaryContact = true,
-        )
-      }
+    val userContact = user.mayBeEmail()?.let { email ->
+      BookingContact(
+        videoBookingId = videoBookingId,
+        contactType = ContactType.USER,
+        name = user.name,
+        email = email,
+        primaryContact = true,
+      )
     }
 
     return bookingContactsRepository.findContactsByVideoBookingIdAndPrimaryContactTrue(videoBookingId).filter { it.email != userContact?.email } + listOfNotNull(userContact)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
@@ -43,7 +43,7 @@ class CreateVideoBookingService(
   private fun createCourt(request: CreateVideoBookingRequest, createdBy: User): Pair<VideoBooking, Prisoner> {
     checkCaseLoadAccess(createdBy, request.prisoner().prisonCode!!)
 
-    require(createdBy.isCourtUser || createdBy.isUserType(UserType.PRISON)) {
+    require((createdBy is ExternalUser && createdBy.isCourtUser) || createdBy.isUserType(UserType.PRISON)) {
       "Only court and prison users can create court bookings."
     }
 
@@ -69,7 +69,7 @@ class CreateVideoBookingService(
   }
 
   private fun createProbation(request: CreateVideoBookingRequest, createdBy: User): Pair<VideoBooking, Prisoner> {
-    require(createdBy.isProbationUser) {
+    require(createdBy is ExternalUser && createdBy.isProbationUser) {
       "Only probation users can create probation bookings."
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
@@ -43,12 +43,12 @@ class CreateVideoBookingService(
   private fun createCourt(request: CreateVideoBookingRequest, createdBy: User): Pair<VideoBooking, Prisoner> {
     checkCaseLoadAccess(createdBy, request.prisoner().prisonCode!!)
 
-    require((createdBy is ExternalUser && createdBy.isCourtUser) || createdBy.isUserType(UserType.PRISON)) {
+    require((createdBy is ExternalUser && createdBy.isCourtUser) || createdBy is PrisonUser) {
       "Only court and prison users can create court bookings."
     }
 
     val court = courtRepository.findByCode(request.courtCode!!)
-      ?.also { if (!createdBy.isUserType(UserType.PRISON)) require(it.enabled) { "Court with code ${it.code} is not enabled" } }
+      ?.also { if (createdBy !is PrisonUser) require(it.enabled) { "Court with code ${it.code} is not enabled" } }
       ?.also { requireNot(it.readOnly) { "Court with code ${it.code} is read-only" } }
       ?: throw EntityNotFoundException("Court with code ${request.courtCode} not found")
 
@@ -60,7 +60,7 @@ class CreateVideoBookingService(
       comments = request.comments,
       videoUrl = request.videoLinkUrl,
       createdBy = createdBy.username,
-      createdByPrison = createdBy.isUserType(UserType.PRISON),
+      createdByPrison = createdBy is PrisonUser,
     )
       .also { booking -> appointmentsService.createAppointmentsForCourt(booking, request.prisoner(), createdBy) }
       .also { booking -> videoBookingRepository.saveAndFlush(booking) }
@@ -85,7 +85,7 @@ class CreateVideoBookingService(
       comments = request.comments,
       videoUrl = request.videoLinkUrl,
       createdBy = createdBy.username,
-      createdByPrison = createdBy.isUserType(UserType.PRISON),
+      createdByPrison = false,
     )
       .also { thisBooking -> appointmentsService.createAppointmentForProbation(thisBooking, request.prisoner(), createdBy) }
       .also { thisBooking -> videoBookingRepository.saveAndFlush(thisBooking) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/UserService.kt
@@ -5,13 +5,21 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.manageusers.ManageUsersClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.manageusers.model.UserDetailsDto.AuthSource
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.isEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Court
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ProbationTeam
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.CourtRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
 import java.util.Objects
 
 const val COURT_USER_GROUP_CODE = "VIDEO_LINK_COURT_USER"
 const val PROBATION_USER_GROUP_CODE = "VIDEO_LINK_PROBATION_USER"
 
 @Service
-class UserService(private val manageUsersClient: ManageUsersClient) {
+class UserService(
+  private val manageUsersClient: ManageUsersClient,
+  private val courtRepository: CourtRepository,
+  private val probationTeamRepository: ProbationTeamRepository,
+) {
 
   companion object {
 
@@ -45,6 +53,8 @@ class UserService(private val manageUsersClient: ManageUsersClient) {
           val userGroups = manageUsersClient.getUsersGroups(userDetails.userId)
           val isCourtUser = userGroups.any { it.groupCode == COURT_USER_GROUP_CODE }
           val isProbationUser = userGroups.any { it.groupCode == PROBATION_USER_GROUP_CODE }
+          val courts = if (isCourtUser) courtRepository.findCourtsByUsername(username).map { it.code }.toSet() else emptySet()
+          val probationTeams = if (isProbationUser) probationTeamRepository.findProbationTeamsByUsername(username).map { it.code }.toSet() else emptySet()
 
           ExternalUser(
             username = username,
@@ -52,6 +62,8 @@ class UserService(private val manageUsersClient: ManageUsersClient) {
             email = if (username.isEmail()) username.lowercase() else manageUsersClient.getUsersEmail(username)?.email?.lowercase(),
             isCourtUser = isCourtUser,
             isProbationUser = isProbationUser,
+            courts = courts,
+            probationTeams = probationTeams,
           )
         }
 
@@ -114,14 +126,21 @@ class ExternalUser(
   val email: String? = null,
   val isCourtUser: Boolean = false,
   val isProbationUser: Boolean = false,
+  private val courts: Set<String> = emptySet(),
+  private val probationTeams: Set<String> = emptySet(),
   username: String,
   name: String,
 ) : User(username, UserType.EXTERNAL, name) {
+
   init {
     require(isCourtUser || isProbationUser) {
       "External user must be a court or probation user"
     }
   }
+
+  fun hasAccessTo(court: Court) = courts.any { it == court.code }
+
+  fun hasAccessTo(probationTeam: ProbationTeam) = probationTeams.any { it == probationTeam.code }
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
@@ -133,6 +152,8 @@ class ExternalUser(
     if (email != other.email) return false
     if (isCourtUser != other.isCourtUser) return false
     if (isProbationUser != other.isProbationUser) return false
+    if (courts != other.courts) return false
+    if (probationTeams != other.probationTeams) return false
 
     return true
   }
@@ -142,6 +163,8 @@ class ExternalUser(
     result = 31 * result + (email?.hashCode() ?: 0)
     result = 31 * result + isCourtUser.hashCode()
     result = 31 * result + isProbationUser.hashCode()
+    result = 31 * result + courts.hashCode()
+    result = 31 * result + probationTeams.hashCode()
     return result
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/UserService.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.manageusers.ManageUsersClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.manageusers.model.UserDetailsDto.AuthSource
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.isEmail
+import java.util.Objects
 
 const val COURT_USER_GROUP_CODE = "VIDEO_LINK_COURT_USER"
 const val PROBATION_USER_GROUP_CODE = "VIDEO_LINK_PROBATION_USER"
@@ -13,30 +14,27 @@ const val PROBATION_USER_GROUP_CODE = "VIDEO_LINK_PROBATION_USER"
 class UserService(private val manageUsersClient: ManageUsersClient) {
 
   companion object {
+
     private enum class ServiceName {
       BOOK_A_VIDEO_LINK_SERVICE,
     }
 
-    fun getServiceAsUser() = User(
-      username = ServiceName.BOOK_A_VIDEO_LINK_SERVICE.name,
-      userType = UserType.SERVICE,
-      name = ServiceName.BOOK_A_VIDEO_LINK_SERVICE.name,
+    private val serviceUser = ServiceUser(
+      ServiceName.BOOK_A_VIDEO_LINK_SERVICE.name,
+      ServiceName.BOOK_A_VIDEO_LINK_SERVICE.name,
     )
 
-    fun getClientAsUser(clientId: String) = User(
-      username = clientId,
-      userType = UserType.SERVICE,
-      name = clientId,
-    )
+    fun getServiceAsUser() = serviceUser
+
+    fun getClientAsUser(clientId: String) = ServiceUser(username = clientId, name = clientId)
   }
 
   fun getUser(username: String): User? =
     manageUsersClient.getUsersDetails(username)?.let { userDetails ->
       when (userDetails.authSource) {
         AuthSource.nomis -> {
-          User(
+          PrisonUser(
             username = username,
-            userType = UserType.PRISON,
             name = userDetails.name,
             email = if (username.isEmail()) username.lowercase() else manageUsersClient.getUsersEmail(username)?.email?.lowercase(),
             activeCaseLoadId = userDetails.activeCaseLoadId,
@@ -48,9 +46,8 @@ class UserService(private val manageUsersClient: ManageUsersClient) {
           val isCourtUser = userGroups.any { it.groupCode == COURT_USER_GROUP_CODE }
           val isProbationUser = userGroups.any { it.groupCode == PROBATION_USER_GROUP_CODE }
 
-          User(
+          ExternalUser(
             username = username,
-            userType = UserType.EXTERNAL,
             name = userDetails.name,
             email = if (username.isEmail()) username.lowercase() else manageUsersClient.getUsersEmail(username)?.email?.lowercase(),
             isCourtUser = isCourtUser,
@@ -63,27 +60,93 @@ class UserService(private val manageUsersClient: ManageUsersClient) {
     }
 }
 
-data class User(
+abstract class User(
   val username: String,
   private val userType: UserType,
   val name: String,
+) {
+  fun isUserType(vararg types: UserType) = types.contains(userType)
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as User
+
+    if (username != other.username) return false
+    if (userType != other.userType) return false
+    if (name != other.name) return false
+
+    return true
+  }
+
+  override fun hashCode() = Objects.hash(username, userType, name)
+}
+
+class PrisonUser(
+  val email: String? = null,
+  val activeCaseLoadId: String? = null,
+  username: String,
+  name: String,
+) : User(username, UserType.PRISON, name) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+    if (!super.equals(other)) return false
+
+    other as PrisonUser
+
+    if (email != other.email) return false
+    if (activeCaseLoadId != other.activeCaseLoadId) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = super.hashCode()
+    result = 31 * result + (email?.hashCode() ?: 0)
+    result = 31 * result + (activeCaseLoadId?.hashCode() ?: 0)
+    return result
+  }
+}
+
+class ExternalUser(
   val email: String? = null,
   val isCourtUser: Boolean = false,
   val isProbationUser: Boolean = false,
-  val activeCaseLoadId: String? = null,
-) {
+  username: String,
+  name: String,
+) : User(username, UserType.EXTERNAL, name) {
   init {
-    require(userType != UserType.EXTERNAL || (isCourtUser || isProbationUser)) {
+    require(isCourtUser || isProbationUser) {
       "External user must be a court or probation user"
-    }
-
-    require(userType == UserType.EXTERNAL || (!isCourtUser && !isProbationUser)) {
-      "Only external users can be court or probation users"
     }
   }
 
-  fun isUserType(vararg types: UserType) = types.contains(userType)
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+    if (!super.equals(other)) return false
+
+    other as ExternalUser
+
+    if (email != other.email) return false
+    if (isCourtUser != other.isCourtUser) return false
+    if (isProbationUser != other.isProbationUser) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = super.hashCode()
+    result = 31 * result + (email?.hashCode() ?: 0)
+    result = 31 * result + isCourtUser.hashCode()
+    result = 31 * result + isProbationUser.hashCode()
+    return result
+  }
 }
+
+class ServiceUser(username: String, name: String) : User(username, UserType.SERVICE, name)
 
 enum class UserType {
   EXTERNAL,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/UserService.kt
@@ -74,11 +74,8 @@ class UserService(
 
 abstract class User(
   val username: String,
-  private val userType: UserType,
   val name: String,
 ) {
-  fun isUserType(vararg types: UserType) = types.contains(userType)
-
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (javaClass != other?.javaClass) return false
@@ -86,13 +83,12 @@ abstract class User(
     other as User
 
     if (username != other.username) return false
-    if (userType != other.userType) return false
     if (name != other.name) return false
 
     return true
   }
 
-  override fun hashCode() = Objects.hash(username, userType, name)
+  override fun hashCode() = Objects.hash(username, name)
 }
 
 class PrisonUser(
@@ -100,7 +96,7 @@ class PrisonUser(
   val activeCaseLoadId: String? = null,
   username: String,
   name: String,
-) : User(username, UserType.PRISON, name) {
+) : User(username, name) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (javaClass != other?.javaClass) return false
@@ -130,7 +126,7 @@ class ExternalUser(
   private val probationTeams: Set<String> = emptySet(),
   username: String,
   name: String,
-) : User(username, UserType.EXTERNAL, name) {
+) : User(username, name) {
 
   init {
     require(isCourtUser || isProbationUser) {
@@ -169,10 +165,4 @@ class ExternalUser(
   }
 }
 
-class ServiceUser(username: String, name: String) : User(username, UserType.SERVICE, name)
-
-enum class UserType {
-  EXTERNAL,
-  PRISON,
-  SERVICE,
-}
+class ServiceUser(username: String, name: String) : User(username, name)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/BvlsRequestContextConfigurationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/BvlsRequestContextConfigurationTest.kt
@@ -13,9 +13,9 @@ import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.core.context.SecurityContextHolder
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.user
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserService.Companion.getClientAsUser
 import uk.gov.justice.hmpps.kotlin.auth.AuthAwareAuthenticationToken
@@ -30,7 +30,7 @@ class BvlsRequestContextConfigurationTest {
 
   @Test
   fun `should populate request context with user`() {
-    val user = user(username = "USER_NAME")
+    val user = courtUser(username = "USER_NAME")
     setSecurityContext(username = user.username)
 
     whenever(userService.getUser(user.username)) doReturn user

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.daysAgo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isCloseTo
@@ -12,7 +13,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.user
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.yesterday
 import java.time.LocalDateTime.now
 import java.time.LocalTime
@@ -39,7 +39,7 @@ class VideoBookingTest {
       locationKey = "loc-key",
     )
 
-    booking.cancel(user())
+    booking.cancel(courtUser())
 
     booking.statusCode isEqualTo StatusCode.CANCELLED
     booking.amendedBy isEqualTo "user"
@@ -58,10 +58,10 @@ class VideoBookingTest {
       locationKey = "loc-key",
     )
 
-    booking.cancel(user())
+    booking.cancel(courtUser())
 
     val exception = assertThrows<IllegalArgumentException> {
-      booking.cancel(user())
+      booking.cancel(courtUser())
     }
 
     exception.message isEqualTo "Video booking ${booking.videoBookingId} is already cancelled"
@@ -80,7 +80,7 @@ class VideoBookingTest {
     )
 
     val exception = assertThrows<IllegalArgumentException> {
-      booking.cancel(user())
+      booking.cancel(courtUser())
     }
 
     exception.message isEqualTo "Video booking ${booking.videoBookingId} cannot be cancelled"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/Courts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/Courts.kt
@@ -2,3 +2,5 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper
 
 const val CHESTERFIELD_JUSTICE_CENTRE = "CHSTMC"
 const val DERBY_JUSTICE_CENTRE = "DRBYMC"
+
+val courts = setOf(CHESTERFIELD_JUSTICE_CENTRE, DERBY_JUSTICE_CENTRE)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -16,8 +16,9 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Prisone
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.RequestVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.UnknownPrisonerDetails
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ExternalUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.PrisonUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserService
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -27,31 +28,34 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prisoner as Mod
 val birminghamLocation = location(prisonCode = BIRMINGHAM, locationKeySuffix = "ABCEDFG", localName = "Birmingham room")
 val inactiveBirminghamLocation = location(prisonCode = BIRMINGHAM, locationKeySuffix = "HIJLKLM", active = false)
 val wandsworthLocation = location(prisonCode = WANDSWORTH, locationKeySuffix = "ABCEDFG", localName = "Wandsworth room")
-val wandsworthLocation2 = location(prisonCode = WANDSWORTH, locationKeySuffix = "ABCEDFG2", localName = "Wandsworth room 2")
-val wandsworthLocation3 = location(prisonCode = WANDSWORTH, locationKeySuffix = "ABCEDFG3", localName = "Wandsworth room 3")
+val wandsworthLocation2 =
+  location(prisonCode = WANDSWORTH, locationKeySuffix = "ABCEDFG2", localName = "Wandsworth room 2")
+val wandsworthLocation3 =
+  location(prisonCode = WANDSWORTH, locationKeySuffix = "ABCEDFG3", localName = "Wandsworth room 3")
 val pentonvilleLocation = location(prisonCode = PENTONVILLE, locationKeySuffix = "ABCDEFG")
 val norwichLocation = location(prisonCode = NORWICH, locationKeySuffix = "ABCDEFG")
 val risleyLocation = location(prisonCode = RISLEY, locationKeySuffix = "ABCDEFG")
 
-fun location(prisonCode: String, locationKeySuffix: String, active: Boolean = true, localName: String? = null) = Location(
-  id = UUID.randomUUID(),
-  prisonId = prisonCode,
-  code = "VIDEOLINK",
-  pathHierarchy = "VIDEOLINK",
-  locationType = Location.LocationType.VIDEO_LINK,
-  permanentlyInactive = false,
-  active = active,
-  deactivatedByParent = false,
-  topLevelId = UUID.randomUUID(),
-  key = "$prisonCode-$locationKeySuffix",
-  isResidential = false,
-  localName = localName,
-  lastModifiedBy = "test user",
-  lastModifiedDate = LocalDateTime.now().toIsoDateTime(),
-  level = 2,
-  leafLevel = true,
-  status = Location.Status.ACTIVE,
-)
+fun location(prisonCode: String, locationKeySuffix: String, active: Boolean = true, localName: String? = null) =
+  Location(
+    id = UUID.randomUUID(),
+    prisonId = prisonCode,
+    code = "VIDEOLINK",
+    pathHierarchy = "VIDEOLINK",
+    locationType = Location.LocationType.VIDEO_LINK,
+    permanentlyInactive = false,
+    active = active,
+    deactivatedByParent = false,
+    topLevelId = UUID.randomUUID(),
+    key = "$prisonCode-$locationKeySuffix",
+    isResidential = false,
+    localName = localName,
+    lastModifiedBy = "test user",
+    lastModifiedDate = LocalDateTime.now().toIsoDateTime(),
+    level = 2,
+    leafLevel = true,
+    status = Location.Status.ACTIVE,
+  )
 
 fun prisonerSearchPrisoner(
   prisonerNumber: String,
@@ -70,9 +74,16 @@ fun prisonerSearchPrisoner(
   lastPrisonId = lastPrisonCode,
 )
 
-fun userEmailAddress(username: String, email: String, verified: Boolean = true) = EmailAddressDto(username, verified, email)
+fun userEmailAddress(username: String, email: String, verified: Boolean = true) =
+  EmailAddressDto(username, verified, email)
 
-fun userDetails(username: String, name: String = "Test User", authSource: AuthSource = AuthSource.auth, activeCaseLoadId: String? = null, userId: String = "TEST") =
+fun userDetails(
+  username: String,
+  name: String = "Test User",
+  authSource: AuthSource = AuthSource.auth,
+  activeCaseLoadId: String? = null,
+  userId: String = "TEST",
+) =
   UserDetailsDto(
     userId = userId,
     username = username,
@@ -82,32 +93,37 @@ fun userDetails(username: String, name: String = "Test User", authSource: AuthSo
     activeCaseLoadId = activeCaseLoadId,
   )
 
-fun user(username: String = "user", userType: UserType = UserType.EXTERNAL, name: String = "Test User", email: String? = null) =
-  User(
+fun serviceUser() = UserService.getServiceAsUser()
+
+fun prisonUser(
+  username: String = "prison_user",
+  name: String = "Prison User",
+  email: String? = "prison.user@prison.com",
+  activeCaseLoadId: String = BIRMINGHAM,
+) =
+  PrisonUser(
     username = username,
-    userType = userType,
     name = name,
     email = email,
-    isCourtUser = userType == UserType.EXTERNAL,
-    isProbationUser = userType == UserType.EXTERNAL,
+    activeCaseLoadId = activeCaseLoadId,
   )
 
 fun courtUser(username: String = "user", name: String = "Test User", email: String? = null) =
-  User(
+  ExternalUser(
     username = username,
-    userType = UserType.EXTERNAL,
     name = name,
     email = email,
     isCourtUser = true,
+    isProbationUser = false,
   )
 
 fun probationUser(username: String = "user", name: String = "Test User", email: String? = null) =
-  User(
+  ExternalUser(
     username = username,
-    userType = UserType.EXTERNAL,
     name = name,
     email = email,
     isProbationUser = true,
+    isCourtUser = false,
   )
 
 fun prisoner(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -115,6 +115,7 @@ fun courtUser(username: String = "user", name: String = "Test User", email: Stri
     email = email,
     isCourtUser = true,
     isProbationUser = false,
+    courts = courts,
   )
 
 fun probationUser(username: String = "user", name: String = "Test User", email: String? = null) =
@@ -124,6 +125,7 @@ fun probationUser(username: String = "user", name: String = "Test User", email: 
     email = email,
     isProbationUser = true,
     isCourtUser = false,
+    probationTeams = probationTeams,
   )
 
 fun prisoner(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ProbationTeams.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ProbationTeams.kt
@@ -2,3 +2,5 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper
 
 const val BLACKPOOL_MC_PPOC = "BLKPPP"
 const val HARROW = "HARROW"
+
+val probationTeams = setOf(BLACKPOOL_MC_PPOC, HARROW)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/Users.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/Users.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper
 
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserService
 
-val COURT_USER = courtUser(username = "court_user", name = "Court User", email = "court.user@court.com")
+val COURT_USER = courtUser(username = "court_user", name = "Court User", email = "court_user")
 val PRISON_USER_BIRMINGHAM = prisonUser()
 val PRISON_USER_PENTONVILLE = prisonUser(activeCaseLoadId = PENTONVILLE)
 val PRISON_USER_RISLEY = prisonUser(activeCaseLoadId = RISLEY)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/Users.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/Users.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper
 
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserService
 
 val COURT_USER = courtUser(username = "court_user", name = "Court User", email = "court.user@court.com")
-val PRISON_USER = user(username = "prison_user", userType = UserType.PRISON, name = "Prison User", email = "prison.user@prison.com")
+val PRISON_USER_BIRMINGHAM = prisonUser()
+val PRISON_USER_PENTONVILLE = prisonUser(activeCaseLoadId = PENTONVILLE)
+val PRISON_USER_RISLEY = prisonUser(activeCaseLoadId = RISLEY)
+val PRISON_USER_WANDSWORTH = prisonUser(activeCaseLoadId = WANDSWORTH)
 val PROBATION_USER = probationUser(username = "probation_user", name = "Probation User", email = "probation.user@probation.com")
-val SERVICE_USER = user(username = "service_user", userType = UserType.SERVICE, name = "service user")
+val SERVICE_USER = UserService.getServiceAsUser()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
@@ -26,7 +26,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateV
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ExternalUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.PrisonUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserType
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
@@ -87,15 +86,15 @@ abstract class IntegrationTestBase {
   protected fun nomisMappingApi() = NomisMappingApiExtension.server
 
   protected fun stubUser(user: User) {
-    val authSource = when {
-      user.isUserType(UserType.EXTERNAL) -> AuthSource.auth
-      user.isUserType(UserType.PRISON) -> AuthSource.nomis
+    val authSource = when (user) {
+      is ExternalUser -> AuthSource.auth
+      is PrisonUser -> AuthSource.nomis
       else -> AuthSource.none
     }
 
-    val userId = when {
-      user.isUserType(UserType.EXTERNAL) -> "external"
-      user.isUserType(UserType.PRISON) -> "nomis"
+    val userId = when (user) {
+      is ExternalUser -> "external"
+      is PrisonUser -> "nomis"
       else -> "other"
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CourtsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CourtsResourceIntegrationTest.kt
@@ -8,10 +8,10 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.user
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.SetCourtPreferencesRequest
@@ -54,8 +54,8 @@ class CourtsResourceIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:integration-test-data/seed-user-court-data.sql")
   @Test
   fun `should return a list of preferred courts for a specified user`() {
-    stubUser(user("michael.horden@itv.com"))
-    val listOfPreferredCourts = webTestClient.getUserPreferenceCourts(user("michael.horden@itv.com"))
+    stubUser(courtUser("michael.horden@itv.com"))
+    val listOfPreferredCourts = webTestClient.getUserPreferenceCourts(courtUser("michael.horden@itv.com"))
 
     // Check that the user-preferences as setup by the SQL above are returned
     assertThat(listOfPreferredCourts).extracting("courtId").containsExactlyInAnyOrder(1L, 2L)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/JobTriggerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/JobTriggerIntegrationTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_CENTRE
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBookingRequest
@@ -114,7 +114,7 @@ class JobTriggerIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `should not send an email to the court to remind them to add the court hearing link to a booking at a non-enabled prison`() {
-    val prisonUser = PRISON_USER.copy(activeCaseLoadId = RISLEY).also(::stubUser)
+    val prisonUser = PRISON_USER_RISLEY.also(::stubUser)
 
     videoBookingRepository.findAll() hasSize 0
     notificationRepository.findAll() hasSize 0

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationTeamsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationTeamsResourceIntegrationTest.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.user
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.ProbationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.SetProbationTeamPreferencesRequest
@@ -54,8 +54,8 @@ class ProbationTeamsResourceIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:integration-test-data/seed-user-probation-team-data.sql")
   @Test
   fun `should return a list of preferred probation teams for a specified user`() {
-    stubUser(user("michael.horden@channel4.com"))
-    val listOfPreferredTeams = webTestClient.getUserPreferenceTeams(user("michael.horden@channel4.com"))
+    stubUser(probationUser("michael.horden@channel4.com"))
+    val listOfPreferredTeams = webTestClient.getUserPreferenceTeams(probationUser("michael.horden@channel4.com"))
 
     // Check that the user-preferences as setup by the SQL above are returned
     assertThat(listOfPreferredTeams).extracting("probationTeamId").containsExactlyInAnyOrder(1L, 2L)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -1149,6 +1149,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     }
   }
 
+  @Sql("classpath:integration-test-data/seed-video-booking-user-preferences.sql")
   @Test
   fun `should fail to amend a court booking when prisoner not at prison`() {
     videoBookingRepository.findAll() hasSize 0

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -877,8 +877,8 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
       .returnResult().responseBody!!
 
     with(error) {
-      status isEqualTo 403
-      userMessage isEqualTo "Forbidden: Prison with code RSI for booking with id 1 is not self service"
+      status isEqualTo 404
+      userMessage isEqualTo "Not found: Prison with code RSI for booking with id 1 is not self service"
       developerMessage isEqualTo "Prison with code RSI for booking with id 1 is not self service"
     }
   }
@@ -1225,8 +1225,8 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
       .returnResult().responseBody!!
 
     with(error) {
-      status isEqualTo 403
-      userMessage isEqualTo "Forbidden: Prison with code RSI for booking with id 1000 is not self service"
+      status isEqualTo 404
+      userMessage isEqualTo "Not found: Prison with code RSI for booking with id 1000 is not self service"
       developerMessage isEqualTo "Prison with code RSI for booking with id 1000 is not self service"
     }
   }
@@ -1484,8 +1484,8 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
       .returnResult().responseBody!!
 
     with(error) {
-      status isEqualTo 403
-      userMessage isEqualTo "Forbidden: Prison with code RSI for booking with id 1001 is not self service"
+      status isEqualTo 404
+      userMessage isEqualTo "Not found: Prison with code RSI for booking with id 1001 is not self service"
       developerMessage isEqualTo "Prison with code RSI for booking with id 1001 is not self service"
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -27,7 +27,9 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.HARROW
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.NORWICH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_PENTONVILLE
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
@@ -171,7 +173,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
 
   @Test
   fun `should create a Derby court booking as prison user and emails sent to Werrington prison and Derby court`() {
-    val prisonUser = PRISON_USER.copy(activeCaseLoadId = PENTONVILLE).also(::stubUser)
+    val prisonUser = PRISON_USER_PENTONVILLE.also(::stubUser)
 
     videoBookingRepository.findAll() hasSize 0
     notificationRepository.findAll() hasSize 0
@@ -200,7 +202,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
       hearingType isEqualTo courtBookingRequest.courtHearingType?.name
       comments isEqualTo "integration test court booking comments"
       videoUrl isEqualTo courtBookingRequest.videoLinkUrl
-      createdBy isEqualTo PRISON_USER.username
+      createdBy isEqualTo PRISON_USER_PENTONVILLE.username
       createdByPrison isEqualTo true
     }
 
@@ -245,7 +247,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
 
   @Test
   fun `should allow creation of overlapping court bookings as a prison user`() {
-    val prisonUser = PRISON_USER.copy(activeCaseLoadId = PENTONVILLE).also(::stubUser)
+    val prisonUser = PRISON_USER_PENTONVILLE.also(::stubUser)
 
     videoBookingRepository.findAll() hasSize 0
     notificationRepository.findAll() hasSize 0
@@ -282,7 +284,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
 
   @Test
   fun `should reject duplicate court booking creation as a prison user`() {
-    val prisonUser = PRISON_USER.copy(activeCaseLoadId = PENTONVILLE).also(::stubUser)
+    val prisonUser = PRISON_USER_PENTONVILLE.also(::stubUser)
 
     videoBookingRepository.findAll() hasSize 0
     notificationRepository.findAll() hasSize 0
@@ -723,7 +725,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
 
   @Test
   fun `should fail to create a probation booking when user is prison user`() {
-    val error = webTestClient.createBookingFails(probationBookingRequest(), PRISON_USER)
+    val error = webTestClient.createBookingFails(probationBookingRequest(), PRISON_USER_BIRMINGHAM)
       .expectStatus().isBadRequest
       .expectStatus().is4xxClientError
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -791,7 +793,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
 
   @Test
   fun `should return the details of a court video link booking by ID when prison is not self service for prison user`() {
-    val prisonUser = PRISON_USER.copy(activeCaseLoadId = RISLEY).also(::stubUser)
+    val prisonUser = PRISON_USER_RISLEY.also(::stubUser)
     videoBookingRepository.findAll() hasSize 0
 
     prisonSearchApi().stubGetPrisoner("123456", RISLEY)
@@ -844,7 +846,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
 
   @Test
   fun `should fail to return the details of a court video link booking by ID if the prison is not self service for court user`() {
-    val prisonUser = PRISON_USER.copy(activeCaseLoadId = RISLEY).also(::stubUser)
+    val prisonUser = PRISON_USER_RISLEY.also(::stubUser)
     videoBookingRepository.findAll() hasSize 0
 
     prisonSearchApi().stubGetPrisoner("123456", RISLEY)
@@ -1230,7 +1232,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
 
   @Test
   fun `should be able to create and amend a court booking when the prison is not enabled as prison user`() {
-    val prisonUser = PRISON_USER.copy(activeCaseLoadId = RISLEY).also(::stubUser)
+    val prisonUser = PRISON_USER_RISLEY.also(::stubUser)
     videoBookingRepository.findAll() hasSize 0
 
     prisonSearchApi().stubGetPrisoner("123456", RISLEY)
@@ -1556,7 +1558,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     val notifications = notificationRepository.findAll().also { it hasSize 2 }
 
     notifications.isPresent("r@r.com", "requested court booking prison template id with email address")
-    notifications.isPresent(PRISON_USER.email!!, "requested court booking user template id")
+    notifications.isPresent(PRISON_USER_BIRMINGHAM.email!!, "requested court booking user template id")
   }
 
   @Test
@@ -1583,7 +1585,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     val notifications = notificationRepository.findAll().also { it hasSize 2 }
 
     notifications.isPresent("j@j.com", "requested court booking prison template id with no email address")
-    notifications.isPresent(PRISON_USER.email!!, "requested court booking user template id")
+    notifications.isPresent(PRISON_USER_BIRMINGHAM.email!!, "requested court booking user template id")
   }
 
   @Test
@@ -1658,7 +1660,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     val notifications = notificationRepository.findAll().also { it hasSize 2 }
 
     notifications.isPresent("r@r.com", "requested probation booking prison template id with email address")
-    notifications.isPresent(PRISON_USER.email!!, "requested probation booking user template id")
+    notifications.isPresent(PRISON_USER_BIRMINGHAM.email!!, "requested probation booking user template id")
   }
 
   @Test
@@ -1685,7 +1687,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     val notifications = notificationRepository.findAll().also { it hasSize 2 }
 
     notifications.isPresent("j@j.com", "requested probation booking prison template id with no email address")
-    notifications.isPresent(PRISON_USER.email!!, "requested probation booking user template id")
+    notifications.isPresent(PRISON_USER_BIRMINGHAM.email!!, "requested probation booking user template id")
   }
 
   @Test
@@ -1823,7 +1825,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
       .uri("/video-link-booking/request")
       .bodyValue(request)
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(user = PRISON_USER.username, roles = listOf("ROLE_BOOK_A_VIDEO_LINK_ADMIN")))
+      .headers(setAuthorisation(user = PRISON_USER_BIRMINGHAM.username, roles = listOf("ROLE_BOOK_A_VIDEO_LINK_ADMIN")))
       .exchange()
       .expectStatus().isOk
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
@@ -248,11 +248,11 @@ class VideoLinkBookingControllerTest {
       contentType = MediaType.APPLICATION_JSON
       requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(PROBATION_USER, LocalDateTime.now()))
     }
-      .andExpect { status { isForbidden() } }.andReturn()
+      .andExpect { status { isNotFound() } }.andReturn()
 
     with(response.resolvedException!!) {
       this isInstanceOf VideoBookingAccessException::class.java
-      message isEqualTo "Required role to view a COURT booking is missing"
+      message isEqualTo "Video booking 0 is not accessible by user"
     }
   }
 
@@ -264,11 +264,11 @@ class VideoLinkBookingControllerTest {
       contentType = MediaType.APPLICATION_JSON
       requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(COURT_USER, LocalDateTime.now()))
     }
-      .andExpect { status { isForbidden() } }.andReturn()
+      .andExpect { status { isNotFound() } }.andReturn()
 
     with(response.resolvedException!!) {
       this isInstanceOf VideoBookingAccessException::class.java
-      message isEqualTo "Required role to view a PROBATION booking is missing"
+      message isEqualTo "Video booking 0 is not accessible by user"
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
@@ -29,19 +29,19 @@ import org.springframework.web.context.WebApplicationContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.BvlsRequestContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.HmppsBookAVideoLinkApiExceptionHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_RISLEY
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_WANDSWORTH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.contains
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtAppealReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isInstanceOf
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.user
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
@@ -145,7 +145,7 @@ class VideoLinkBookingControllerTest {
     val response = mockMvc.post("/video-link-booking") {
       contentType = MediaType.APPLICATION_JSON
       content = json
-      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(user(), LocalDateTime.now()))
+      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(courtUser(), LocalDateTime.now()))
     }
       .andExpect {
         status { isBadRequest() }
@@ -186,13 +186,13 @@ class VideoLinkBookingControllerTest {
     mockMvc.post("/video-link-booking") {
       contentType = MediaType.APPLICATION_JSON
       content = json
-      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(user(), LocalDateTime.now()))
+      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(courtUser(), LocalDateTime.now()))
     }
       .andExpect {
         status { isCreated() }
       }
 
-    verify(bookingFacade).create(objectMapper.readValue(json, CreateVideoBookingRequest::class.java), user())
+    verify(bookingFacade).create(objectMapper.readValue(json, CreateVideoBookingRequest::class.java), courtUser())
   }
 
   @Test
@@ -217,7 +217,7 @@ class VideoLinkBookingControllerTest {
 
     mockMvc.get("/video-link-booking/id/1") {
       contentType = MediaType.APPLICATION_JSON
-      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(PRISON_USER.copy(activeCaseLoadId = WANDSWORTH), LocalDateTime.now()))
+      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(PRISON_USER_WANDSWORTH, LocalDateTime.now()))
     }
       .andExpect {
         status { isOk() }
@@ -231,7 +231,7 @@ class VideoLinkBookingControllerTest {
 
     val response = mockMvc.get("/video-link-booking/id/1") {
       contentType = MediaType.APPLICATION_JSON
-      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(PRISON_USER.copy(activeCaseLoadId = RISLEY), LocalDateTime.now()))
+      requestAttr(BvlsRequestContext::class.simpleName.toString(), BvlsRequestContext(PRISON_USER_RISLEY, LocalDateTime.now()))
     }
       .andExpect {
         status { isForbidden() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/CaseloadAccessKtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/CaseloadAccessKtTest.kt
@@ -4,19 +4,19 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.SERVICE_USER
 
 class CaseloadAccessKtTest {
   @Test
   fun `should fail caseload check when does not match that of prison user`() {
-    assertThrows<CaseloadAccessException> { checkCaseLoadAccess(PRISON_USER.copy(activeCaseLoadId = "THIS"), "THAT") }
+    assertThrows<CaseloadAccessException> { checkCaseLoadAccess(PRISON_USER_BIRMINGHAM, "DIFFERENT_PRISON_CODE") }
   }
 
   @Test
   fun `should succeed caseload check when does match that of prison user`() {
-    assertDoesNotThrow { checkCaseLoadAccess(PRISON_USER.copy(activeCaseLoadId = "MATCH"), "MATCH") }
+    assertDoesNotThrow { checkCaseLoadAccess(PRISON_USER_BIRMINGHAM, PRISON_USER_BIRMINGHAM.activeCaseLoadId!!) }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/VideoBookingAccessKtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/security/VideoBookingAccessKtTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.UNKNOWN_COURT_CODE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.UNKNOWN_PROBATION_TEAM_CODE
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.SERVICE_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
@@ -47,9 +47,9 @@ class VideoBookingAccessKtTest {
 
   @Test
   fun `should succeed booking check when user is not an external user`() {
-    assertDoesNotThrow { checkVideoBookingAccess(PRISON_USER, courtBooking()) }
+    assertDoesNotThrow { checkVideoBookingAccess(PRISON_USER_BIRMINGHAM, courtBooking()) }
     assertDoesNotThrow { checkVideoBookingAccess(SERVICE_USER, courtBooking()) }
-    assertDoesNotThrow { checkVideoBookingAccess(PRISON_USER, probationBooking()) }
+    assertDoesNotThrow { checkVideoBookingAccess(PRISON_USER_BIRMINGHAM, probationBooking()) }
     assertDoesNotThrow { checkVideoBookingAccess(SERVICE_USER, probationBooking()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingServiceTest.kt
@@ -22,9 +22,9 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.CHESTERFIELD_J
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_CENTRE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.amendCourtBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.amendProbationBookingRequest
@@ -36,6 +36,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.pentonvilleLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonerSearchPrisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
@@ -53,7 +54,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security.CaseloadAcce
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security.VideoBookingAccessException
 import java.time.LocalDateTime
 import java.time.LocalTime
-import java.util.Optional
+import java.util.*
 
 class AmendVideoBookingServiceTest {
 
@@ -445,7 +446,7 @@ class AmendVideoBookingServiceTest {
   fun `should fail to amend a Birmingham prison court video booking for Risley prison user`() {
     whenever(videoBookingRepository.findById(1)) doReturn Optional.of(courtBooking().withMainCourtPrisonAppointment())
 
-    assertThrows<CaseloadAccessException> { service.amend(1, mock<AmendVideoBookingRequest>(), PRISON_USER.copy(activeCaseLoadId = RISLEY)) }
+    assertThrows<CaseloadAccessException> { service.amend(1, mock<AmendVideoBookingRequest>(), PRISON_USER_RISLEY) }
   }
 
   @Test
@@ -507,7 +508,7 @@ class AmendVideoBookingServiceTest {
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
     whenever(prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(BIRMINGHAM, birminghamLocation.key, tomorrow())) doReturn listOf(overlappingAppointment)
 
-    assertDoesNotThrow { service.amend(1, amendCourtBookingRequest, PRISON_USER.copy(activeCaseLoadId = BIRMINGHAM)) }
+    assertDoesNotThrow { service.amend(1, amendCourtBookingRequest, PRISON_USER_BIRMINGHAM) }
   }
 
   @Test
@@ -616,7 +617,7 @@ class AmendVideoBookingServiceTest {
     withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
 
     assertDoesNotThrow {
-      service.amend(2, probationBookingRequest, PRISON_USER.copy(activeCaseLoadId = probationBooking.prisonCode()))
+      service.amend(2, probationBookingRequest, prisonUser(activeCaseLoadId = probationBooking.prisonCode()))
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
@@ -1353,7 +1353,7 @@ class BookingFacadeTest {
     // Not ideal but have logic in test to mimic stubbed service behaviour regarding matching email addresses for contacts
     contactsService.stub {
       on { getPrimaryBookingContacts(any(), eq(user)) } doReturn listOfNotNull(
-        bookingContact(contactType = ContactType.USER, email = mayBeEmail, name = user.name).takeUnless { user.isUserType(UserType.SERVICE) },
+        bookingContact(contactType = ContactType.USER, email = mayBeEmail, name = user.name).takeUnless { user is ServiceUser },
         bookingContact(contactType = ContactType.PRISON, email = PRISON_USER_BIRMINGHAM.email, name = PRISON_USER_BIRMINGHAM.name).takeUnless { it.email == mayBeEmail },
         bookingContact(contactType = ContactType.PROBATION, email = PROBATION_USER.email, name = PROBATION_USER.name).takeUnless { it.email == mayBeEmail },
       )
@@ -1370,7 +1370,7 @@ class BookingFacadeTest {
     // Not ideal but have logic in test to mimic stubbed service behaviour regarding matching email addresses for contacts
     contactsService.stub {
       on { getPrimaryBookingContacts(any(), eq(user)) } doReturn listOfNotNull(
-        bookingContact(contactType = ContactType.USER, email = mayBeEmail, name = user.name).takeUnless { user.isUserType(UserType.SERVICE) },
+        bookingContact(contactType = ContactType.USER, email = mayBeEmail, name = user.name).takeUnless { user is ServiceUser },
         bookingContact(contactType = ContactType.PRISON, email = PRISON_USER_BIRMINGHAM.email, name = PRISON_USER_BIRMINGHAM.name).takeUnless { it.email == mayBeEmail },
         bookingContact(contactType = ContactType.COURT, email = COURT_USER.email, name = COURT_USER.name).takeUnless { it.email == mayBeEmail },
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Notification
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_CENTRE
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.SERVICE_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
@@ -211,7 +211,7 @@ class BookingFacadeTest {
       }
       with(emailCaptor.secondValue) {
         this isInstanceOf NewCourtBookingPrisonNoCourtEmail::class.java
-        address isEqualTo PRISON_USER.email
+        address isEqualTo PRISON_USER_BIRMINGHAM.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
           "court" to DERBY_JUSTICE_CENTRE,
           "prison" to "Wandsworth",
@@ -234,7 +234,7 @@ class BookingFacadeTest {
         reason isEqualTo "CREATE"
       }
       with(notificationCaptor.secondValue) {
-        email isEqualTo PRISON_USER.email
+        email isEqualTo PRISON_USER_BIRMINGHAM.email
         templateName isEqualTo "prison template id"
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo courtBooking
@@ -244,18 +244,18 @@ class BookingFacadeTest {
 
     @Test
     fun `should send events and emails on creation of court booking by a prison user`() {
-      setupCourtPrimaryContactsFor(PRISON_USER)
+      setupCourtPrimaryContactsFor(PRISON_USER_BIRMINGHAM)
 
       val bookingRequest = courtBookingRequest(prisonCode = WANDSWORTH, prisonerNumber = courtBookingCreatedByPrison.prisoner())
 
-      whenever(createBookingService.create(bookingRequest, PRISON_USER)) doReturn Pair(courtBookingCreatedByPrison, prisoner(prisonerNumber = courtBookingCreatedByPrison.prisoner(), prisonCode = WANDSWORTH))
+      whenever(createBookingService.create(bookingRequest, PRISON_USER_BIRMINGHAM)) doReturn Pair(courtBookingCreatedByPrison, prisoner(prisonerNumber = courtBookingCreatedByPrison.prisoner(), prisonCode = WANDSWORTH))
       whenever(emailService.send(any<NewCourtBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
       whenever(emailService.send(any<NewCourtBookingCourtEmail>())) doReturn Result.success(emailNotificationId to "court template id")
 
-      facade.create(bookingRequest, PRISON_USER)
+      facade.create(bookingRequest, PRISON_USER_BIRMINGHAM)
 
       inOrder(createBookingService, outboundEventsService, emailService, notificationRepository) {
-        verify(createBookingService).create(bookingRequest, PRISON_USER)
+        verify(createBookingService).create(bookingRequest, PRISON_USER_BIRMINGHAM)
         verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CREATED, courtBookingCreatedByPrison.videoBookingId)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
@@ -266,9 +266,9 @@ class BookingFacadeTest {
       emailCaptor.allValues hasSize 2
       with(emailCaptor.firstValue) {
         this isInstanceOf NewCourtBookingUserEmail::class.java
-        address isEqualTo PRISON_USER.email
+        address isEqualTo PRISON_USER_BIRMINGHAM.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
-          "userName" to PRISON_USER.name,
+          "userName" to PRISON_USER_BIRMINGHAM.name,
           "court" to DERBY_JUSTICE_CENTRE,
           "prison" to "Wandsworth",
           "offenderNo" to "123456",
@@ -298,7 +298,7 @@ class BookingFacadeTest {
 
       notificationCaptor.allValues hasSize 2
       with(notificationCaptor.firstValue) {
-        email isEqualTo PRISON_USER.email
+        email isEqualTo PRISON_USER_BIRMINGHAM.email
         templateName isEqualTo "user template id"
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo courtBookingCreatedByPrison
@@ -363,7 +363,7 @@ class BookingFacadeTest {
 
       with(emailCaptor.secondValue) {
         this isInstanceOf NewProbationBookingPrisonNoProbationEmail::class.java
-        address isEqualTo PRISON_USER.email
+        address isEqualTo PRISON_USER_BIRMINGHAM.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
           "probationTeam" to "probation team description",
           "prison" to "Birmingham",
@@ -385,7 +385,7 @@ class BookingFacadeTest {
       }
 
       with(notificationCaptor.secondValue) {
-        email isEqualTo PRISON_USER.email
+        email isEqualTo PRISON_USER_BIRMINGHAM.email
         templateName isEqualTo "probation template id"
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo probationBookingAtBirminghamPrison
@@ -438,7 +438,7 @@ class BookingFacadeTest {
       }
       with(emailCaptor.secondValue) {
         this isInstanceOf CancelledCourtBookingPrisonNoCourtEmail::class.java
-        address isEqualTo PRISON_USER.email
+        address isEqualTo PRISON_USER_BIRMINGHAM.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
           "court" to DERBY_JUSTICE_CENTRE,
           "prison" to "Wandsworth",
@@ -461,7 +461,7 @@ class BookingFacadeTest {
         reason isEqualTo "CANCEL"
       }
       with(notificationCaptor.secondValue) {
-        email isEqualTo PRISON_USER.email
+        email isEqualTo PRISON_USER_BIRMINGHAM.email
         templateName isEqualTo "prison template id"
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo courtBooking
@@ -471,19 +471,19 @@ class BookingFacadeTest {
 
     @Test
     fun `should send events and emails on cancellation of court booking by prison user`() {
-      setupCourtPrimaryContactsFor(PRISON_USER)
+      setupCourtPrimaryContactsFor(PRISON_USER_BIRMINGHAM)
 
       val prisoner = Prisoner(courtBooking.prisoner(), WANDSWORTH, "Bob", "Builder", yesterday())
 
-      whenever(cancelVideoBookingService.cancel(1, PRISON_USER)) doReturn courtBooking.apply { cancel(PRISON_USER) }
+      whenever(cancelVideoBookingService.cancel(1, PRISON_USER_BIRMINGHAM)) doReturn courtBooking.apply { cancel(PRISON_USER_BIRMINGHAM) }
       whenever(prisonerSearchClient.getPrisoner(courtBooking.prisoner())) doReturn prisoner
       whenever(emailService.send(any<CancelledCourtBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
       whenever(emailService.send(any<CancelledCourtBookingCourtEmail>())) doReturn Result.success(emailNotificationId to "court template id")
 
-      facade.cancel(1, PRISON_USER)
+      facade.cancel(1, PRISON_USER_BIRMINGHAM)
 
       inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
-        verify(cancelVideoBookingService).cancel(1, PRISON_USER)
+        verify(cancelVideoBookingService).cancel(1, PRISON_USER_BIRMINGHAM)
         verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
@@ -494,9 +494,9 @@ class BookingFacadeTest {
       emailCaptor.allValues hasSize 2
       with(emailCaptor.firstValue) {
         this isInstanceOf CancelledCourtBookingUserEmail::class.java
-        address isEqualTo PRISON_USER.email
+        address isEqualTo PRISON_USER_BIRMINGHAM.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
-          "userName" to PRISON_USER.name,
+          "userName" to PRISON_USER_BIRMINGHAM.name,
           "court" to DERBY_JUSTICE_CENTRE,
           "prison" to "Wandsworth",
           "offenderNo" to "123456",
@@ -526,7 +526,7 @@ class BookingFacadeTest {
 
       notificationCaptor.allValues hasSize 2
       with(notificationCaptor.firstValue) {
-        email isEqualTo PRISON_USER.email
+        email isEqualTo PRISON_USER_BIRMINGHAM.email
         templateName isEqualTo "user template id"
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo courtBooking
@@ -581,7 +581,7 @@ class BookingFacadeTest {
 
       with(emailCaptor.secondValue) {
         this isInstanceOf CancelledProbationBookingPrisonNoProbationEmail::class.java
-        address isEqualTo PRISON_USER.email
+        address isEqualTo PRISON_USER_BIRMINGHAM.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
           "probationTeam" to "probation team description",
           "prison" to "Birmingham",
@@ -602,7 +602,7 @@ class BookingFacadeTest {
         reason isEqualTo "CANCEL"
       }
       with(notificationCaptor.secondValue) {
-        email isEqualTo PRISON_USER.email
+        email isEqualTo PRISON_USER_BIRMINGHAM.email
         templateName isEqualTo "prison template id"
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo probationBookingAtBirminghamPrison
@@ -612,19 +612,19 @@ class BookingFacadeTest {
 
     @Test
     fun `should send events and emails on cancellation of probation booking by prison user`() {
-      setupProbationPrimaryContacts(PRISON_USER)
+      setupProbationPrimaryContacts(PRISON_USER_BIRMINGHAM)
 
       val prisoner = Prisoner(probationBookingAtBirminghamPrison.prisoner(), BIRMINGHAM, "Bob", "Builder", yesterday())
 
       whenever(prisonerSearchClient.getPrisoner(prisoner.prisonerNumber)) doReturn prisoner
-      whenever(cancelVideoBookingService.cancel(1, PRISON_USER)) doReturn probationBookingAtBirminghamPrison.apply { cancel(PRISON_USER) }
+      whenever(cancelVideoBookingService.cancel(1, PRISON_USER_BIRMINGHAM)) doReturn probationBookingAtBirminghamPrison.apply { cancel(PRISON_USER_BIRMINGHAM) }
       whenever(emailService.send(any<CancelledProbationBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
       whenever(emailService.send(any<CancelledProbationBookingProbationEmail>())) doReturn Result.success(emailNotificationId to "probation template id")
 
-      facade.cancel(1, PRISON_USER)
+      facade.cancel(1, PRISON_USER_BIRMINGHAM)
 
       inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
-        verify(cancelVideoBookingService).cancel(1, PRISON_USER)
+        verify(cancelVideoBookingService).cancel(1, PRISON_USER_BIRMINGHAM)
         verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
@@ -635,9 +635,9 @@ class BookingFacadeTest {
       emailCaptor.allValues hasSize 2
       with(emailCaptor.firstValue) {
         this isInstanceOf CancelledProbationBookingUserEmail::class.java
-        address isEqualTo PRISON_USER.email
+        address isEqualTo PRISON_USER_BIRMINGHAM.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
-          "userName" to PRISON_USER.name,
+          "userName" to PRISON_USER_BIRMINGHAM.name,
           "probationTeam" to "probation team description",
           "prison" to "Birmingham",
           "offenderNo" to "654321",
@@ -664,7 +664,7 @@ class BookingFacadeTest {
 
       notificationCaptor.allValues hasSize 2
       with(notificationCaptor.firstValue) {
-        email isEqualTo PRISON_USER.email
+        email isEqualTo PRISON_USER_BIRMINGHAM.email
         templateName isEqualTo "user template id"
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo probationBookingAtBirminghamPrison
@@ -722,7 +722,7 @@ class BookingFacadeTest {
       }
       with(emailCaptor.secondValue) {
         this isInstanceOf AmendedCourtBookingPrisonNoCourtEmail::class.java
-        address isEqualTo PRISON_USER.email
+        address isEqualTo PRISON_USER_BIRMINGHAM.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
           "court" to DERBY_JUSTICE_CENTRE,
           "prison" to "Wandsworth",
@@ -745,7 +745,7 @@ class BookingFacadeTest {
         reason isEqualTo "AMEND"
       }
       with(notificationCaptor.secondValue) {
-        email isEqualTo PRISON_USER.email
+        email isEqualTo PRISON_USER_BIRMINGHAM.email
         templateName isEqualTo "prison template id"
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo courtBooking
@@ -755,18 +755,18 @@ class BookingFacadeTest {
 
     @Test
     fun `should send events and emails on amendment of court booking by prison user`() {
-      setupCourtPrimaryContactsFor(PRISON_USER)
+      setupCourtPrimaryContactsFor(PRISON_USER_BIRMINGHAM)
 
       val bookingRequest = amendCourtBookingRequest(prisonCode = WANDSWORTH, prisonerNumber = "123456")
 
-      whenever(amendBookingService.amend(1, bookingRequest, PRISON_USER)) doReturn Pair(courtBooking, prisoner(prisonerNumber = "123456", prisonCode = WANDSWORTH))
+      whenever(amendBookingService.amend(1, bookingRequest, PRISON_USER_BIRMINGHAM)) doReturn Pair(courtBooking, prisoner(prisonerNumber = "123456", prisonCode = WANDSWORTH))
       whenever(emailService.send(any<AmendedCourtBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
       whenever(emailService.send(any<AmendedCourtBookingCourtEmail>())) doReturn Result.success(emailNotificationId to "court template id")
 
-      facade.amend(1, bookingRequest, PRISON_USER)
+      facade.amend(1, bookingRequest, PRISON_USER_BIRMINGHAM)
 
       inOrder(amendBookingService, emailService, notificationRepository) {
-        verify(amendBookingService).amend(1, bookingRequest, PRISON_USER)
+        verify(amendBookingService).amend(1, bookingRequest, PRISON_USER_BIRMINGHAM)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
         verify(emailService).send(emailCaptor.capture())
@@ -776,9 +776,9 @@ class BookingFacadeTest {
       emailCaptor.allValues hasSize 2
       with(emailCaptor.firstValue) {
         this isInstanceOf AmendedCourtBookingUserEmail::class.java
-        address isEqualTo PRISON_USER.email
+        address isEqualTo PRISON_USER_BIRMINGHAM.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
-          "userName" to PRISON_USER.name,
+          "userName" to PRISON_USER_BIRMINGHAM.name,
           "court" to DERBY_JUSTICE_CENTRE,
           "offenderNo" to "123456",
           "prisonerName" to "Fred Bloggs",
@@ -808,7 +808,7 @@ class BookingFacadeTest {
 
       notificationCaptor.allValues hasSize 2
       with(notificationCaptor.firstValue) {
-        email isEqualTo PRISON_USER.email
+        email isEqualTo PRISON_USER_BIRMINGHAM.email
         templateName isEqualTo "user template id"
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo courtBooking
@@ -865,7 +865,7 @@ class BookingFacadeTest {
       }
       with(emailCaptor.secondValue) {
         this isInstanceOf AmendedProbationBookingPrisonNoProbationEmail::class.java
-        address isEqualTo PRISON_USER.email
+        address isEqualTo PRISON_USER_BIRMINGHAM.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
           "probationTeam" to "probation team description",
           "prison" to "Birmingham",
@@ -886,7 +886,7 @@ class BookingFacadeTest {
         reason isEqualTo "AMEND"
       }
       with(notificationCaptor.secondValue) {
-        email isEqualTo PRISON_USER.email
+        email isEqualTo PRISON_USER_BIRMINGHAM.email
         templateName isEqualTo "prison template id"
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo probationBookingAtBirminghamPrison
@@ -896,7 +896,7 @@ class BookingFacadeTest {
 
     @Test
     fun `should send events and emails on amendment of probation booking by prison user`() {
-      setupProbationPrimaryContacts(PRISON_USER)
+      setupProbationPrimaryContacts(PRISON_USER_BIRMINGHAM)
 
       val prisoner = Prisoner(probationBookingAtBirminghamPrison.prisoner(), BIRMINGHAM, "Bob", "Builder", yesterday())
 
@@ -904,14 +904,14 @@ class BookingFacadeTest {
 
       val amendRequest = amendProbationBookingRequest(prisonCode = prisoner.prisonId!!, prisonerNumber = prisoner.prisonerNumber, appointmentDate = tomorrow())
 
-      whenever(amendBookingService.amend(1, amendRequest, PRISON_USER)) doReturn Pair(probationBookingAtBirminghamPrison, prisoner(prisonerNumber = prisoner.prisonerNumber, prisonCode = prisoner.prisonId!!))
+      whenever(amendBookingService.amend(1, amendRequest, PRISON_USER_BIRMINGHAM)) doReturn Pair(probationBookingAtBirminghamPrison, prisoner(prisonerNumber = prisoner.prisonerNumber, prisonCode = prisoner.prisonId!!))
       whenever(emailService.send(any<AmendedProbationBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
       whenever(emailService.send(any<AmendedProbationBookingProbationEmail>())) doReturn Result.success(emailNotificationId to "probation template id")
 
-      facade.amend(1, amendRequest, PRISON_USER)
+      facade.amend(1, amendRequest, PRISON_USER_BIRMINGHAM)
 
       inOrder(amendBookingService, outboundEventsService, emailService, notificationRepository) {
-        verify(amendBookingService).amend(1, amendRequest, PRISON_USER)
+        verify(amendBookingService).amend(1, amendRequest, PRISON_USER_BIRMINGHAM)
         verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_AMENDED, 1)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
@@ -922,9 +922,9 @@ class BookingFacadeTest {
       emailCaptor.allValues hasSize 2
       with(emailCaptor.firstValue) {
         this isInstanceOf AmendedProbationBookingUserEmail::class.java
-        address isEqualTo PRISON_USER.email
+        address isEqualTo PRISON_USER_BIRMINGHAM.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
-          "userName" to PRISON_USER.name,
+          "userName" to PRISON_USER_BIRMINGHAM.name,
           "probationTeam" to "probation team description",
           "prison" to "Birmingham",
           "offenderNo" to "654321",
@@ -950,7 +950,7 @@ class BookingFacadeTest {
 
       notificationCaptor.allValues hasSize 2
       with(notificationCaptor.firstValue) {
-        email isEqualTo PRISON_USER.email
+        email isEqualTo PRISON_USER_BIRMINGHAM.email
         templateName isEqualTo "user template id"
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo probationBookingAtBirminghamPrison
@@ -1056,7 +1056,7 @@ class BookingFacadeTest {
       emailCaptor.allValues hasSize 2
       with(emailCaptor.firstValue) {
         this isInstanceOf TransferredProbationBookingPrisonProbationEmail::class.java
-        address isEqualTo PRISON_USER.email
+        address isEqualTo PRISON_USER_BIRMINGHAM.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
           "probationTeam" to "probation team description",
           "probationEmailAddress" to "probation.user@probation.com",
@@ -1086,7 +1086,7 @@ class BookingFacadeTest {
 
       notificationCaptor.allValues hasSize 2
       with(notificationCaptor.firstValue) {
-        email isEqualTo PRISON_USER.email
+        email isEqualTo PRISON_USER_BIRMINGHAM.email
         templateName isEqualTo "prison template id"
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo probationBookingAtBirminghamPrison
@@ -1137,7 +1137,7 @@ class BookingFacadeTest {
       emailCaptor.allValues hasSize 2
       with(emailCaptor.firstValue) {
         this isInstanceOf ReleasedCourtBookingPrisonCourtEmail::class.java
-        address isEqualTo PRISON_USER.email
+        address isEqualTo PRISON_USER_BIRMINGHAM.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
           "court" to DERBY_JUSTICE_CENTRE,
           "prison" to "Wandsworth",
@@ -1171,7 +1171,7 @@ class BookingFacadeTest {
 
       notificationCaptor.allValues hasSize 2
       with(notificationCaptor.firstValue) {
-        email isEqualTo PRISON_USER.email
+        email isEqualTo PRISON_USER_BIRMINGHAM.email
         templateName isEqualTo "prison template id"
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo courtBooking
@@ -1218,7 +1218,7 @@ class BookingFacadeTest {
       emailCaptor.allValues hasSize 2
       with(emailCaptor.firstValue) {
         this isInstanceOf ReleasedProbationBookingPrisonProbationEmail::class.java
-        address isEqualTo PRISON_USER.email
+        address isEqualTo PRISON_USER_BIRMINGHAM.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
           "probationTeam" to "probation team description",
           "probationEmailAddress" to "probation.user@probation.com",
@@ -1248,7 +1248,7 @@ class BookingFacadeTest {
 
       notificationCaptor.allValues hasSize 2
       with(notificationCaptor.firstValue) {
-        email isEqualTo PRISON_USER.email
+        email isEqualTo PRISON_USER_BIRMINGHAM.email
         templateName isEqualTo "prison template id"
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo courtBooking
@@ -1344,23 +1344,35 @@ class BookingFacadeTest {
   }
 
   private fun setupProbationPrimaryContacts(user: User) {
+    val mayBeEmail = when (user) {
+      is ExternalUser -> user.email
+      is PrisonUser -> user.email
+      else -> null
+    }
+
     // Not ideal but have logic in test to mimic stubbed service behaviour regarding matching email addresses for contacts
     contactsService.stub {
       on { getPrimaryBookingContacts(any(), eq(user)) } doReturn listOfNotNull(
-        bookingContact(contactType = ContactType.USER, email = user.email, name = user.name).takeUnless { user.isUserType(UserType.SERVICE) },
-        bookingContact(contactType = ContactType.PRISON, email = PRISON_USER.email, name = PRISON_USER.name).takeUnless { it.email == user.email },
-        bookingContact(contactType = ContactType.PROBATION, email = PROBATION_USER.email, name = PROBATION_USER.name).takeUnless { it.email == user.email },
+        bookingContact(contactType = ContactType.USER, email = mayBeEmail, name = user.name).takeUnless { user.isUserType(UserType.SERVICE) },
+        bookingContact(contactType = ContactType.PRISON, email = PRISON_USER_BIRMINGHAM.email, name = PRISON_USER_BIRMINGHAM.name).takeUnless { it.email == mayBeEmail },
+        bookingContact(contactType = ContactType.PROBATION, email = PROBATION_USER.email, name = PROBATION_USER.name).takeUnless { it.email == mayBeEmail },
       )
     }
   }
 
   private fun setupCourtPrimaryContactsFor(user: User) {
+    val mayBeEmail = when (user) {
+      is ExternalUser -> user.email
+      is PrisonUser -> user.email
+      else -> null
+    }
+
     // Not ideal but have logic in test to mimic stubbed service behaviour regarding matching email addresses for contacts
     contactsService.stub {
       on { getPrimaryBookingContacts(any(), eq(user)) } doReturn listOfNotNull(
-        bookingContact(contactType = ContactType.USER, email = user.email, name = user.name).takeUnless { user.isUserType(UserType.SERVICE) },
-        bookingContact(contactType = ContactType.PRISON, email = PRISON_USER.email, name = PRISON_USER.name).takeUnless { it.email == user.email },
-        bookingContact(contactType = ContactType.COURT, email = COURT_USER.email, name = COURT_USER.name).takeUnless { it.email == user.email },
+        bookingContact(contactType = ContactType.USER, email = mayBeEmail, name = user.name).takeUnless { user.isUserType(UserType.SERVICE) },
+        bookingContact(contactType = ContactType.PRISON, email = PRISON_USER_BIRMINGHAM.email, name = PRISON_USER_BIRMINGHAM.name).takeUnless { it.email == mayBeEmail },
+        bookingContact(contactType = ContactType.COURT, email = COURT_USER.email, name = COURT_USER.name).takeUnless { it.email == mayBeEmail },
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CancelVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CancelVideoBookingServiceTest.kt
@@ -14,9 +14,9 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.StatusCode
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
@@ -84,7 +84,7 @@ class CancelVideoBookingServiceTest {
 
     probationBooking.statusCode isEqualTo StatusCode.ACTIVE
 
-    val booking = service.cancel(1, PRISON_USER.copy(activeCaseLoadId = BIRMINGHAM))
+    val booking = service.cancel(1, PRISON_USER_BIRMINGHAM)
 
     booking.statusCode isEqualTo StatusCode.CANCELLED
 
@@ -99,7 +99,7 @@ class CancelVideoBookingServiceTest {
 
     probationBooking.statusCode isEqualTo StatusCode.ACTIVE
 
-    assertThrows<CaseloadAccessException> { service.cancel(1, PRISON_USER.copy(activeCaseLoadId = RISLEY)) }
+    assertThrows<CaseloadAccessException> { service.cancel(1, PRISON_USER_RISLEY) }
 
     verifyNoInteractions(bookingHistoryService)
     verify(videoBookingRepository, never()).saveAndFlush(any())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ContactsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ContactsServiceTest.kt
@@ -12,12 +12,15 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.contact
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.user
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.serviceUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.BookingContactsRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ContactsRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
@@ -39,8 +42,8 @@ class ContactsServiceTest {
 
     whenever(bookingContactsRepository.findContactsByVideoBookingId(videoBookingId)) doReturn listOf(bookingContact)
     whenever(videoBookingRepository.findById(videoBookingId)) doReturn Optional.of(booking)
-    whenever(userService.getUser("createdByUser")) doReturn user(name = "Created User", email = "created@example.com")
-    whenever(userService.getUser("amendedByUser")) doReturn user(name = "Amended User", email = "amended@example.com")
+    whenever(userService.getUser("createdByUser")) doReturn courtUser(name = "Created User", email = "created@example.com")
+    whenever(userService.getUser("amendedByUser")) doReturn courtUser(name = "Amended User", email = "amended@example.com")
 
     val result = service.getAllBookingContacts(videoBookingId)
 
@@ -70,7 +73,7 @@ class ContactsServiceTest {
     whenever(contactsRepository.findContactsByContactTypeAndCodeAndPrimaryContactTrue(ContactType.COURT, court.code)) doReturn listOf(courtContact)
     whenever(contactsRepository.findContactsByContactTypeAndCodeAndPrimaryContactTrue(ContactType.PRISON, prison.code)) doReturn listOf(prisonContact)
 
-    val result = service.getContactsForCourtBookingRequest(court, prison, user(name = "User Name"))
+    val result = service.getContactsForCourtBookingRequest(court, prison, courtUser(name = "User Name"))
 
     result hasSize 3
     result.containsAll(listOf(courtContact, prisonContact)) isBool true
@@ -88,7 +91,7 @@ class ContactsServiceTest {
     whenever(contactsRepository.findContactsByContactTypeAndCodeAndPrimaryContactTrue(ContactType.PROBATION, probationTeam.code)) doReturn listOf(probationContact)
     whenever(contactsRepository.findContactsByContactTypeAndCodeAndPrimaryContactTrue(ContactType.PRISON, prison.code)) doReturn listOf(prisonContact)
 
-    val result = service.getContactsForProbationBookingRequest(probationTeam, prison, user(name = "User Name"))
+    val result = service.getContactsForProbationBookingRequest(probationTeam, prison, probationUser(name = "User Name"))
 
     result hasSize 3
     result.containsAll(listOf(probationContact, prisonContact)) isBool true
@@ -103,7 +106,7 @@ class ContactsServiceTest {
 
     whenever(bookingContactsRepository.findContactsByVideoBookingIdAndPrimaryContactTrue(1L)) doReturn listOf(bookingContact)
 
-    val result = service.getPrimaryBookingContacts(1L, user(name = "User Name", email = "prison.contact@example.com"))
+    val result = service.getPrimaryBookingContacts(1L, prisonUser(name = "User Name", email = "prison.contact@example.com"))
 
     result.single().contactType isEqualTo ContactType.USER
   }
@@ -116,7 +119,7 @@ class ContactsServiceTest {
 
     whenever(bookingContactsRepository.findContactsByVideoBookingIdAndPrimaryContactTrue(1L)) doReturn listOf(bookingContact)
 
-    val result = service.getPrimaryBookingContacts(1L, user(name = "User Name", email = "prisoner.contact@example.com"))
+    val result = service.getPrimaryBookingContacts(1L, prisonUser(name = "User Name", email = "prisoner.contact@example.com"))
 
     result.map { it.contactType } containsExactlyInAnyOrder listOf(ContactType.PRISON, ContactType.USER)
   }
@@ -129,7 +132,7 @@ class ContactsServiceTest {
 
     whenever(bookingContactsRepository.findContactsByVideoBookingIdAndPrimaryContactTrue(1L)) doReturn listOf(bookingContact)
 
-    val result = service.getPrimaryBookingContacts(1L, user(name = "User Name", userType = UserType.SERVICE, email = "blah"))
+    val result = service.getPrimaryBookingContacts(1L, serviceUser())
 
     result.single().contactType isEqualTo ContactType.PRISON
   }
@@ -142,7 +145,7 @@ class ContactsServiceTest {
 
     whenever(bookingContactsRepository.findContactsByVideoBookingIdAndPrimaryContactTrue(1L)) doReturn listOf(bookingContact)
 
-    val result = service.getPrimaryBookingContacts(1L, user(name = "User Name", email = null))
+    val result = service.getPrimaryBookingContacts(1L, prisonUser(name = "User Name", email = null))
 
     result.single().contactType isEqualTo ContactType.PRISON
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CourtsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CourtsServiceTest.kt
@@ -12,7 +12,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.never
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsExactlyInAnyOrder
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.user
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.SetCourtPreferencesRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.SetCourtPreferencesResponse
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.CourtRepository
@@ -46,7 +46,7 @@ class CourtsServiceTest {
 
     whenever(courtRepository.findCourtsByUsername("user")).thenReturn(listOfCourtsForUser)
 
-    assertThat(service.getUserCourtPreferences(user("user"))).isEqualTo(
+    assertThat(service.getUserCourtPreferences(courtUser("user"))).isEqualTo(
       listOfCourtsForUser.toModel(),
     )
 
@@ -55,7 +55,7 @@ class CourtsServiceTest {
 
   @Test
   fun `Should set court preferences for a user`() {
-    val user = user("user")
+    val user = courtUser("user")
     val existingCourts = listOf("COURT1", "COURT2")
     val requestedCourts = listOf("COURT3", "COURT4")
     val request = SetCourtPreferencesRequest(courtCodes = requestedCourts)
@@ -86,7 +86,7 @@ class CourtsServiceTest {
 
   @Test
   fun `Should set court preferences for a user only for enabled courts`() {
-    val user = user("user")
+    val user = courtUser("user")
     val existingCourts = listOf("COURT1")
     val requestedCourts = listOf("COURT3", "COURT4")
     val request = SetCourtPreferencesRequest(courtCodes = requestedCourts)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingServiceTest.kt
@@ -20,9 +20,9 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointm
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.SERVICE_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
@@ -184,7 +184,7 @@ class CreateVideoBookingServiceTest {
       ),
     )
 
-    assertThrows<CaseloadAccessException> { service.create(courtBookingRequest, PRISON_USER.copy(activeCaseLoadId = RISLEY)) }
+    assertThrows<CaseloadAccessException> { service.create(courtBookingRequest, PRISON_USER_RISLEY) }
   }
 
   @Test
@@ -542,7 +542,7 @@ class CreateVideoBookingServiceTest {
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 
     assertDoesNotThrow {
-      service.create(courtBookingRequest, PRISON_USER.copy(activeCaseLoadId = BIRMINGHAM))
+      service.create(courtBookingRequest, PRISON_USER_BIRMINGHAM)
     }
   }
 
@@ -566,7 +566,7 @@ class CreateVideoBookingServiceTest {
 
     whenever(courtRepository.findByCode(courtBookingRequest.courtCode!!)) doReturn readOnlyCourt()
 
-    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, PRISON_USER.copy(activeCaseLoadId = BIRMINGHAM)) }
+    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, PRISON_USER_BIRMINGHAM) }
 
     error.message isEqualTo "Court with code ${courtBookingRequest.courtCode} is read-only"
 
@@ -605,7 +605,7 @@ class CreateVideoBookingServiceTest {
     whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
 
     assertDoesNotThrow {
-      service.create(courtBookingRequest, PRISON_USER.copy(activeCaseLoadId = BIRMINGHAM))
+      service.create(courtBookingRequest, PRISON_USER_BIRMINGHAM)
     }
   }
 
@@ -724,7 +724,7 @@ class CreateVideoBookingServiceTest {
 
   @Test
   fun `should fail to create a probation video booking when not probation user`() {
-    assertThrows<IllegalArgumentException> { service.create(probationBookingRequest(), PRISON_USER) }.message isEqualTo "Only probation users can create probation bookings."
+    assertThrows<IllegalArgumentException> { service.create(probationBookingRequest(), PRISON_USER_BIRMINGHAM) }.message isEqualTo "Only probation users can create probation bookings."
     assertThrows<IllegalArgumentException> { service.create(probationBookingRequest(), COURT_USER) }.message isEqualTo "Only probation users can create probation bookings."
     assertThrows<IllegalArgumentException> { service.create(probationBookingRequest(), SERVICE_USER) }.message isEqualTo "Only probation users can create probation bookings."
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ProbationTeamsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ProbationTeamsServiceTest.kt
@@ -10,7 +10,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.never
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsExactlyInAnyOrder
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.user
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.UserProbationRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
@@ -37,7 +37,7 @@ class ProbationTeamsServiceTest {
 
     whenever(probationTeamRepository.findProbationTeamsByUsername("user")).thenReturn(listOfTeamsForUser)
 
-    assertThat(service.getUserProbationTeamPreferences(user("user"))).isEqualTo(
+    assertThat(service.getUserProbationTeamPreferences(probationUser("user"))).isEqualTo(
       listOfTeamsForUser.toModel(),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/RequestBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/RequestBookingServiceTest.kt
@@ -26,15 +26,16 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.contact
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntriesExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtHearingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isInstanceOf
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.requestCourtVideoLinkRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.requestProbationVideoLinkRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.user
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.CourtRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.NotificationRepository
@@ -105,7 +106,7 @@ class RequestBookingServiceTest {
     whenever(emailService.send(any<CourtBookingRequestUserEmail>())) doReturn Result.success(notificationId to "court template id")
     whenever(emailService.send(any<CourtBookingRequestPrisonNoCourtEmail>())) doReturn Result.success(notificationId to "prison template id")
 
-    service.request(bookingRequest, user("court user"))
+    service.request(bookingRequest, courtUser("court user"))
 
     inOrder(emailService, notificationRepository) {
       verify(emailService).send(emailCaptor.capture())
@@ -174,7 +175,7 @@ class RequestBookingServiceTest {
       location = wandsworthLocation,
     )
 
-    val error = assertThrows<IllegalArgumentException> { service.request(bookingRequest, user("court user")) }
+    val error = assertThrows<IllegalArgumentException> { service.request(bookingRequest, courtUser("court user")) }
     error.message isEqualTo "Court with code $DERBY_JUSTICE_CENTRE is not enabled"
 
     verify(emailService, never()).send(any())
@@ -193,7 +194,7 @@ class RequestBookingServiceTest {
       location = wandsworthLocation,
     )
 
-    val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, user("court user")) }
+    val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, courtUser("court user")) }
     error.message isEqualTo "Court with code $DERBY_JUSTICE_CENTRE not found"
 
     verify(emailService, never()).send(any())
@@ -212,7 +213,7 @@ class RequestBookingServiceTest {
       location = wandsworthLocation,
     )
 
-    val error = assertThrows<IllegalArgumentException> { service.request(bookingRequest, user("court user")) }
+    val error = assertThrows<IllegalArgumentException> { service.request(bookingRequest, courtUser("court user")) }
     error.message isEqualTo "Prison with code $WANDSWORTH is not enabled"
 
     verify(emailService, never()).send(any())
@@ -231,7 +232,7 @@ class RequestBookingServiceTest {
       location = wandsworthLocation,
     )
 
-    val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, user("court user")) }
+    val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, courtUser("court user")) }
     error.message isEqualTo "Prison with code $WANDSWORTH not found"
 
     verify(emailService, never()).send(any())
@@ -250,7 +251,7 @@ class RequestBookingServiceTest {
       location = wandsworthLocation,
     )
 
-    val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, user("court user")) }
+    val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, courtUser("court user")) }
     error.message isEqualTo "COURT_HEARING_TYPE with code TRIBUNAL not found"
 
     verify(emailService, never()).send(any())
@@ -272,7 +273,7 @@ class RequestBookingServiceTest {
     whenever(emailService.send(any<ProbationBookingRequestUserEmail>())) doReturn Result.success(notificationId to "probation template id")
     whenever(emailService.send(any<ProbationBookingRequestPrisonNoProbationTeamEmail>())) doReturn Result.success(notificationId to "prison template id")
 
-    service.request(bookingRequest, user("probation user"))
+    service.request(bookingRequest, probationUser("probation user"))
 
     inOrder(emailService, notificationRepository) {
       verify(emailService).send(emailCaptor.capture())
@@ -337,7 +338,7 @@ class RequestBookingServiceTest {
       location = wandsworthLocation,
     )
 
-    val error = assertThrows<IllegalArgumentException> { service.request(bookingRequest, user("probation user")) }
+    val error = assertThrows<IllegalArgumentException> { service.request(bookingRequest, probationUser("probation user")) }
     error.message isEqualTo "Probation team with code $BLACKPOOL_MC_PPOC is not enabled"
 
     verify(emailService, never()).send(any())
@@ -356,7 +357,7 @@ class RequestBookingServiceTest {
       location = wandsworthLocation,
     )
 
-    val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, user("probation user")) }
+    val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, probationUser("probation user")) }
     error.message isEqualTo "Probation team with code $BLACKPOOL_MC_PPOC not found"
 
     verify(emailService, never()).send(any())
@@ -375,7 +376,7 @@ class RequestBookingServiceTest {
       location = wandsworthLocation,
     )
 
-    val error = assertThrows<IllegalArgumentException> { service.request(bookingRequest, user("probation user")) }
+    val error = assertThrows<IllegalArgumentException> { service.request(bookingRequest, probationUser("probation user")) }
     error.message isEqualTo "Prison with code $WANDSWORTH is not enabled"
 
     verify(emailService, never()).send(any())
@@ -394,7 +395,7 @@ class RequestBookingServiceTest {
       location = wandsworthLocation,
     )
 
-    val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, user("probation user")) }
+    val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, probationUser("probation user")) }
     error.message isEqualTo "Prison with code $WANDSWORTH not found"
 
     verify(emailService, never()).send(any())
@@ -413,7 +414,7 @@ class RequestBookingServiceTest {
       location = wandsworthLocation,
     )
 
-    val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, user("probation user")) }
+    val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, probationUser("probation user")) }
     error.message isEqualTo "PROBATION_MEETING_TYPE with code PSR not found"
 
     verify(emailService, never()).send(any())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/UserServiceTest.kt
@@ -33,7 +33,6 @@ class UserServiceTest {
     with(getServiceAsUser()) {
       username isEqualTo "BOOK_A_VIDEO_LINK_SERVICE"
       name isEqualTo "BOOK_A_VIDEO_LINK_SERVICE"
-      isUserType(UserType.SERVICE) isBool true
     }
   }
 
@@ -42,7 +41,6 @@ class UserServiceTest {
     with(getClientAsUser("client")) {
       username isEqualTo "client"
       name isEqualTo "client"
-      isUserType(UserType.SERVICE) isBool true
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsServiceTest.kt
@@ -12,12 +12,11 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ReferenceCode
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_CENTRE
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
@@ -138,7 +137,7 @@ class VideoLinkBookingsServiceTest {
     fun `should fail to get a Wandsworth court video link booking by ID for a Birmingham prison user`() {
       whenever(videoBookingRepository.findById(any())) doReturn Optional.of(courtBooking().withMainCourtPrisonAppointment(prisonCode = WANDSWORTH))
 
-      assertThrows<CaseloadAccessException> { service.getVideoLinkBookingById(1L, PRISON_USER.copy(activeCaseLoadId = BIRMINGHAM)) }
+      assertThrows<CaseloadAccessException> { service.getVideoLinkBookingById(1L, PRISON_USER_BIRMINGHAM) }
     }
 
     @Test
@@ -316,7 +315,7 @@ class VideoLinkBookingsServiceTest {
       whenever(videoBookingRepository.findById(booking.videoBookingId)) doReturn Optional.of(booking)
 
       assertThrows<CaseloadAccessException> {
-        service.findMatchingVideoLinkBooking(searchRequest, PRISON_USER.copy(activeCaseLoadId = RISLEY)) isEqualTo booking.toModel(
+        service.findMatchingVideoLinkBooking(searchRequest, PRISON_USER_RISLEY) isEqualTo booking.toModel(
           courtHearingTypeDescription = "Tribunal",
         )
       }

--- a/src/test/resources/integration-test-data/seed-video-booking-user-preferences.sql
+++ b/src/test/resources/integration-test-data/seed-video-booking-user-preferences.sql
@@ -1,0 +1,3 @@
+insert into user_court (user_court_id, court_id, username, created_by, created_time) values (-1, 1, 'court_user', 'TIM', current_timestamp) on conflict do nothing ;
+insert into user_court (user_court_id, court_id, username, created_by, created_time) values (-2, 6, 'court_user', 'TIM', current_timestamp) on conflict do nothing ;
+insert into user_probation (user_probation_id, probation_team_id, username, created_by, created_time) values (-1, 1, 'probation_user', 'TIM', current_timestamp) on conflict do nothing ;


### PR DESCRIPTION
As part of the booking access check we now check if an external user can see a court or probation teams bookings.

As a result the User type now has some specialisations:

- ServiceUser
- ExternalUser
- PrisonUser

The  single User class trying to capture all that is required for each user type was just getting too messy/complicated.

The end result is this should make it easier 🤞  to add user type specific changes going forwards.