### PR TITLE
BAVL-43 slight improvement to logging and adding temporary migration controller to assist with debugging.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/MigrationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/MigrationController.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.MigrateVideoBookingEvent
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.MigrateVideoBookingEventHandler
+
+@Tag(name = "Migrate a video link booking from old BVLS")
+@RestController
+@RequestMapping(value = ["migrate"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN')")
+@Deprecated(message = "Can be removed when migration is completed")
+class MigrationController(private val migrateVideoBookingEventHandler: MigrateVideoBookingEventHandler) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Operation(summary = "Endpoint to migrate a single video booking from old BVLS into this service")
+  @GetMapping(value = ["/{videoBookingId}"], produces = [MediaType.TEXT_PLAIN_VALUE])
+  fun migrateSingle(
+    @PathVariable("videoBookingId") videoBookingId: Long,
+  ): String {
+    migrateVideoBookingEventHandler.handle(MigrateVideoBookingEvent(videoBookingId))
+
+    return "Migrated booking $videoBookingId"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/migration/MigrateVideoBookingService.kt
@@ -43,7 +43,7 @@ class MigrateVideoBookingService(
 
   private fun migrateCourt(bookingToMigrate: VideoBookingMigrateResponse): VideoBooking {
     val prisonerNumber = mappingService.mapBookingIdToPrisonerNumber(bookingToMigrate.offenderBookingId)
-      ?: throw MigrationException("Unable to find prisoner number for booking ${bookingToMigrate.videoBookingId}")
+      ?: throw MigrationException("Unable to find prisoner number for offender booking ID ${bookingToMigrate.offenderBookingId} for court booking ${bookingToMigrate.videoBookingId}")
 
     val preLocation = bookingToMigrate.pre?.let {
       mappingService.mapInternalLocationIdToLocation(it.locationId) ?: throw NullPointerException(
@@ -127,7 +127,7 @@ class MigrateVideoBookingService(
 
   private fun migrateProbationTeam(bookingToMigrate: VideoBookingMigrateResponse): VideoBooking {
     val prisonerNumber = mappingService.mapBookingIdToPrisonerNumber(bookingToMigrate.offenderBookingId)
-      ?: throw MigrationException("Unable to find prisoner number for booking ${bookingToMigrate.videoBookingId}")
+      ?: throw MigrationException("Unable to find prisoner number for offender booking ID ${bookingToMigrate.offenderBookingId} for probation booking ${bookingToMigrate.videoBookingId}")
 
     val mainLocation =
       mappingService.mapInternalLocationIdToLocation(bookingToMigrate.main.locationId) ?: throw NullPointerException(


### PR DESCRIPTION
Improving telemetry failure logging around offender booking id not found.

Also added a temporary migration controller so we can migrate an individual booking on a need only basis e.g. something fails to migrate but we can easily retry it.