### PR TITLE
BAVL-260 capturing metrics for cancellation of court and probation bookings.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingCancelledTelemetryEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingCancelledTelemetryEvent.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry
+
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.StatusCode
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ExternalUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.PrisonUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
+
+class CourtBookingCancelledTelemetryEvent private constructor(
+  private val booking: VideoBooking,
+  private val cancelledBy: String,
+) : MetricTelemetryEvent("BVLS-court-booking-cancelled") {
+
+  init {
+    require(booking.isCourtBooking()) {
+      "Cannot create court cancelled metric, video booking with ID '${booking.videoBookingId}' is not a court booking."
+    }
+
+    require(booking.isStatus(StatusCode.CANCELLED)) {
+      "Cannot create court cancelled metric, video booking with ID '${booking.videoBookingId}' has not been cancelled."
+    }
+  }
+
+  override fun properties(): Map<String, String> = booking.commonProperties().plus("cancelled_by" to cancelledBy)
+
+  override fun metrics() = mapOf(booking.hoursBeforeStartTimeMetric())
+
+  companion object {
+    fun user(booking: VideoBooking, user: User): CourtBookingCancelledTelemetryEvent {
+      require(user is PrisonUser || (user is ExternalUser && user.isCourtUser)) {
+        "Can only create court cancelled metric for prison or court users."
+      }
+
+      require(user.username == booking.amendedBy) {
+        "Cannot create court cancelled metric, user does not match the cancelled by user."
+      }
+
+      return CourtBookingCancelledTelemetryEvent(booking, if (user is PrisonUser) "prison" else "court")
+    }
+
+    fun released(videoBooking: VideoBooking): CourtBookingCancelledTelemetryEvent =
+      CourtBookingCancelledTelemetryEvent(videoBooking, "release")
+
+    fun transferred(videoBooking: VideoBooking): CourtBookingCancelledTelemetryEvent =
+      CourtBookingCancelledTelemetryEvent(videoBooking, "transfer")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingCreatedTelemetryEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingCreatedTelemetryEvent.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry
 
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
-import java.time.temporal.ChronoUnit
 
 class CourtBookingCreatedTelemetryEvent(private val booking: VideoBooking) :
   MetricTelemetryEvent("BVLS-court-booking-created") {
@@ -18,32 +16,7 @@ class CourtBookingCreatedTelemetryEvent(private val booking: VideoBooking) :
   }
 
   override fun properties() =
-    mapOf(
-      "video_booking_id" to "${booking.videoBookingId}",
-      "created_by" to if (booking.createdByPrison) "prison" else "court",
-      "court_code" to booking.court!!.code,
-      "hearing_type" to booking.hearingType!!,
-      "prison_code" to booking.prisonCode(),
-      "pre_location_key" to (booking.pre()?.prisonLocKey ?: ""),
-      "pre_start" to (booking.pre()?.start()?.toIsoDateTime() ?: ""),
-      "pre_end" to (booking.pre()?.end()?.toIsoDateTime() ?: ""),
-      "main_location_key" to booking.main().prisonLocKey,
-      "main_start" to booking.main().start().toIsoDateTime(),
-      "main_end" to booking.main().end().toIsoDateTime(),
-      "post_location_key" to (booking.post()?.prisonLocKey ?: ""),
-      "post_start" to (booking.post()?.start()?.toIsoDateTime() ?: ""),
-      "post_end" to (booking.post()?.end()?.toIsoDateTime() ?: ""),
-      "cvp_link" to (booking.videoUrl != null).toString(),
-    )
+    booking.commonProperties().plus("created_by" to if (booking.createdByPrison) "prison" else "court")
 
-  override fun metrics() =
-    mapOf(
-      "hoursBeforeStartTime" to ChronoUnit.HOURS.between(booking.createdTime, booking.main().start()).toDouble(),
-    )
-
-  private fun VideoBooking.pre() = appointments().singleOrNull { it.isType("VLB_COURT_PRE") }
-
-  private fun VideoBooking.main() = appointments().single { it.isType("VLB_COURT_MAIN") }
-
-  private fun VideoBooking.post() = appointments().singleOrNull { it.isType("VLB_COURT_POST") }
+  override fun metrics() = mapOf(booking.hoursBeforeStartTimeMetric())
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCancelledTelemetryEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCancelledTelemetryEvent.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry
+
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.StatusCode
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ExternalUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.PrisonUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
+
+class ProbationBookingCancelledTelemetryEvent private constructor(
+  private val booking: VideoBooking,
+  private val cancelledBy: String,
+) : MetricTelemetryEvent("BVLS-court-booking-cancelled") {
+
+  init {
+    require(booking.isProbationBooking()) {
+      "Cannot create probation cancelled metric, video booking with ID '${booking.videoBookingId}' is not a probation booking."
+    }
+
+    require(booking.isStatus(StatusCode.CANCELLED)) {
+      "Cannot create probation cancelled metric, video booking with ID '${booking.videoBookingId}' has not been cancelled."
+    }
+  }
+
+  override fun properties(): Map<String, String> = booking.commonProperties().plus("cancelled_by" to cancelledBy)
+
+  override fun metrics() = mapOf(booking.hoursBeforeStartTimeMetric())
+
+  companion object {
+    fun user(booking: VideoBooking, user: User): ProbationBookingCancelledTelemetryEvent {
+      require(user is PrisonUser || (user is ExternalUser && user.isProbationUser)) {
+        "Cannot only create probation cancelled metric for prison or probation users."
+      }
+
+      require(user.username == booking.amendedBy) {
+        "Cannot create probation cancelled metric, user does not match the cancelled by user."
+      }
+
+      return ProbationBookingCancelledTelemetryEvent(booking, if (user is PrisonUser) "prison" else "probation")
+    }
+
+    fun released(videoBooking: VideoBooking): ProbationBookingCancelledTelemetryEvent =
+      ProbationBookingCancelledTelemetryEvent(videoBooking, "release")
+
+    fun transferred(videoBooking: VideoBooking): ProbationBookingCancelledTelemetryEvent =
+      ProbationBookingCancelledTelemetryEvent(videoBooking, "transfer")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCreatedTelemetryEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCreatedTelemetryEvent.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry
 
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
-import java.time.temporal.ChronoUnit
 
 class ProbationBookingCreatedTelemetryEvent(private val booking: VideoBooking) :
   MetricTelemetryEvent("BVLS-probation-booking-created") {
@@ -17,24 +15,8 @@ class ProbationBookingCreatedTelemetryEvent(private val booking: VideoBooking) :
     }
   }
 
-  override fun properties() =
-    mapOf(
-      "video_booking_id" to "${booking.videoBookingId}",
-      // Probation bookings are only created by probation users
-      "created_by" to "probation",
-      "team_code" to booking.probationTeam!!.code,
-      "meeting_type" to booking.probationMeetingType!!,
-      "prison_code" to booking.prisonCode(),
-      "location_key" to booking.appointment().prisonLocKey,
-      "start" to booking.appointment().start().toIsoDateTime(),
-      "end" to booking.appointment().end().toIsoDateTime(),
-      "cvp_link" to (booking.videoUrl != null).toString(),
-    )
+  // Probation bookings are only created by probation users
+  override fun properties() = booking.commonProperties().plus("created_by" to "probation")
 
-  override fun metrics() =
-    mapOf(
-      "hoursBeforeStartTime" to ChronoUnit.HOURS.between(booking.createdTime, booking.appointment().start()).toDouble(),
-    )
-
-  private fun VideoBooking.appointment() = appointments().single { it.isType("VLB_PROBATION") }
+  override fun metrics() = mapOf(booking.hoursBeforeStartTimeMetric())
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/TelemetryService.kt
@@ -2,6 +2,9 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import java.time.temporal.ChronoUnit
 
 @Service
 class TelemetryService(private val telemetryClient: TelemetryClient) {
@@ -15,10 +18,57 @@ class TelemetryService(private val telemetryClient: TelemetryClient) {
 
 sealed class TelemetryEvent(val eventType: String) {
   abstract fun properties(): Map<String, String>
+
+  protected fun VideoBooking.pre() = appointments().singleOrNull { it.isType("VLB_COURT_PRE") }
+
+  protected fun VideoBooking.main() = appointments().single { it.isType("VLB_COURT_MAIN") }
+
+  protected fun VideoBooking.post() = appointments().singleOrNull { it.isType("VLB_COURT_POST") }
+
+  protected fun VideoBooking.meeting() = appointments().single { it.isType("VLB_PROBATION") }
+
+  protected fun VideoBooking.commonProperties(): Map<String, String> =
+    if (isCourtBooking()) {
+      mapOf(
+        "video_booking_id" to "$videoBookingId",
+        "court_code" to court!!.code,
+        "hearing_type" to hearingType!!,
+        "prison_code" to prisonCode(),
+        "pre_location_key" to (pre()?.prisonLocKey ?: ""),
+        "pre_start" to (pre()?.start()?.toIsoDateTime() ?: ""),
+        "pre_end" to (pre()?.end()?.toIsoDateTime() ?: ""),
+        "main_location_key" to main().prisonLocKey,
+        "main_start" to main().start().toIsoDateTime(),
+        "main_end" to main().end().toIsoDateTime(),
+        "post_location_key" to (post()?.prisonLocKey ?: ""),
+        "post_start" to (post()?.start()?.toIsoDateTime() ?: ""),
+        "post_end" to (post()?.end()?.toIsoDateTime() ?: ""),
+        "cvp_link" to (videoUrl != null).toString(),
+      )
+    } else {
+      mapOf(
+        "video_booking_id" to "$videoBookingId",
+        "team_code" to probationTeam!!.code,
+        "meeting_type" to probationMeetingType!!,
+        "prison_code" to prisonCode(),
+        "location_key" to meeting().prisonLocKey,
+        "start" to meeting().start().toIsoDateTime(),
+        "end" to meeting().end().toIsoDateTime(),
+        "cvp_link" to (videoUrl != null).toString(),
+      )
+    }
 }
 
 abstract class MetricTelemetryEvent(eventType: String) : TelemetryEvent(eventType) {
   abstract fun metrics(): Map<String, Double>
+
+  protected fun VideoBooking.hoursBeforeStartTimeMetric(): Pair<String, Double> {
+    return if (isCourtBooking()) {
+      "hoursBeforeStartTime" to ChronoUnit.HOURS.between(amendedTime ?: createdTime, main().start()).toDouble()
+    } else {
+      "hoursBeforeStartTime" to ChronoUnit.HOURS.between(amendedTime ?: createdTime, meeting().start()).toDouble()
+    }
+  }
 }
 
 abstract class StandardTelemetryEvent(eventType: String) : TelemetryEvent(eventType)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
@@ -78,8 +78,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probat
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.DomainEventType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.OutboundEventsService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry.CourtBookingAmendedTelemetryEvent
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry.CourtBookingCancelledTelemetryEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry.CourtBookingCreatedTelemetryEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry.ProbationBookingAmendedTelemetryEvent
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry.ProbationBookingCancelledTelemetryEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry.ProbationBookingCreatedTelemetryEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry.TelemetryEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry.TelemetryService
@@ -252,7 +254,9 @@ class BookingFacadeTest {
         reason isEqualTo "CREATE"
       }
 
-      telemetryCaptor.firstValue isInstanceOf CourtBookingCreatedTelemetryEvent::class.java
+      with(telemetryCaptor.firstValue as CourtBookingCreatedTelemetryEvent) {
+        properties()["created_by"] isEqualTo "court"
+      }
     }
 
     @Test
@@ -267,13 +271,14 @@ class BookingFacadeTest {
 
       facade.create(bookingRequest, PRISON_USER_BIRMINGHAM)
 
-      inOrder(createBookingService, outboundEventsService, emailService, notificationRepository) {
+      inOrder(createBookingService, outboundEventsService, emailService, notificationRepository, telemetryService) {
         verify(createBookingService).create(bookingRequest, PRISON_USER_BIRMINGHAM)
         verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CREATED, courtBookingCreatedByPrison.videoBookingId)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
+        verify(telemetryService).track(telemetryCaptor.capture())
       }
 
       emailCaptor.allValues hasSize 2
@@ -323,6 +328,10 @@ class BookingFacadeTest {
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo courtBookingCreatedByPrison
         reason isEqualTo "CREATE"
+      }
+
+      with(telemetryCaptor.firstValue as CourtBookingCreatedTelemetryEvent) {
+        properties()["created_by"] isEqualTo "prison"
       }
     }
 
@@ -406,7 +415,9 @@ class BookingFacadeTest {
         reason isEqualTo "CREATE"
       }
 
-      telemetryCaptor.firstValue isInstanceOf ProbationBookingCreatedTelemetryEvent::class.java
+      with(telemetryCaptor.firstValue as ProbationBookingCreatedTelemetryEvent) {
+        properties()["created_by"] isEqualTo "probation"
+      }
     }
   }
 
@@ -426,13 +437,14 @@ class BookingFacadeTest {
 
       facade.cancel(1, COURT_USER)
 
-      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
+      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository, telemetryService) {
         verify(cancelVideoBookingService).cancel(1, COURT_USER)
         verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
+        verify(telemetryService).track(telemetryCaptor.capture())
       }
 
       emailCaptor.allValues hasSize 2
@@ -483,6 +495,10 @@ class BookingFacadeTest {
         videoBooking isEqualTo courtBooking
         reason isEqualTo "CANCEL"
       }
+
+      with(telemetryCaptor.firstValue as CourtBookingCancelledTelemetryEvent) {
+        properties()["cancelled_by"] isEqualTo "court"
+      }
     }
 
     @Test
@@ -498,13 +514,14 @@ class BookingFacadeTest {
 
       facade.cancel(1, PRISON_USER_BIRMINGHAM)
 
-      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
+      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository, telemetryService) {
         verify(cancelVideoBookingService).cancel(1, PRISON_USER_BIRMINGHAM)
         verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
+        verify(telemetryService).track(telemetryCaptor.capture())
       }
 
       emailCaptor.allValues hasSize 2
@@ -555,6 +572,10 @@ class BookingFacadeTest {
         videoBooking isEqualTo courtBooking
         reason isEqualTo "CANCEL"
       }
+
+      with(telemetryCaptor.firstValue as CourtBookingCancelledTelemetryEvent) {
+        properties()["cancelled_by"] isEqualTo "prison"
+      }
     }
 
     @Test
@@ -570,13 +591,14 @@ class BookingFacadeTest {
 
       facade.cancel(1, PROBATION_USER)
 
-      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
+      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository, telemetryService) {
         verify(cancelVideoBookingService).cancel(1, PROBATION_USER)
         verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
+        verify(telemetryService).track(telemetryCaptor.capture())
       }
 
       emailCaptor.allValues hasSize 2
@@ -624,6 +646,10 @@ class BookingFacadeTest {
         videoBooking isEqualTo probationBookingAtBirminghamPrison
         reason isEqualTo "CANCEL"
       }
+
+      with(telemetryCaptor.firstValue as ProbationBookingCancelledTelemetryEvent) {
+        properties()["cancelled_by"] isEqualTo "probation"
+      }
     }
 
     @Test
@@ -639,13 +665,14 @@ class BookingFacadeTest {
 
       facade.cancel(1, PRISON_USER_BIRMINGHAM)
 
-      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
+      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository, telemetryService) {
         verify(cancelVideoBookingService).cancel(1, PRISON_USER_BIRMINGHAM)
         verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
+        verify(telemetryService).track(telemetryCaptor.capture())
       }
 
       emailCaptor.allValues hasSize 2
@@ -693,6 +720,10 @@ class BookingFacadeTest {
         videoBooking isEqualTo probationBookingAtBirminghamPrison
         reason isEqualTo "CANCEL"
       }
+
+      with(telemetryCaptor.firstValue as ProbationBookingCancelledTelemetryEvent) {
+        properties()["cancelled_by"] isEqualTo "prison"
+      }
     }
   }
 
@@ -705,7 +736,20 @@ class BookingFacadeTest {
 
       val bookingRequest = amendCourtBookingRequest(prisonCode = WANDSWORTH, prisonerNumber = "123456")
 
-      whenever(amendBookingService.amend(1, bookingRequest, COURT_USER)) doReturn Pair(courtBooking.apply { amendedTime = now() }, prisoner(prisonerNumber = "123456", prisonCode = WANDSWORTH))
+      whenever(
+        amendBookingService.amend(
+          1,
+          bookingRequest,
+          COURT_USER,
+        ),
+      ) doReturn Pair(
+        courtBooking.apply {
+          amendedTime = now()
+          amendedBy = COURT_USER.username
+        },
+        prisoner(prisonerNumber = "123456", prisonCode = WANDSWORTH),
+      )
+
       whenever(emailService.send(any<AmendedCourtBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
       whenever(emailService.send(any<AmendedCourtBookingPrisonNoCourtEmail>())) doReturn Result.success(emailNotificationId to "prison template id")
 
@@ -769,7 +813,9 @@ class BookingFacadeTest {
         reason isEqualTo "AMEND"
       }
 
-      telemetryCaptor.firstValue isInstanceOf CourtBookingAmendedTelemetryEvent::class.java
+      with(telemetryCaptor.firstValue as CourtBookingAmendedTelemetryEvent) {
+        properties()["amended_by"] isEqualTo "court"
+      }
     }
 
     @Test
@@ -778,18 +824,27 @@ class BookingFacadeTest {
 
       val bookingRequest = amendCourtBookingRequest(prisonCode = WANDSWORTH, prisonerNumber = "123456")
 
-      whenever(amendBookingService.amend(1, bookingRequest, PRISON_USER_BIRMINGHAM)) doReturn Pair(courtBooking.apply { amendedTime = now() }, prisoner(prisonerNumber = "123456", prisonCode = WANDSWORTH))
+      whenever(amendBookingService.amend(1, bookingRequest, PRISON_USER_BIRMINGHAM)) doReturn
+        Pair(
+          courtBooking.apply {
+            amendedTime = now()
+            amendedBy = PRISON_USER_BIRMINGHAM.username
+          },
+          prisoner(prisonerNumber = "123456", prisonCode = WANDSWORTH),
+        )
+
       whenever(emailService.send(any<AmendedCourtBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
       whenever(emailService.send(any<AmendedCourtBookingCourtEmail>())) doReturn Result.success(emailNotificationId to "court template id")
 
       facade.amend(1, bookingRequest, PRISON_USER_BIRMINGHAM)
 
-      inOrder(amendBookingService, emailService, notificationRepository) {
+      inOrder(amendBookingService, emailService, notificationRepository, telemetryService) {
         verify(amendBookingService).amend(1, bookingRequest, PRISON_USER_BIRMINGHAM)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
+        verify(telemetryService).track(telemetryCaptor.capture())
       }
 
       emailCaptor.allValues hasSize 2
@@ -840,6 +895,10 @@ class BookingFacadeTest {
         videoBooking isEqualTo courtBooking
         reason isEqualTo "AMEND"
       }
+
+      with(telemetryCaptor.firstValue as CourtBookingAmendedTelemetryEvent) {
+        properties()["amended_by"] isEqualTo "prison"
+      }
     }
 
     @Test
@@ -852,7 +911,13 @@ class BookingFacadeTest {
 
       val amendRequest = amendProbationBookingRequest(prisonCode = prisoner.prisonId!!, prisonerNumber = prisoner.prisonerNumber, appointmentDate = tomorrow())
 
-      whenever(amendBookingService.amend(1, amendRequest, PROBATION_USER)) doReturn Pair(probationBookingAtBirminghamPrison.apply { amendedTime = now() }, prisoner(prisonerNumber = prisoner.prisonerNumber, prisonCode = prisoner.prisonId!!))
+      whenever(amendBookingService.amend(1, amendRequest, PROBATION_USER)) doReturn Pair(
+        probationBookingAtBirminghamPrison.apply {
+          amendedTime = now()
+          amendedBy = PROBATION_USER.username
+        },
+        prisoner(prisonerNumber = prisoner.prisonerNumber, prisonCode = prisoner.prisonId!!),
+      )
       whenever(emailService.send(any<AmendedProbationBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
       whenever(emailService.send(any<AmendedProbationBookingPrisonNoProbationEmail>())) doReturn Result.success(emailNotificationId to "prison template id")
 
@@ -913,7 +978,9 @@ class BookingFacadeTest {
         reason isEqualTo "AMEND"
       }
 
-      telemetryCaptor.firstValue isInstanceOf ProbationBookingAmendedTelemetryEvent::class.java
+      with(telemetryCaptor.firstValue as ProbationBookingAmendedTelemetryEvent) {
+        properties()["amended_by"] isEqualTo "probation"
+      }
     }
 
     @Test
@@ -926,19 +993,26 @@ class BookingFacadeTest {
 
       val amendRequest = amendProbationBookingRequest(prisonCode = prisoner.prisonId!!, prisonerNumber = prisoner.prisonerNumber, appointmentDate = tomorrow())
 
-      whenever(amendBookingService.amend(1, amendRequest, PRISON_USER_BIRMINGHAM)) doReturn Pair(probationBookingAtBirminghamPrison.apply { amendedTime = now() }, prisoner(prisonerNumber = prisoner.prisonerNumber, prisonCode = prisoner.prisonId!!))
+      whenever(amendBookingService.amend(1, amendRequest, PRISON_USER_BIRMINGHAM)) doReturn Pair(
+        probationBookingAtBirminghamPrison.apply {
+          amendedTime = now()
+          amendedBy = PRISON_USER_BIRMINGHAM.username
+        },
+        prisoner(prisonerNumber = prisoner.prisonerNumber, prisonCode = prisoner.prisonId!!),
+      )
       whenever(emailService.send(any<AmendedProbationBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
       whenever(emailService.send(any<AmendedProbationBookingProbationEmail>())) doReturn Result.success(emailNotificationId to "probation template id")
 
       facade.amend(1, amendRequest, PRISON_USER_BIRMINGHAM)
 
-      inOrder(amendBookingService, outboundEventsService, emailService, notificationRepository) {
+      inOrder(amendBookingService, outboundEventsService, emailService, notificationRepository, telemetryService) {
         verify(amendBookingService).amend(1, amendRequest, PRISON_USER_BIRMINGHAM)
         verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_AMENDED, 1)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
+        verify(telemetryService).track(telemetryCaptor.capture())
       }
 
       emailCaptor.allValues hasSize 2
@@ -985,6 +1059,10 @@ class BookingFacadeTest {
         videoBooking isEqualTo probationBookingAtBirminghamPrison
         reason isEqualTo "AMEND"
       }
+
+      with(telemetryCaptor.firstValue as ProbationBookingAmendedTelemetryEvent) {
+        properties()["amended_by"] isEqualTo "prison"
+      }
     }
   }
 
@@ -1011,11 +1089,12 @@ class BookingFacadeTest {
 
       facade.prisonerTransferred(1, SERVICE_USER)
 
-      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
+      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository, telemetryService) {
         verify(cancelVideoBookingService).cancel(1, SERVICE_USER)
         verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
+        verify(telemetryService).track(telemetryCaptor.capture())
       }
 
       emailCaptor.allValues hasSize 1
@@ -1044,10 +1123,14 @@ class BookingFacadeTest {
         videoBooking isEqualTo courtBooking
         reason isEqualTo "TRANSFERRED"
       }
+
+      with(telemetryCaptor.firstValue as CourtBookingCancelledTelemetryEvent) {
+        properties()["cancelled_by"] isEqualTo "transfer"
+      }
     }
 
     @Test
-    fun `should send events and emails on release of prisoner by service user for a probation booking`() {
+    fun `should send events and emails on transfer of prisoner by service user for a probation booking`() {
       val prisoner = Prisoner(
         prisonerNumber = probationBookingAtBirminghamPrison.prisoner(),
         prisonId = "TRN",
@@ -1066,13 +1149,14 @@ class BookingFacadeTest {
 
       facade.prisonerTransferred(1, SERVICE_USER)
 
-      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
+      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository, telemetryService) {
         verify(cancelVideoBookingService).cancel(1, SERVICE_USER)
         verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
+        verify(telemetryService).track(telemetryCaptor.capture())
       }
 
       emailCaptor.allValues hasSize 2
@@ -1121,6 +1205,10 @@ class BookingFacadeTest {
         videoBooking isEqualTo probationBookingAtBirminghamPrison
         reason isEqualTo "TRANSFERRED"
       }
+
+      with(telemetryCaptor.firstValue as ProbationBookingCancelledTelemetryEvent) {
+        properties()["cancelled_by"] isEqualTo "transfer"
+      }
     }
   }
 
@@ -1147,13 +1235,14 @@ class BookingFacadeTest {
 
       facade.prisonerReleased(1, SERVICE_USER)
 
-      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
+      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository, telemetryService) {
         verify(cancelVideoBookingService).cancel(1, SERVICE_USER)
         verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
+        verify(telemetryService).track(telemetryCaptor.capture())
       }
 
       emailCaptor.allValues hasSize 2
@@ -1206,6 +1295,10 @@ class BookingFacadeTest {
         videoBooking isEqualTo courtBooking
         reason isEqualTo "RELEASED"
       }
+
+      with(telemetryCaptor.firstValue as CourtBookingCancelledTelemetryEvent) {
+        properties()["cancelled_by"] isEqualTo "release"
+      }
     }
 
     @Test
@@ -1228,13 +1321,14 @@ class BookingFacadeTest {
 
       facade.prisonerReleased(1, SERVICE_USER)
 
-      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository) {
+      inOrder(cancelVideoBookingService, outboundEventsService, emailService, notificationRepository, telemetryService) {
         verify(cancelVideoBookingService).cancel(1, SERVICE_USER)
         verify(outboundEventsService).send(DomainEventType.VIDEO_BOOKING_CANCELLED, 1)
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
         verify(emailService).send(emailCaptor.capture())
         verify(notificationRepository).saveAndFlush(notificationCaptor.capture())
+        verify(telemetryService).track(telemetryCaptor.capture())
       }
 
       emailCaptor.allValues hasSize 2
@@ -1282,6 +1376,10 @@ class BookingFacadeTest {
         govNotifyNotificationId isEqualTo emailNotificationId
         videoBooking isEqualTo courtBooking
         reason isEqualTo "RELEASED"
+      }
+
+      with(telemetryCaptor.firstValue as ProbationBookingCancelledTelemetryEvent) {
+        properties()["cancelled_by"] isEqualTo "release"
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingAmendedTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingAmendedTelemetryEventTest.kt
@@ -10,9 +10,12 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntriesExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.risleyLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
@@ -61,9 +64,10 @@ class CourtBookingAmendedTelemetryEventTest {
       locationKey = wandsworthLocation3.key,
     ).apply {
       amendedTime = amendedAt
+      amendedBy = courtUser().username
     }
 
-    with(CourtBookingAmendedTelemetryEvent(booking, false)) {
+    with(CourtBookingAmendedTelemetryEvent(booking, courtUser())) {
       eventType isEqualTo "BVLS-court-booking-amended"
       properties() containsEntriesExactlyInAnyOrder mapOf(
         "video_booking_id" to "0",
@@ -111,9 +115,10 @@ class CourtBookingAmendedTelemetryEventTest {
       locationKey = risleyLocation.key,
     ).apply {
       amendedTime = amendedAt
+      amendedBy = prisonUser().username
     }
 
-    with(CourtBookingAmendedTelemetryEvent(booking, true)) {
+    with(CourtBookingAmendedTelemetryEvent(booking, prisonUser())) {
       eventType isEqualTo "BVLS-court-booking-amended"
       properties() containsEntriesExactlyInAnyOrder mapOf(
         "video_booking_id" to "0",
@@ -146,14 +151,14 @@ class CourtBookingAmendedTelemetryEventTest {
 
   @Test
   fun `should fail to create event if probation booking`() {
-    val error = assertThrows<IllegalArgumentException> { CourtBookingAmendedTelemetryEvent(probationBooking(), false) }
+    val error = assertThrows<IllegalArgumentException> { CourtBookingAmendedTelemetryEvent(probationBooking(), probationUser()) }
 
     error.message isEqualTo "Cannot create court amended metric, video booking with ID '0' is not a court booking."
   }
 
   @Test
   fun `should fail to create event when booking has not been amended`() {
-    val error = assertThrows<IllegalArgumentException> { CourtBookingAmendedTelemetryEvent(courtBooking(), false) }
+    val error = assertThrows<IllegalArgumentException> { CourtBookingAmendedTelemetryEvent(courtBooking(), courtUser()) }
 
     error.message isEqualTo "Cannot create court amended metric, video booking with ID '0' has not been amended."
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingCancelledTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingCancelledTelemetryEventTest.kt
@@ -1,0 +1,203 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_CENTRE
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntriesExactlyInAnyOrder
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation2
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation3
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.temporal.ChronoUnit
+
+class CourtBookingCancelledTelemetryEventTest {
+
+  private val booking = VideoBooking.newCourtBooking(
+    court = court(DERBY_JUSTICE_CENTRE),
+    hearingType = "APPEAL",
+    createdBy = "court_user",
+    createdByPrison = false,
+    comments = null,
+    videoUrl = "http://booking.created.url",
+  ).addAppointment(
+    prison = prison(WANDSWORTH),
+    prisonerNumber = "ABC123",
+    appointmentType = "VLB_COURT_PRE",
+    date = tomorrow(),
+    startTime = LocalTime.of(9, 0),
+    endTime = LocalTime.of(10, 0),
+    locationKey = wandsworthLocation.key,
+  ).addAppointment(
+    prison = prison(WANDSWORTH),
+    prisonerNumber = "ABC123",
+    appointmentType = "VLB_COURT_MAIN",
+    date = tomorrow(),
+    startTime = LocalTime.of(10, 0),
+    endTime = LocalTime.of(11, 0),
+    locationKey = wandsworthLocation2.key,
+  ).addAppointment(
+    prison = prison(WANDSWORTH),
+    prisonerNumber = "ABC123",
+    appointmentType = "VLB_COURT_POST",
+    date = tomorrow(),
+    startTime = LocalTime.of(11, 0),
+    endTime = LocalTime.of(12, 0),
+    locationKey = wandsworthLocation3.key,
+  )
+
+  @Test
+  fun `should raise a court booking cancelled telemetry event cancelled by a court`() {
+    booking.cancel(courtUser())
+
+    with(CourtBookingCancelledTelemetryEvent.user(booking, courtUser())) {
+      properties() containsEntriesExactlyInAnyOrder mapOf(
+        "video_booking_id" to "0",
+        "cancelled_by" to "court",
+        "court_code" to DERBY_JUSTICE_CENTRE,
+        "hearing_type" to "APPEAL",
+        "prison_code" to WANDSWORTH,
+        "pre_location_key" to wandsworthLocation.key,
+        "pre_start" to tomorrow().atTime(LocalTime.of(9, 0)).toIsoDateTime(),
+        "pre_end" to tomorrow().atTime(LocalTime.of(10, 0)).toIsoDateTime(),
+        "main_location_key" to wandsworthLocation2.key,
+        "main_start" to tomorrow().atTime(LocalTime.of(10, 0)).toIsoDateTime(),
+        "main_end" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
+        "post_location_key" to wandsworthLocation3.key,
+        "post_start" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
+        "post_end" to tomorrow().atTime(LocalTime.of(12, 0)).toIsoDateTime(),
+        "cvp_link" to "true",
+      )
+
+      metrics() containsEntriesExactlyInAnyOrder mapOf(
+        "hoursBeforeStartTime" to hoursBetween(
+          booking.amendedTime!!,
+          tomorrow().atTime(LocalTime.of(10, 0)),
+        ).toDouble(),
+      )
+    }
+  }
+
+  @Test
+  fun `should raise a court booking cancelled telemetry event cancelled by a prison`() {
+    booking.cancel(prisonUser())
+
+    with(CourtBookingCancelledTelemetryEvent.user(booking, prisonUser())) {
+      properties() containsEntriesExactlyInAnyOrder mapOf(
+        "video_booking_id" to "0",
+        "cancelled_by" to "prison",
+        "court_code" to DERBY_JUSTICE_CENTRE,
+        "hearing_type" to "APPEAL",
+        "prison_code" to WANDSWORTH,
+        "pre_location_key" to wandsworthLocation.key,
+        "pre_start" to tomorrow().atTime(LocalTime.of(9, 0)).toIsoDateTime(),
+        "pre_end" to tomorrow().atTime(LocalTime.of(10, 0)).toIsoDateTime(),
+        "main_location_key" to wandsworthLocation2.key,
+        "main_start" to tomorrow().atTime(LocalTime.of(10, 0)).toIsoDateTime(),
+        "main_end" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
+        "post_location_key" to wandsworthLocation3.key,
+        "post_start" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
+        "post_end" to tomorrow().atTime(LocalTime.of(12, 0)).toIsoDateTime(),
+        "cvp_link" to "true",
+      )
+
+      metrics() containsEntriesExactlyInAnyOrder mapOf(
+        "hoursBeforeStartTime" to hoursBetween(
+          booking.amendedTime!!,
+          tomorrow().atTime(LocalTime.of(10, 0)),
+        ).toDouble(),
+      )
+    }
+  }
+
+  @Test
+  fun `should raise a court booking cancelled telemetry event cancelled by release`() {
+    booking.cancel(prisonUser())
+
+    with(CourtBookingCancelledTelemetryEvent.released(booking)) {
+      properties() containsEntriesExactlyInAnyOrder mapOf(
+        "video_booking_id" to "0",
+        "cancelled_by" to "release",
+        "court_code" to DERBY_JUSTICE_CENTRE,
+        "hearing_type" to "APPEAL",
+        "prison_code" to WANDSWORTH,
+        "pre_location_key" to wandsworthLocation.key,
+        "pre_start" to tomorrow().atTime(LocalTime.of(9, 0)).toIsoDateTime(),
+        "pre_end" to tomorrow().atTime(LocalTime.of(10, 0)).toIsoDateTime(),
+        "main_location_key" to wandsworthLocation2.key,
+        "main_start" to tomorrow().atTime(LocalTime.of(10, 0)).toIsoDateTime(),
+        "main_end" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
+        "post_location_key" to wandsworthLocation3.key,
+        "post_start" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
+        "post_end" to tomorrow().atTime(LocalTime.of(12, 0)).toIsoDateTime(),
+        "cvp_link" to "true",
+      )
+
+      metrics() containsEntriesExactlyInAnyOrder mapOf(
+        "hoursBeforeStartTime" to hoursBetween(
+          booking.amendedTime!!,
+          tomorrow().atTime(LocalTime.of(10, 0)),
+        ).toDouble(),
+      )
+    }
+  }
+
+  @Test
+  fun `should raise a court booking cancelled telemetry event cancelled by transfer`() {
+    booking.cancel(prisonUser())
+
+    with(CourtBookingCancelledTelemetryEvent.transferred(booking)) {
+      properties() containsEntriesExactlyInAnyOrder mapOf(
+        "video_booking_id" to "0",
+        "cancelled_by" to "transfer",
+        "court_code" to DERBY_JUSTICE_CENTRE,
+        "hearing_type" to "APPEAL",
+        "prison_code" to WANDSWORTH,
+        "pre_location_key" to wandsworthLocation.key,
+        "pre_start" to tomorrow().atTime(LocalTime.of(9, 0)).toIsoDateTime(),
+        "pre_end" to tomorrow().atTime(LocalTime.of(10, 0)).toIsoDateTime(),
+        "main_location_key" to wandsworthLocation2.key,
+        "main_start" to tomorrow().atTime(LocalTime.of(10, 0)).toIsoDateTime(),
+        "main_end" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
+        "post_location_key" to wandsworthLocation3.key,
+        "post_start" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
+        "post_end" to tomorrow().atTime(LocalTime.of(12, 0)).toIsoDateTime(),
+        "cvp_link" to "true",
+      )
+
+      metrics() containsEntriesExactlyInAnyOrder mapOf(
+        "hoursBeforeStartTime" to hoursBetween(
+          booking.amendedTime!!,
+          tomorrow().atTime(LocalTime.of(10, 0)),
+        ).toDouble(),
+      )
+    }
+  }
+
+  private fun hoursBetween(from: LocalDateTime, to: LocalDateTime) = ChronoUnit.HOURS.between(from, to)
+
+  @Test
+  fun `should fail to create event if probation booking`() {
+    val error = assertThrows<IllegalArgumentException> { CourtBookingCancelledTelemetryEvent.transferred(probationBooking()) }
+
+    error.message isEqualTo "Cannot create court cancelled metric, video booking with ID '0' is not a court booking."
+  }
+
+  @Test
+  fun `should fail to create event when booking has not been cancelled`() {
+    val error = assertThrows<IllegalArgumentException> { CourtBookingCancelledTelemetryEvent.transferred(courtBooking()) }
+
+    error.message isEqualTo "Cannot create court cancelled metric, video booking with ID '0' has not been cancelled."
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingAmendedTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingAmendedTelemetryEventTest.kt
@@ -11,8 +11,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntrie
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -41,9 +43,10 @@ class ProbationBookingAmendedTelemetryEventTest {
       locationKey = birminghamLocation.key,
     ).apply {
       amendedTime = amendedAt
+      amendedBy = probationUser().username
     }
 
-    with(ProbationBookingAmendedTelemetryEvent(booking, false)) {
+    with(ProbationBookingAmendedTelemetryEvent(booking, probationUser())) {
       eventType isEqualTo "BVLS-probation-booking-amended"
       properties() containsEntriesExactlyInAnyOrder mapOf(
         "video_booking_id" to "0",
@@ -85,9 +88,10 @@ class ProbationBookingAmendedTelemetryEventTest {
       locationKey = birminghamLocation.key,
     ).apply {
       amendedTime = amendedAt
+      amendedBy = prisonUser().username
     }
 
-    with(ProbationBookingAmendedTelemetryEvent(booking, true)) {
+    with(ProbationBookingAmendedTelemetryEvent(booking, prisonUser())) {
       eventType isEqualTo "BVLS-probation-booking-amended"
       properties() containsEntriesExactlyInAnyOrder mapOf(
         "video_booking_id" to "0",
@@ -121,7 +125,7 @@ class ProbationBookingAmendedTelemetryEventTest {
 
   @Test
   fun `should fail to create event when booking has not been amended`() {
-    val error = assertThrows<IllegalArgumentException> { ProbationBookingAmendedTelemetryEvent(probationBooking(), false) }
+    val error = assertThrows<IllegalArgumentException> { ProbationBookingAmendedTelemetryEvent(probationBooking(), probationUser()) }
 
     error.message isEqualTo "Cannot create probation amended metric, video booking with ID '0' has not been amended."
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCancelledTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCancelledTelemetryEventTest.kt
@@ -1,0 +1,161 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BLACKPOOL_MC_PPOC
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntriesExactlyInAnyOrder
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.temporal.ChronoUnit
+
+class ProbationBookingCancelledTelemetryEventTest {
+
+  private val booking = VideoBooking.newProbationBooking(
+    probationTeam = probationTeam(BLACKPOOL_MC_PPOC),
+    probationMeetingType = "PSR",
+    createdBy = "probation_user",
+    createdByPrison = false,
+    comments = null,
+    videoUrl = "http://booking.created.url",
+  ).addAppointment(
+    prison = prison(BIRMINGHAM),
+    prisonerNumber = "ABC123",
+    appointmentType = "VLB_PROBATION",
+    date = tomorrow(),
+    startTime = LocalTime.of(14, 0),
+    endTime = LocalTime.of(15, 0),
+    locationKey = birminghamLocation.key,
+  )
+
+  @Test
+  fun `should raise a probation booking cancelled telemetry event cancelled by a probation`() {
+    booking.cancel(probationUser())
+
+    with(ProbationBookingCancelledTelemetryEvent.user(booking, probationUser())) {
+      properties() containsEntriesExactlyInAnyOrder mapOf(
+        "video_booking_id" to "0",
+        "cancelled_by" to "probation",
+        "team_code" to BLACKPOOL_MC_PPOC,
+        "meeting_type" to "PSR",
+        "prison_code" to BIRMINGHAM,
+        "location_key" to birminghamLocation.key,
+        "start" to tomorrow().atTime(LocalTime.of(14, 0)).toIsoDateTime(),
+        "end" to tomorrow().atTime(LocalTime.of(15, 0)).toIsoDateTime(),
+        "cvp_link" to "true",
+      )
+
+      metrics() containsEntriesExactlyInAnyOrder mapOf(
+        "hoursBeforeStartTime" to hoursBetween(
+          booking.amendedTime!!,
+          tomorrow().atTime(LocalTime.of(14, 0)),
+        ).toDouble(),
+      )
+    }
+  }
+
+  @Test
+  fun `should raise a probation booking cancelled telemetry event cancelled by a prison`() {
+    booking.cancel(prisonUser())
+
+    with(ProbationBookingCancelledTelemetryEvent.user(booking, prisonUser())) {
+      properties() containsEntriesExactlyInAnyOrder mapOf(
+        "video_booking_id" to "0",
+        "cancelled_by" to "prison",
+        "team_code" to BLACKPOOL_MC_PPOC,
+        "meeting_type" to "PSR",
+        "prison_code" to BIRMINGHAM,
+        "location_key" to birminghamLocation.key,
+        "start" to tomorrow().atTime(LocalTime.of(14, 0)).toIsoDateTime(),
+        "end" to tomorrow().atTime(LocalTime.of(15, 0)).toIsoDateTime(),
+        "cvp_link" to "true",
+      )
+
+      metrics() containsEntriesExactlyInAnyOrder mapOf(
+        "hoursBeforeStartTime" to hoursBetween(
+          booking.amendedTime!!,
+          tomorrow().atTime(LocalTime.of(14, 0)),
+        ).toDouble(),
+      )
+    }
+  }
+
+  @Test
+  fun `should raise a probation booking cancelled telemetry event cancelled by release`() {
+    booking.cancel(prisonUser())
+
+    with(ProbationBookingCancelledTelemetryEvent.released(booking)) {
+      properties() containsEntriesExactlyInAnyOrder mapOf(
+        "video_booking_id" to "0",
+        "cancelled_by" to "release",
+        "team_code" to BLACKPOOL_MC_PPOC,
+        "meeting_type" to "PSR",
+        "prison_code" to BIRMINGHAM,
+        "location_key" to birminghamLocation.key,
+        "start" to tomorrow().atTime(LocalTime.of(14, 0)).toIsoDateTime(),
+        "end" to tomorrow().atTime(LocalTime.of(15, 0)).toIsoDateTime(),
+        "cvp_link" to "true",
+      )
+
+      metrics() containsEntriesExactlyInAnyOrder mapOf(
+        "hoursBeforeStartTime" to hoursBetween(
+          booking.amendedTime!!,
+          tomorrow().atTime(LocalTime.of(14, 0)),
+        ).toDouble(),
+      )
+    }
+  }
+
+  @Test
+  fun `should raise a probation booking cancelled telemetry event cancelled by transfer`() {
+    booking.cancel(prisonUser())
+
+    with(ProbationBookingCancelledTelemetryEvent.transferred(booking)) {
+      properties() containsEntriesExactlyInAnyOrder mapOf(
+        "video_booking_id" to "0",
+        "cancelled_by" to "transfer",
+        "team_code" to BLACKPOOL_MC_PPOC,
+        "meeting_type" to "PSR",
+        "prison_code" to BIRMINGHAM,
+        "location_key" to birminghamLocation.key,
+        "start" to tomorrow().atTime(LocalTime.of(14, 0)).toIsoDateTime(),
+        "end" to tomorrow().atTime(LocalTime.of(15, 0)).toIsoDateTime(),
+        "cvp_link" to "true",
+      )
+
+      metrics() containsEntriesExactlyInAnyOrder mapOf(
+        "hoursBeforeStartTime" to hoursBetween(
+          booking.amendedTime!!,
+          tomorrow().atTime(LocalTime.of(14, 0)),
+        ).toDouble(),
+      )
+    }
+  }
+
+  private fun hoursBetween(from: LocalDateTime, to: LocalDateTime) = ChronoUnit.HOURS.between(from, to)
+
+  @Test
+  fun `should fail to create event if court booking`() {
+    val error = assertThrows<IllegalArgumentException> { ProbationBookingCancelledTelemetryEvent.transferred(courtBooking()) }
+
+    error.message isEqualTo "Cannot create probation cancelled metric, video booking with ID '0' is not a probation booking."
+  }
+
+  @Test
+  fun `should fail to create event when booking has not been cancelled`() {
+    val error = assertThrows<IllegalArgumentException> { ProbationBookingCancelledTelemetryEvent.transferred(probationBooking()) }
+
+    error.message isEqualTo "Cannot create probation cancelled metric, video booking with ID '0' has not been cancelled."
+  }
+}


### PR DESCRIPTION
This change introduces two new metrics for Court and probation cancellations.

There is also a bit of refactoring that has taken place as a result of introducing them.