### PR TITLE
BAVL-260 correcting the event type for probation cancellations, tests updated.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCancelledTelemetryEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCancelledTelemetryEvent.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
 class ProbationBookingCancelledTelemetryEvent private constructor(
   private val booking: VideoBooking,
   private val cancelledBy: String,
-) : MetricTelemetryEvent("BVLS-court-booking-cancelled") {
+) : MetricTelemetryEvent("BVLS-probation-booking-cancelled") {
 
   init {
     require(booking.isProbationBooking()) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingCancelledTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingCancelledTelemetryEventTest.kt
@@ -62,6 +62,8 @@ class CourtBookingCancelledTelemetryEventTest {
     booking.cancel(courtUser())
 
     with(CourtBookingCancelledTelemetryEvent.user(booking, courtUser())) {
+      eventType isEqualTo "BVLS-court-booking-cancelled"
+
       properties() containsEntriesExactlyInAnyOrder mapOf(
         "video_booking_id" to "0",
         "cancelled_by" to "court",
@@ -94,6 +96,8 @@ class CourtBookingCancelledTelemetryEventTest {
     booking.cancel(prisonUser())
 
     with(CourtBookingCancelledTelemetryEvent.user(booking, prisonUser())) {
+      eventType isEqualTo "BVLS-court-booking-cancelled"
+
       properties() containsEntriesExactlyInAnyOrder mapOf(
         "video_booking_id" to "0",
         "cancelled_by" to "prison",
@@ -126,6 +130,8 @@ class CourtBookingCancelledTelemetryEventTest {
     booking.cancel(prisonUser())
 
     with(CourtBookingCancelledTelemetryEvent.released(booking)) {
+      eventType isEqualTo "BVLS-court-booking-cancelled"
+
       properties() containsEntriesExactlyInAnyOrder mapOf(
         "video_booking_id" to "0",
         "cancelled_by" to "release",
@@ -158,6 +164,8 @@ class CourtBookingCancelledTelemetryEventTest {
     booking.cancel(prisonUser())
 
     with(CourtBookingCancelledTelemetryEvent.transferred(booking)) {
+      eventType isEqualTo "BVLS-court-booking-cancelled"
+
       properties() containsEntriesExactlyInAnyOrder mapOf(
         "video_booking_id" to "0",
         "cancelled_by" to "transfer",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCancelledTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCancelledTelemetryEventTest.kt
@@ -44,6 +44,8 @@ class ProbationBookingCancelledTelemetryEventTest {
     booking.cancel(probationUser())
 
     with(ProbationBookingCancelledTelemetryEvent.user(booking, probationUser())) {
+      eventType isEqualTo "BVLS-probation-booking-cancelled"
+
       properties() containsEntriesExactlyInAnyOrder mapOf(
         "video_booking_id" to "0",
         "cancelled_by" to "probation",
@@ -70,6 +72,8 @@ class ProbationBookingCancelledTelemetryEventTest {
     booking.cancel(prisonUser())
 
     with(ProbationBookingCancelledTelemetryEvent.user(booking, prisonUser())) {
+      eventType isEqualTo "BVLS-probation-booking-cancelled"
+
       properties() containsEntriesExactlyInAnyOrder mapOf(
         "video_booking_id" to "0",
         "cancelled_by" to "prison",
@@ -96,6 +100,8 @@ class ProbationBookingCancelledTelemetryEventTest {
     booking.cancel(prisonUser())
 
     with(ProbationBookingCancelledTelemetryEvent.released(booking)) {
+      eventType isEqualTo "BVLS-probation-booking-cancelled"
+
       properties() containsEntriesExactlyInAnyOrder mapOf(
         "video_booking_id" to "0",
         "cancelled_by" to "release",
@@ -122,6 +128,8 @@ class ProbationBookingCancelledTelemetryEventTest {
     booking.cancel(prisonUser())
 
     with(ProbationBookingCancelledTelemetryEvent.transferred(booking)) {
+      eventType isEqualTo "BVLS-probation-booking-cancelled"
+
       properties() containsEntriesExactlyInAnyOrder mapOf(
         "video_booking_id" to "0",
         "cancelled_by" to "transfer",


### PR DESCRIPTION
Noticed during testing in dev the metric name/label was not quite right for the probation cancellations.