### PR TITLE
BAVL-261 capturing metrics for prisoner merge events.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/VideoBookingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/VideoBookingRepository.kt
@@ -1,10 +1,21 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 
 @Repository
 interface VideoBookingRepository : JpaRepository<VideoBooking, Long> {
   fun existsByMigratedVideoBookingId(id: Long): Boolean
+
+  @Query(
+    value = """
+      SELECT count(distinct v)
+      FROM VideoBooking v
+      JOIN VideoAppointment va on va.videoBookingId = v.videoBookingId
+      WHERE va.prisonerNumber = :prisonerNumber
+    """,
+  )
+  fun countDistinctByPrisonerNumber(prisonerNumber: String): Long
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerMergedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerMergedEventHandler.kt
@@ -5,12 +5,17 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.BookingHistoryAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PrisonerMergedEvent
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry.PrisonerMergedTelemetryEvent
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry.TelemetryService
 
 @Component
 class PrisonerMergedEventHandler(
+  private val videoBookingRepository: VideoBookingRepository,
   private val prisonAppRepository: PrisonAppointmentRepository,
   private val bookingHistoryAppRepository: BookingHistoryAppointmentRepository,
+  private val telemetryService: TelemetryService,
 ) : DomainEventHandler<PrisonerMergedEvent> {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -21,14 +26,34 @@ class PrisonerMergedEventHandler(
     val removed = event.removedPrisonerNumber()
     val replacement = event.replacementPrisonerNumber()
 
-    prisonAppRepository.countByPrisonerNumber(removed).takeIf { it > 0 }?.let { count ->
+    videoBookingRepository.countDistinctByPrisonerNumber(removed).takeIf { it > 0 }?.let { numberOfBookingsAffected ->
+      mergeAffectedAppointments(removed, replacement)
+      mergeAffectedAppointmentsHistory(removed, replacement)
+      captureTelemetry(removed, replacement, numberOfBookingsAffected)
+    } ?: log.info("PRISONER MERGED: nothing to merge for prisoner number '$removed'")
+  }
+
+  private fun mergeAffectedAppointments(removed: String, replacement: String) {
+    prisonAppRepository.countByPrisonerNumber(removed).let { count ->
       prisonAppRepository.mergePrisonerNumber(removedNumber = removed, replacementNumber = replacement)
       log.info("PRISONER MERGED: merged $count prison appointment(s) - replaced number '$removed' with '$replacement'")
-    } ?: log.info("PRISONER MERGED: nothing to merge for prisoner number '$removed'")
+    }
+  }
 
-    bookingHistoryAppRepository.countByPrisonerNumber(removed).takeIf { it > 0 }?.let { count ->
+  private fun mergeAffectedAppointmentsHistory(removed: String, replacement: String) {
+    bookingHistoryAppRepository.countByPrisonerNumber(removed).let { count ->
       bookingHistoryAppRepository.mergePrisonerNumber(removedNumber = removed, replacementNumber = replacement)
       log.info("PRISONER MERGED: merged $count booking history appointment(s) - replaced number '$removed' with '$replacement'")
     }
+  }
+
+  private fun captureTelemetry(removed: String, replacement: String, bookingsUpdated: Long) {
+    telemetryService.track(
+      PrisonerMergedTelemetryEvent(
+        previousPrisonerNumber = removed,
+        newPrisonerNumber = replacement,
+        bookingsUpdated = bookingsUpdated,
+      ),
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/PrisonerMergedTelemetryEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/PrisonerMergedTelemetryEvent.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry
+
+class PrisonerMergedTelemetryEvent(
+  private val previousPrisonerNumber: String,
+  private val newPrisonerNumber: String,
+  private val bookingsUpdated: Long,
+) : MetricTelemetryEvent("BVLS-prisoner-merged") {
+  override fun properties() = mapOf(
+    "previous_prisoner_number" to previousPrisonerNumber,
+    "new_prisoner_number" to newPrisonerNumber,
+  )
+
+  override fun metrics() = mapOf("bookings_updated" to bookingsUpdated.toDouble())
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerMergedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerMergedEventHandlerTest.kt
@@ -3,61 +3,64 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handl
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntriesExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.BookingHistoryAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.MergeInformation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PrisonerMergedEvent
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry.PrisonerMergedTelemetryEvent
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry.TelemetryService
 
 class PrisonerMergedEventHandlerTest {
 
   private val mergeEvent = PrisonerMergedEvent(MergeInformation(removedNomsNumber = "removed", nomsNumber = "replacement"))
+  private val videoBookingRepository: VideoBookingRepository = mock()
   private val prisonAppointmentRepository: PrisonAppointmentRepository = mock()
   private val bookingHistoryAppointmentRepository: BookingHistoryAppointmentRepository = mock()
-  private val handler = PrisonerMergedEventHandler(prisonAppointmentRepository, bookingHistoryAppointmentRepository)
-
-  @Test
-  fun `should merge only prison appointments`() {
-    whenever(prisonAppointmentRepository.countByPrisonerNumber("removed")) doReturn 1
-
-    handler.handle(mergeEvent)
-
-    verify(prisonAppointmentRepository).mergePrisonerNumber(removedNumber = "removed", replacementNumber = "replacement")
-    verify(bookingHistoryAppointmentRepository, never()).mergePrisonerNumber(anyString(), anyString())
-  }
-
-  @Test
-  fun `should merge only booking history appointments`() {
-    whenever(bookingHistoryAppointmentRepository.countByPrisonerNumber("removed")) doReturn 1
-
-    handler.handle(mergeEvent)
-
-    verify(bookingHistoryAppointmentRepository).mergePrisonerNumber(removedNumber = "removed", replacementNumber = "replacement")
-    verify(prisonAppointmentRepository, never()).mergePrisonerNumber(anyString(), anyString())
-  }
+  private val telemetryService: TelemetryService = mock()
+  private val telemetryCaptor = argumentCaptor<PrisonerMergedTelemetryEvent>()
+  private val handler = PrisonerMergedEventHandler(videoBookingRepository, prisonAppointmentRepository, bookingHistoryAppointmentRepository, telemetryService)
 
   @Test
   fun `should merge prison appointments and booking history appointments`() {
+    whenever(videoBookingRepository.countDistinctByPrisonerNumber("removed")) doReturn 1
     whenever(prisonAppointmentRepository.countByPrisonerNumber("removed")) doReturn 1
     whenever(bookingHistoryAppointmentRepository.countByPrisonerNumber("removed")) doReturn 1
 
     handler.handle(mergeEvent)
 
-    verify(prisonAppointmentRepository).mergePrisonerNumber(removedNumber = "removed", replacementNumber = "replacement")
-    verify(bookingHistoryAppointmentRepository).mergePrisonerNumber(removedNumber = "removed", replacementNumber = "replacement")
+    inOrder(prisonAppointmentRepository, bookingHistoryAppointmentRepository, telemetryService) {
+      verify(prisonAppointmentRepository).mergePrisonerNumber(removedNumber = "removed", replacementNumber = "replacement")
+      verify(bookingHistoryAppointmentRepository).mergePrisonerNumber(removedNumber = "removed", replacementNumber = "replacement")
+      verify(telemetryService).track(telemetryCaptor.capture())
+    }
+
+    with(telemetryCaptor.firstValue) {
+      properties() containsEntriesExactlyInAnyOrder mapOf(
+        "previous_prisoner_number" to "removed",
+        "new_prisoner_number" to "replacement",
+      )
+
+      metrics() containsEntriesExactlyInAnyOrder mapOf("bookings_updated" to 1.0)
+    }
   }
 
   @Test
   fun `should be no-op when nothing to merge`() {
-    whenever(prisonAppointmentRepository.countByPrisonerNumber("removed")) doReturn 0
-    whenever(bookingHistoryAppointmentRepository.countByPrisonerNumber("removed")) doReturn 0
+    whenever(videoBookingRepository.countDistinctByPrisonerNumber("removed")) doReturn 0
 
     handler.handle(mergeEvent)
 
     verify(prisonAppointmentRepository, never()).mergePrisonerNumber(anyString(), anyString())
     verify(bookingHistoryAppointmentRepository, never()).mergePrisonerNumber(anyString(), anyString())
+    verify(telemetryService, never()).track(any())
   }
 }

--- a/src/test/resources/integration-test-data/seed-prisoner-merge.sql
+++ b/src/test/resources/integration-test-data/seed-prisoner-merge.sql
@@ -9,3 +9,15 @@ values (-1, -1, 'CREATE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_use
 
 insert into booking_history_appointment(booking_history_appointment_id, booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_loc_key, start_time, end_time)
 values (-1, -1, 'PVI', 'OLD123', current_date, 'VLB_COURT_MAIN', 'PVI-ABCDEFG', '12:00', '13:00');
+
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
+values (-2, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
+
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_loc_key, appointment_date,  start_time, end_time)
+values (-2, 2, 'OLD123', 'VLB_COURT_MAIN', 'comments about the hearing', 'PVI-ABCDEFG', current_date, '09:00', '10:00');
+
+insert into booking_history (booking_history_id, video_booking_id, history_type, court_id, hearing_type, comments, created_by, created_time)
+values (-2, -2, 'CREATE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
+
+insert into booking_history_appointment(booking_history_appointment_id, booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_loc_key, start_time, end_time)
+values (-2, -2, 'PVI', 'OLD123', current_date, 'VLB_COURT_MAIN', 'PVI-ABCDEFG', '09:00', '10:00');


### PR DESCRIPTION
Changes to support the capture of metrics for prisoner merge events.