### PR TITLE
BAVL-380: Adding missing prisons

### DIFF
--- a/src/main/resources/migrations/common/V2024.10.15__extra_prisons.sql
+++ b/src/main/resources/migrations/common/V2024.10.15__extra_prisons.sql
@@ -1,0 +1,17 @@
+insert into prison (prison_id, code, name, enabled, notes, created_by, created_time)
+values (114,'ACI', 'Altcourse (HMP & YOI)', false, null, 'TIM', current_timestamp),
+       (115,'ASI', 'Ashfield (HMP)', false, null, 'TIM', current_timestamp),
+       (116,'DGI', 'Dovegate (HMP)', false, null, 'TIM', current_timestamp),
+       (117,'DNI', 'Doncaster (HMP)', false, null, 'TIM', current_timestamp),
+       (118,'FBI', 'Forest Bank (HMP)', false, null, 'TIM', current_timestamp),
+       (119,'FEI', 'Fosse Way (HMP)', false, null, 'TIM', current_timestamp),
+       (120,'FWI', 'Five Wells (HMP)', false, null, 'TIM', current_timestamp),
+       (121,'LGI', 'Lowdham Grange (HMP)', false, null, 'TIM', current_timestamp),
+       (122,'NLI', 'Northumberland (HMP)', false, null, 'TIM', current_timestamp),
+       (123,'OWI', 'Oakwood (HMP)', false, null, 'TIM', current_timestamp),
+       (124,'PFI', 'Peterborough (HMP & YOI)', false, null, 'TIM', current_timestamp),
+       (125,'PRI', 'Parc (HMP)', false, null, 'TIM', current_timestamp),
+       (126,'PYI', 'Parc (YOI)', false, null, 'TIM', current_timestamp),
+       (127,'RHI', 'Rye Hill (HMP)', false, null, 'TIM', current_timestamp);
+
+alter sequence if exists prison_prison_id_seq restart with 128;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/PrisonsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/PrisonsResourceIntegrationTest.kt
@@ -44,11 +44,11 @@ class PrisonsResourceIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `should return a list of all prisons`() {
-    prisonRepository.findAll() hasSize 113
+    prisonRepository.findAll() hasSize 127
 
     val listOfAllPrisons = webTestClient.getPrisons(false)
 
-    assertThat(listOfAllPrisons).hasSize(113)
+    assertThat(listOfAllPrisons).hasSize(127)
     assertThat(listOfAllPrisons).extracting("code").containsAll(listOf("LEI", "BMI", "WWI"))
   }
 


### PR DESCRIPTION
Details on ticket - missing prisons, at least one of which (Peterborough) was blocking the migration of existing bookings.