### PR TITLE
BAVL-390 changes to support handling of domain event for prison appointment cancelled.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/VideoAppointmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/VideoAppointmentRepository.kt
@@ -43,4 +43,21 @@ interface VideoAppointmentRepository : ReadOnlyRepository<VideoAppointment, Long
     startTime: LocalTime,
     endTime: LocalTime,
   ): VideoAppointment?
+
+  @Query(
+    value = """
+      FROM VideoAppointment va 
+      WHERE va.prisonCode = :prisonCode
+      AND va.prisonerNumber = :prisonerNumber
+      AND va.appointmentDate = :appointmentDate
+      AND va.startTime = :startTime
+      AND va.statusCode = 'ACTIVE'
+    """,
+  )
+  fun findActiveVideoAppointments(
+    prisonCode: String,
+    prisonerNumber: String,
+    appointmentDate: LocalDate,
+    startTime: LocalTime,
+  ): List<VideoAppointment>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingController.kt
@@ -29,6 +29,8 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Request
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.VideoBookingSearchRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.VideoLinkBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingFacade
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ExternalUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.PrisonUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.RequestBookingService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.VideoLinkBookingsService
 
@@ -178,7 +180,11 @@ class VideoLinkBookingController(
     @PathVariable("videoBookingId") videoBookingId: Long,
     httpRequest: HttpServletRequest,
   ) {
-    bookingFacade.cancel(videoBookingId, httpRequest.getBvlsRequestContext().user)
+    when (val user = httpRequest.getBvlsRequestContext().user) {
+      is PrisonUser -> bookingFacade.cancel(videoBookingId, user)
+      is ExternalUser -> bookingFacade.cancel(videoBookingId, user)
+      else -> throw IllegalArgumentException("Unsupported user for cancel operation.")
+    }
   }
 
   @Operation(summary = "Endpoint to support the request for a prison to create a video link booking for a prisoner due to arrive")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
@@ -67,10 +67,26 @@ class BookingFacade(
     return booking.videoBookingId
   }
 
-  fun cancel(videoBookingId: Long, cancelledBy: User) {
+  fun cancel(videoBookingId: Long, cancelledBy: PrisonUser) {
+    cancelBooking(videoBookingId, cancelledBy)
+  }
+
+  fun cancel(videoBookingId: Long, cancelledBy: ExternalUser) {
+    cancelBooking(videoBookingId, cancelledBy)
+  }
+
+  private fun cancelBooking(videoBookingId: Long, cancelledBy: User) {
     val booking = cancelVideoBookingService.cancel(videoBookingId, cancelledBy)
     log.info("Video booking ${booking.videoBookingId} cancelled by user")
     outboundEventsService.send(DomainEventType.VIDEO_BOOKING_CANCELLED, videoBookingId)
+    sendBookingEmails(BookingAction.CANCEL, booking, getPrisoner(booking.prisoner()), cancelledBy)
+    sendTelemetry(BookingAction.CANCEL, booking, cancelledBy)
+  }
+
+  fun cancel(videoBookingId: Long, cancelledBy: ServiceUser) {
+    // No events should be raised on the back of calling this function, this is by design.
+    val booking = cancelVideoBookingService.cancel(videoBookingId, cancelledBy)
+    log.info("Video booking ${booking.videoBookingId} cancelled by user")
     sendBookingEmails(BookingAction.CANCEL, booking, getPrisoner(booking.prisoner()), cancelledBy)
     sendTelemetry(BookingAction.CANCEL, booking, cancelledBy)
   }
@@ -83,7 +99,7 @@ class BookingFacade(
     sendBookingEmails(BookingAction.COURT_HEARING_LINK_REMINDER, videoBooking, getPrisoner(videoBooking.prisoner()), user)
   }
 
-  fun prisonerTransferred(videoBookingId: Long, user: User) {
+  fun prisonerTransferred(videoBookingId: Long, user: ServiceUser) {
     val booking = cancelVideoBookingService.cancel(videoBookingId, user)
     log.info("Video booking ${booking.videoBookingId} cancelled due to transfer")
     outboundEventsService.send(DomainEventType.VIDEO_BOOKING_CANCELLED, videoBookingId)
@@ -91,7 +107,7 @@ class BookingFacade(
     sendTelemetry(BookingAction.TRANSFERRED, booking, user)
   }
 
-  fun prisonerReleased(videoBookingId: Long, user: User) {
+  fun prisonerReleased(videoBookingId: Long, user: ServiceUser) {
     val booking = cancelVideoBookingService.cancel(videoBookingId, user)
     log.info("Video booking ${booking.videoBookingId} cancelled due to release")
     outboundEventsService.send(DomainEventType.VIDEO_BOOKING_CANCELLED, videoBookingId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
@@ -77,7 +77,7 @@ class BookingFacade(
 
   private fun cancelBooking(videoBookingId: Long, cancelledBy: User) {
     val booking = cancelVideoBookingService.cancel(videoBookingId, cancelledBy)
-    log.info("Video booking ${booking.videoBookingId} cancelled by user")
+    log.info("Video booking ${booking.videoBookingId} cancelled by user type ${cancelledBy::class.simpleName}")
     outboundEventsService.send(DomainEventType.VIDEO_BOOKING_CANCELLED, videoBookingId)
     sendBookingEmails(BookingAction.CANCEL, booking, getPrisoner(booking.prisoner()), cancelledBy)
     sendTelemetry(BookingAction.CANCEL, booking, cancelledBy)
@@ -86,7 +86,7 @@ class BookingFacade(
   fun cancel(videoBookingId: Long, cancelledBy: ServiceUser) {
     // No events should be raised on the back of calling this function, this is by design.
     val booking = cancelVideoBookingService.cancel(videoBookingId, cancelledBy)
-    log.info("Video booking ${booking.videoBookingId} cancelled by user")
+    log.info("Video booking ${booking.videoBookingId} cancelled by user type ${cancelledBy::class.simpleName}")
     sendBookingEmails(BookingAction.CANCEL, booking, getPrisoner(booking.prisoner()), cancelledBy)
     sendTelemetry(BookingAction.CANCEL, booking, cancelledBy)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingHistoryService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
-import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingHistory
@@ -14,11 +13,6 @@ class BookingHistoryService(private val bookingHistoryRepository: BookingHistory
 
   fun getByVideoBookingId(videoBookingId: Long): List<BookingHistory> =
     bookingHistoryRepository.findAllByVideoBookingIdOrderByCreatedTime(videoBookingId)
-
-  // TODO: For use in retrieving a specific history row - coming soon
-  fun getByBookingHistoryId(bookingHistoryId: Long): BookingHistory =
-    bookingHistoryRepository.findById(bookingHistoryId)
-      .orElseThrow { EntityNotFoundException("Video booking history with ID $bookingHistoryId not found") }
 
   @Transactional
   fun createBookingHistory(historyType: HistoryType, booking: VideoBooking) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/DomainEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/DomainEvents.kt
@@ -77,7 +77,7 @@ class PrisonerMergedEvent(additionalInformation: MergeInformation) :
 data class MergeInformation(val nomsNumber: String, val removedNomsNumber: String) : AdditionalInformation
 
 class PrisonerVideoAppointmentCancelledEvent(
-  private val personReference: PersonReference,
+  val personReference: PersonReference,
   additionalInformation: AppointmentScheduleInformation,
 ) :
   DomainEvent<AppointmentScheduleInformation>(DomainEventType.PRISONER_VIDEO_APPOINTMENT_CANCELLED, additionalInformation) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsService.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handle
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.MigrateVideoBookingEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerMergedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerReleasedEventHandler
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerVideoAppointmentCancelledEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.VideoBookingAmendedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.VideoBookingCancelledEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.VideoBookingCreatedEventHandler
@@ -21,6 +22,7 @@ class InboundEventsService(
   private val prisonerReleasedEventHandler: PrisonerReleasedEventHandler,
   private val prisonerMergedEventHandler: PrisonerMergedEventHandler,
   private val migrateVideoBookingEventHandler: MigrateVideoBookingEventHandler,
+  private val prisonerVideoAppointmentCancelledEventHandler: PrisonerVideoAppointmentCancelledEventHandler,
 ) {
   companion object {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -35,6 +37,7 @@ class InboundEventsService(
       is VideoBookingCancelledEvent -> videoBookingCancelledEventHandler.handle(event)
       is VideoBookingCreatedEvent -> videoBookingCreatedEventHandler.handle(event)
       is MigrateVideoBookingEvent -> migrateVideoBookingEventHandler.handle(event)
+      is PrisonerVideoAppointmentCancelledEvent -> prisonerVideoAppointmentCancelledEventHandler.handle(event)
       else -> log.warn("Unsupported domain event ${event.javaClass.name}")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerVideoAppointmentCancelledEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerVideoAppointmentCancelledEventHandler.kt
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingFacade
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserService
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PrisonerVideoAppointmentCancelledEvent
+
+@Component
+class PrisonerVideoAppointmentCancelledEventHandler(
+  private val videoAppointmentRepository: VideoAppointmentRepository,
+  private val bookingFacade: BookingFacade,
+) : DomainEventHandler<PrisonerVideoAppointmentCancelledEvent> {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  override fun handle(event: PrisonerVideoAppointmentCancelledEvent) {
+    if (event.isVideoLinkBooking()) {
+      val activeAppointments = videoAppointmentRepository.findActiveVideoAppointments(
+        prisonCode = event.prisonCode(),
+        prisonerNumber = event.prisonerNumber(),
+        appointmentDate = event.date(),
+        startTime = event.startTime(),
+      )
+
+      if (activeAppointments.size == 1) {
+        val appointment = activeAppointments.single()
+
+        if (appointment.isMainAppointment()) {
+          bookingFacade.cancel(appointment.videoBookingId, UserService.getServiceAsUser())
+        } else {
+          // TODO - not yet implemented
+          // if single matching appointment and is a pre or post,
+          //   remove the appointment, do not propagate to other services
+          //   no email necessary
+          //   record a history of the removal
+          log.info("Not yet handling removal of pre/post appointment here.")
+        }
+
+        return
+      }
+
+      log.info("Ignoring event for cancellation of appointment, could not find a unique match.")
+    }
+  }
+
+  private fun VideoAppointment.isMainAppointment() = listOf("VLB_COURT_MAIN", "VLB_PROBATION").contains(appointmentType)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingCancelledTelemetryEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingCancelledTelemetryEvent.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.StatusCode
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ExternalUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.PrisonUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ServiceUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
 
 class CourtBookingCancelledTelemetryEvent private constructor(
@@ -27,15 +28,22 @@ class CourtBookingCancelledTelemetryEvent private constructor(
 
   companion object {
     fun user(booking: VideoBooking, user: User): CourtBookingCancelledTelemetryEvent {
-      require(user is PrisonUser || (user is ExternalUser && user.isCourtUser)) {
-        "Can only create court cancelled metric for prison or court users."
+      require(user is PrisonUser || user is ServiceUser || (user is ExternalUser && user.isCourtUser)) {
+        "Can only create court cancelled metric for service, prison or court users."
       }
 
       require(user.username == booking.amendedBy) {
         "Cannot create court cancelled metric, user does not match the cancelled by user."
       }
 
-      return CourtBookingCancelledTelemetryEvent(booking, if (user is PrisonUser) "prison" else "court")
+      val cancelledBy = when (user) {
+        is PrisonUser -> "prison"
+        is ExternalUser -> "court"
+        is ServiceUser -> "service"
+        else -> throw IllegalArgumentException("Unsupported user type.")
+      }
+
+      return CourtBookingCancelledTelemetryEvent(booking, cancelledBy)
     }
 
     fun released(videoBooking: VideoBooking): CourtBookingCancelledTelemetryEvent =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/TestEmailConfiguration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/TestEmailConfiguration.kt
@@ -2,75 +2,10 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config
 
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingCourtEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonCourtEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonNoCourtEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingUserEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingCourtEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingPrisonCourtEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingPrisonNoCourtEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingUserEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CourtBookingRequestPrisonCourtEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CourtBookingRequestPrisonNoCourtEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CourtBookingRequestUserEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CourtHearingLinkReminderEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.NewCourtBookingCourtEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.NewCourtBookingPrisonCourtEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.NewCourtBookingPrisonNoCourtEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.NewCourtBookingUserEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.AmendedProbationBookingPrisonNoProbationEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.AmendedProbationBookingPrisonProbationEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.AmendedProbationBookingProbationEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.AmendedProbationBookingUserEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.CancelledProbationBookingPrisonNoProbationEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.CancelledProbationBookingPrisonProbationEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.CancelledProbationBookingProbationEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.CancelledProbationBookingUserEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.NewProbationBookingPrisonNoProbationEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.NewProbationBookingPrisonProbationEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.NewProbationBookingUserEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationBookingRequestPrisonNoProbationTeamEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationBookingRequestPrisonProbationTeamEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationBookingRequestUserEmail
 import java.util.UUID
 
 @TestConfiguration
 class TestEmailConfiguration {
   @Bean
-  fun emailService() =
-    EmailService { email ->
-      when (email) {
-        is NewCourtBookingUserEmail -> Result.success(UUID.randomUUID() to "new court booking user template id")
-        is NewCourtBookingCourtEmail -> Result.success(UUID.randomUUID() to "new court booking court template id")
-        is NewCourtBookingPrisonCourtEmail -> Result.success(UUID.randomUUID() to "new court booking prison template id with email address")
-        is NewCourtBookingPrisonNoCourtEmail -> Result.success(UUID.randomUUID() to "new court booking prison template id no email address")
-        is AmendedCourtBookingUserEmail -> Result.success(UUID.randomUUID() to "amended court booking user template id")
-        is AmendedCourtBookingCourtEmail -> Result.success(UUID.randomUUID() to "amended court booking court template id")
-        is AmendedCourtBookingPrisonCourtEmail -> Result.success(UUID.randomUUID() to "amended court booking prison template id with email address")
-        is AmendedCourtBookingPrisonNoCourtEmail -> Result.success(UUID.randomUUID() to "amended court booking prison template id no email address")
-        is CancelledCourtBookingUserEmail -> Result.success(UUID.randomUUID() to "cancelled court booking user template id")
-        is CancelledCourtBookingCourtEmail -> Result.success(UUID.randomUUID() to "cancelled court booking user template id")
-        is CancelledCourtBookingPrisonCourtEmail -> Result.success(UUID.randomUUID() to "cancelled court booking prison template id with email address")
-        is CancelledCourtBookingPrisonNoCourtEmail -> Result.success(UUID.randomUUID() to "cancelled court booking prison template id no email address")
-        is CourtBookingRequestUserEmail -> Result.success(UUID.randomUUID() to "requested court booking user template id")
-        is CourtBookingRequestPrisonCourtEmail -> Result.success(UUID.randomUUID() to "requested court booking prison template id with email address")
-        is CourtBookingRequestPrisonNoCourtEmail -> Result.success(UUID.randomUUID() to "requested court booking prison template id with no email address")
-        is ProbationBookingRequestUserEmail -> Result.success(UUID.randomUUID() to "requested probation booking user template id")
-        is ProbationBookingRequestPrisonProbationTeamEmail -> Result.success(UUID.randomUUID() to "requested probation booking prison template id with email address")
-        is ProbationBookingRequestPrisonNoProbationTeamEmail -> Result.success(UUID.randomUUID() to "requested probation booking prison template id with no email address")
-        is NewProbationBookingUserEmail -> Result.success(UUID.randomUUID() to "new probation booking user template id")
-        is NewProbationBookingPrisonProbationEmail -> Result.success(UUID.randomUUID() to "new probation booking prison template id with email address")
-        is NewProbationBookingPrisonNoProbationEmail -> Result.success(UUID.randomUUID() to "new probation booking prison template id no email address")
-        is AmendedProbationBookingUserEmail -> Result.success(UUID.randomUUID() to "amended probation booking user template id")
-        is AmendedProbationBookingPrisonProbationEmail -> Result.success(UUID.randomUUID() to "amended probation booking template id with email address")
-        is AmendedProbationBookingPrisonNoProbationEmail -> Result.success(UUID.randomUUID() to "amended probation booking template id no email address")
-        is AmendedProbationBookingProbationEmail -> Result.success(UUID.randomUUID() to "amended probation booking probation template id")
-        is CancelledProbationBookingUserEmail -> Result.success(UUID.randomUUID() to "cancelled probation booking user template id")
-        is CancelledProbationBookingProbationEmail -> Result.success(UUID.randomUUID() to "cancelled probation booking probation template id")
-        is CancelledProbationBookingPrisonProbationEmail -> Result.success(UUID.randomUUID() to "cancelled probation booking template id with email address")
-        is CancelledProbationBookingPrisonNoProbationEmail -> Result.success(UUID.randomUUID() to "cancelled probation booking template id no email address")
-        is CourtHearingLinkReminderEmail -> Result.success(UUID.randomUUID() to "court hearing link reminder template id")
-        else -> throw RuntimeException("Unsupported email in test email configuration: ${email.javaClass.simpleName}")
-      }
-    }
+  fun emailService() = EmailService { email -> Result.success(UUID.randomUUID() to email.javaClass.simpleName) }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -97,9 +97,10 @@ fun probationBooking(probationTeam: ProbationTeam = probationTeam()) = VideoBook
 fun VideoBooking.withProbationPrisonAppointment(
   prisonCode: String = BIRMINGHAM,
   location: Location = birminghamLocation,
+  prisonerNumber: String = "123456",
 ) = addAppointment(
   prison = prison(prisonCode = prisonCode),
-  prisonerNumber = "123456",
+  prisonerNumber = prisonerNumber,
   appointmentType = "VLB_PROBATION",
   date = tomorrow(),
   startTime = LocalTime.MIDNIGHT,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/InboundEventsIntegrationTest.kt
@@ -2,45 +2,71 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.resource
 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.boot.test.mock.mockito.SpyBean
+import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.jdbc.Sql
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Email
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.TestEmailConfiguration
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Notification
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.StatusCode
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BLACKPOOL_MC_PPOC
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_CENTRE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntriesExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.pentonvilleLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.SqsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.BookingHistoryAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.NotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingPrisonCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.NewCourtBookingPrisonCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.NewCourtBookingUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.CancelledProbationBookingPrisonProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.CancelledProbationBookingProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.NewProbationBookingPrisonProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.NewProbationBookingUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.AppointmentScheduleInformation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.Identifier
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.InboundEventsListener
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.ManageExternalAppointmentsService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.MergeInformation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.OutboundEventsService
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PrisonerMergedEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PrisonerReleasedEvent
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PrisonerVideoAppointmentCancelledEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.ReleaseInformation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry.PrisonerMergedTelemetryEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry.TelemetryService
 import java.time.LocalTime
+import kotlin.reflect.KClass
 
+@ContextConfiguration(classes = [TestEmailConfiguration::class])
 class InboundEventsIntegrationTest : SqsIntegrationTestBase() {
 
   @SpyBean
   private lateinit var inboundEventsListener: InboundEventsListener
 
   @MockBean
-  private lateinit var manageExternalAppointmentsService: ManageExternalAppointmentsService
+  private lateinit var outboundEventsService: OutboundEventsService
 
   @Autowired
   private lateinit var videoBookingRepository: VideoBookingRepository
@@ -51,17 +77,19 @@ class InboundEventsIntegrationTest : SqsIntegrationTestBase() {
   @Autowired
   private lateinit var bookingHistoryAppointmentRepository: BookingHistoryAppointmentRepository
 
+  @Autowired
+  private lateinit var notificationRepository: NotificationRepository
+
   @MockBean
   private lateinit var telemetryService: TelemetryService
 
   private val telemetryCaptor = argumentCaptor<PrisonerMergedTelemetryEvent>()
 
-  @DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
   @Test
   fun `should cancel a video booking on receipt of a permanent release event`() {
     videoBookingRepository.findAll() hasSize 0
 
-    prisonSearchApi().stubGetPrisoner("123456", PENTONVILLE)
+    prisonSearchApi().stubGetPrisoner("123456", prisonCode = PENTONVILLE, lastPrisonCode = PENTONVILLE)
     locationsInsidePrisonApi().stubPostLocationByKeys(setOf(pentonvilleLocation.key), setOf(pentonvilleLocation))
     locationsInsidePrisonApi().stubGetLocationById(pentonvilleLocation.id, pentonvilleLocation)
 
@@ -80,22 +108,21 @@ class InboundEventsIntegrationTest : SqsIntegrationTestBase() {
 
     videoBookingRepository.findById(bookingId).orElseThrow().statusCode isEqualTo StatusCode.ACTIVE
 
-    receiveEvent(
-      PrisonerReleasedEvent(
-        ReleaseInformation(
-          nomsNumber = "123456",
-          prisonId = PENTONVILLE,
-          reason = "RELEASED",
-        ),
-      ).also { it.isPermanent() isBool true },
+    inboundEventsListener.onMessage(
+      raw(
+        PrisonerReleasedEvent(
+          ReleaseInformation(
+            nomsNumber = "123456",
+            prisonId = PENTONVILLE,
+            reason = "RELEASED",
+          ),
+        ).also { it.isPermanent() isBool true },
+      ),
     )
-
-    waitForMessagesOnQueue(4)
 
     videoBookingRepository.findById(bookingId).orElseThrow().statusCode isEqualTo StatusCode.CANCELLED
   }
 
-  @DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
   @Test
   fun `should not cancel a video booking on receipt of a temporary release event`() {
     videoBookingRepository.findAll() hasSize 0
@@ -119,41 +146,40 @@ class InboundEventsIntegrationTest : SqsIntegrationTestBase() {
 
     videoBookingRepository.findById(bookingId).orElseThrow().statusCode isEqualTo StatusCode.ACTIVE
 
-    receiveEvent(
-      PrisonerReleasedEvent(
-        ReleaseInformation(
-          nomsNumber = "123456",
-          prisonId = PENTONVILLE,
-          reason = "TEMPORARY_ABSENCE_RELEASE",
-        ),
-      ).also { it.isTemporary() isBool true },
+    inboundEventsListener.onMessage(
+      raw(
+        PrisonerReleasedEvent(
+          ReleaseInformation(
+            nomsNumber = "123456",
+            prisonId = PENTONVILLE,
+            reason = "TEMPORARY_ABSENCE_RELEASE",
+          ),
+        ).also { it.isTemporary() isBool true },
+      ),
     )
-
-    waitForMessagesOnQueue(3)
 
     videoBookingRepository.findById(bookingId).orElseThrow().statusCode isEqualTo StatusCode.ACTIVE
   }
 
-  @DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
   @Sql("classpath:integration-test-data/seed-historic-booking.sql")
   @Test
   fun `should not cancel historic video booking on receipt of a permanent release event`() {
-    val historicBooking = videoBookingRepository.findById(-1).orElseThrow()
+    val historicBooking = videoBookingRepository.findById(-3).orElseThrow()
 
     prisonSearchApi().stubGetPrisoner("ABCDEF", PENTONVILLE)
     locationsInsidePrisonApi().stubPostLocationByKeys(setOf(pentonvilleLocation.key), PENTONVILLE)
 
-    receiveEvent(
-      PrisonerReleasedEvent(
-        ReleaseInformation(
-          nomsNumber = "ABCDEF",
-          prisonId = PENTONVILLE,
-          reason = "RELEASED",
-        ),
-      ).also { it.isPermanent() isBool true },
+    inboundEventsListener.onMessage(
+      raw(
+        PrisonerReleasedEvent(
+          ReleaseInformation(
+            nomsNumber = "ABCDEF",
+            prisonId = PENTONVILLE,
+            reason = "RELEASED",
+          ),
+        ).also { it.isPermanent() isBool true },
+      ),
     )
-
-    waitForMessagesOnQueue(1)
 
     videoBookingRepository.findById(historicBooking.videoBookingId).orElseThrow().statusCode isEqualTo StatusCode.ACTIVE
   }
@@ -211,8 +237,8 @@ class InboundEventsIntegrationTest : SqsIntegrationTestBase() {
   @Test
   @Sql("classpath:integration-test-data/seed-prisoner-merge.sql")
   fun `should merge prison appointments and booking appointment history when prison merged`() {
-    val firstBooking = videoBookingRepository.findById(-1).orElseThrow()
-    val secondBooking = videoBookingRepository.findById(-2).orElseThrow()
+    val firstBooking = videoBookingRepository.findById(-100).orElseThrow()
+    val secondBooking = videoBookingRepository.findById(-200).orElseThrow()
 
     prisonAppointmentRepository.findByVideoBooking(firstBooking).single { it.prisonerNumber == "OLD123" }
     prisonAppointmentRepository.findByVideoBooking(secondBooking).single { it.prisonerNumber == "OLD123" }
@@ -242,5 +268,118 @@ class InboundEventsIntegrationTest : SqsIntegrationTestBase() {
 
       metrics() containsEntriesExactlyInAnyOrder mapOf("bookings_updated" to 2.0)
     }
+  }
+
+  @Test
+  fun `should cancel a video court booking on receipt of a prisoner appointment cancelled event`() {
+    videoBookingRepository.findAll() hasSize 0
+    notificationRepository.findAll() hasSize 0
+
+    prisonSearchApi().stubGetPrisoner("123456", PENTONVILLE)
+    locationsInsidePrisonApi().stubPostLocationByKeys(setOf(pentonvilleLocation.key), PENTONVILLE)
+
+    val courtBookingRequest = courtBookingRequest(
+      courtCode = DERBY_JUSTICE_CENTRE,
+      prisonerNumber = "123456",
+      prisonCode = PENTONVILLE,
+      location = pentonvilleLocation,
+      date = tomorrow(),
+      startTime = LocalTime.of(12, 0),
+      endTime = LocalTime.of(12, 30),
+      comments = "integration test court booking comments",
+    )
+
+    val bookingId = webTestClient.createBooking(courtBookingRequest, COURT_USER)
+
+    videoBookingRepository.findById(bookingId).orElseThrow().statusCode isEqualTo StatusCode.ACTIVE
+
+    inboundEventsListener.onMessage(
+      raw(
+        PrisonerVideoAppointmentCancelledEvent(
+          personReference = PersonReference(listOf(Identifier("NOMS", "123456"))),
+          additionalInformation = AppointmentScheduleInformation(
+            scheduleEventId = 1,
+            scheduledStartTime = tomorrow().atTime(12, 0),
+            scheduledEndTime = null,
+            scheduleEventSubType = "VLB",
+            scheduleEventStatus = "",
+            recordDeleted = true,
+            agencyLocationId = PENTONVILLE,
+          ),
+        ),
+      ),
+    )
+
+    val persistedBooking = videoBookingRepository.findById(bookingId).orElseThrow().also { it.statusCode isEqualTo StatusCode.CANCELLED }
+
+    // There will be 5 notifications, 3 on back of create and 4 on back of cancellation
+    val notifications = notificationRepository.findAll().also { it hasSize 7 }
+
+    notifications.isPresent("court_user", NewCourtBookingUserEmail::class, persistedBooking)
+    notifications.isPresent("g@g.com", NewCourtBookingPrisonCourtEmail::class, persistedBooking)
+    notifications.isPresent("p@p.com", NewCourtBookingPrisonCourtEmail::class, persistedBooking)
+    notifications.isPresent("b@b.com", CancelledCourtBookingCourtEmail::class, persistedBooking)
+    notifications.isPresent("j@j.com", CancelledCourtBookingCourtEmail::class, persistedBooking)
+    notifications.isPresent("g@g.com", CancelledCourtBookingPrisonCourtEmail::class, persistedBooking)
+    notifications.isPresent("p@p.com", CancelledCourtBookingPrisonCourtEmail::class, persistedBooking)
+  }
+
+  @Test
+  fun `should cancel a video probation booking on receipt of a prisoner appointment cancelled event`() {
+    videoBookingRepository.findAll() hasSize 0
+    notificationRepository.findAll() hasSize 0
+
+    prisonSearchApi().stubGetPrisoner("123456", BIRMINGHAM)
+    locationsInsidePrisonApi().stubGetLocationByKey(birminghamLocation.key, birminghamLocation)
+    locationsInsidePrisonApi().stubGetLocationById(birminghamLocation.id, birminghamLocation)
+
+    val probationBookingRequest = probationBookingRequest(
+      probationTeamCode = BLACKPOOL_MC_PPOC,
+      probationMeetingType = ProbationMeetingType.PSR,
+      videoLinkUrl = "https://probation.videolink.com",
+      prisonCode = BIRMINGHAM,
+      prisonerNumber = "123456",
+      startTime = LocalTime.of(9, 0),
+      endTime = LocalTime.of(9, 30),
+      appointmentType = AppointmentType.VLB_PROBATION,
+      location = birminghamLocation,
+      comments = "integration test probation booking comments",
+    )
+
+    val bookingId = webTestClient.createBooking(probationBookingRequest, PROBATION_USER)
+
+    videoBookingRepository.findById(bookingId).orElseThrow().statusCode isEqualTo StatusCode.ACTIVE
+
+    inboundEventsListener.onMessage(
+      raw(
+        PrisonerVideoAppointmentCancelledEvent(
+          personReference = PersonReference(listOf(Identifier("NOMS", "123456"))),
+          additionalInformation = AppointmentScheduleInformation(
+            scheduleEventId = 1,
+            scheduledStartTime = tomorrow().atTime(9, 0),
+            scheduledEndTime = null,
+            scheduleEventSubType = "VLB",
+            scheduleEventStatus = "",
+            recordDeleted = true,
+            agencyLocationId = BIRMINGHAM,
+          ),
+        ),
+      ),
+    )
+
+    val persistedBooking = videoBookingRepository.findById(bookingId).orElseThrow().also { it.statusCode isEqualTo StatusCode.CANCELLED }
+
+    // There will be 5 notifications, 2 on back of create and 3 on back of cancellation
+    val notifications = notificationRepository.findAll().also { it hasSize 5 }
+
+    notifications.isPresent("probation.user@probation.com", NewProbationBookingUserEmail::class, persistedBooking)
+    notifications.isPresent("a@a.com", NewProbationBookingPrisonProbationEmail::class, persistedBooking)
+    notifications.isPresent("t@t.com", CancelledProbationBookingProbationEmail::class, persistedBooking)
+    notifications.isPresent("m@m.com", CancelledProbationBookingProbationEmail::class, persistedBooking)
+    notifications.isPresent("a@a.com", CancelledProbationBookingPrisonProbationEmail::class, persistedBooking)
+  }
+
+  private fun <T : Email> Collection<Notification>.isPresent(email: String, template: KClass<T>, booking: VideoBooking? = null) {
+    single { it.email == email && it.templateName == template.simpleName && it.videoBooking == booking }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsServiceTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handle
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.MigrateVideoBookingEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerMergedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerReleasedEventHandler
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerVideoAppointmentCancelledEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.VideoBookingAmendedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.VideoBookingCancelledEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.VideoBookingCreatedEventHandler
@@ -22,6 +23,7 @@ class InboundEventsServiceTest {
   private val prisonerReleasedEventHandler: PrisonerReleasedEventHandler = mock()
   private val prisonerMergedEventHandler: PrisonerMergedEventHandler = mock()
   private val migrateVideoBookingEventHandler: MigrateVideoBookingEventHandler = mock()
+  private val prisonerVideoAppointmentCancelledEventHandler: PrisonerVideoAppointmentCancelledEventHandler = mock()
 
   private val service = InboundEventsService(
     appointmentCreatedEventHandler,
@@ -31,6 +33,7 @@ class InboundEventsServiceTest {
     prisonerReleasedEventHandler,
     prisonerMergedEventHandler,
     migrateVideoBookingEventHandler,
+    prisonerVideoAppointmentCancelledEventHandler,
   )
 
   @Test
@@ -100,5 +103,12 @@ class InboundEventsServiceTest {
     val event = MigrateVideoBookingEvent(1)
     service.process(event)
     verify(migrateVideoBookingEventHandler).handle(event)
+  }
+
+  @Test
+  fun `should call prison video appointment cancelled handler when appointment cancelled event`() {
+    val event = mock<PrisonerVideoAppointmentCancelledEvent>()
+    service.process(event)
+    verify(prisonerVideoAppointmentCancelledEventHandler).handle(event)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerVideoAppointmentCancelledEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerVideoAppointmentCancelledEventHandlerTest.kt
@@ -1,0 +1,167 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers
+
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.SERVICE_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.today
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.videoAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withMainCourtPrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withProbationPrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingFacade
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.AppointmentScheduleInformation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.Identifier
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PersonReference
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PrisonerVideoAppointmentCancelledEvent
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class PrisonerVideoAppointmentCancelledEventHandlerTest {
+
+  private val videoAppointmentRepository: VideoAppointmentRepository = mock()
+  private val bookingFacade: BookingFacade = mock()
+  private val handler = PrisonerVideoAppointmentCancelledEventHandler(videoAppointmentRepository, bookingFacade)
+
+  @Test
+  fun `should attempt to cancel a court booking when main appointment`() {
+    val courtBooking = courtBooking().withMainCourtPrisonAppointment(prisonerNumber = "ABC345", prisonCode = WANDSWORTH)
+    val courtAppointment = videoAppointment(courtBooking, courtBooking.appointments().single())
+
+    whenever(
+      videoAppointmentRepository.findActiveVideoAppointments(
+        prisonCode = WANDSWORTH,
+        prisonerNumber = "ABC345",
+        appointmentDate = today(),
+        startTime = LocalTime.MIDNIGHT,
+      ),
+    ) doReturn listOf(courtAppointment)
+
+    handler.handle(
+      cancellationEvent(
+        prisonCode = WANDSWORTH,
+        prisonerNumber = "ABC345",
+        start = today().atStartOfDay(),
+      ),
+    )
+
+    inOrder(videoAppointmentRepository, bookingFacade) {
+      verify(videoAppointmentRepository).findActiveVideoAppointments(
+        WANDSWORTH,
+        "ABC345",
+        appointmentDate = today(),
+        startTime = LocalTime.MIDNIGHT,
+      )
+      verify(bookingFacade).cancel(courtBooking.videoBookingId, SERVICE_USER)
+    }
+  }
+
+  @Test
+  fun `should attempt to cancel a probation booking`() {
+    val probationBooking = probationBooking().withProbationPrisonAppointment(prisonerNumber = "DEF345", prisonCode = PENTONVILLE)
+    val probationAppointment = videoAppointment(probationBooking, probationBooking.appointments().single())
+
+    whenever(
+      videoAppointmentRepository.findActiveVideoAppointments(
+        prisonCode = PENTONVILLE,
+        prisonerNumber = "DEF345",
+        appointmentDate = tomorrow(),
+        startTime = LocalTime.MIDNIGHT,
+      ),
+    ) doReturn listOf(probationAppointment)
+
+    handler.handle(
+      cancellationEvent(
+        prisonCode = PENTONVILLE,
+        prisonerNumber = "DEF345",
+        start = tomorrow().atStartOfDay(),
+      ),
+    )
+
+    inOrder(videoAppointmentRepository, bookingFacade) {
+      verify(videoAppointmentRepository).findActiveVideoAppointments(
+        PENTONVILLE,
+        "DEF345",
+        appointmentDate = tomorrow(),
+        startTime = LocalTime.MIDNIGHT,
+      )
+      verify(bookingFacade).cancel(probationBooking.videoBookingId, SERVICE_USER)
+    }
+  }
+
+  @Test
+  fun `should be a no-op when multiple appointments found`() {
+    val courtBooking = courtBooking().withMainCourtPrisonAppointment(prisonerNumber = "ABC345", prisonCode = WANDSWORTH)
+    val courtAppointment = videoAppointment(courtBooking, courtBooking.appointments().single())
+    val probationBooking = probationBooking().withProbationPrisonAppointment(prisonerNumber = "ABC345", prisonCode = WANDSWORTH)
+    val probationAppointment = videoAppointment(probationBooking, probationBooking.appointments().single())
+
+    whenever(
+      videoAppointmentRepository.findActiveVideoAppointments(
+        prisonCode = WANDSWORTH,
+        prisonerNumber = "ABC345",
+        appointmentDate = today(),
+        startTime = LocalTime.MIDNIGHT,
+      ),
+    ) doReturn listOf(courtAppointment, probationAppointment)
+
+    handler.handle(
+      cancellationEvent(
+        prisonCode = WANDSWORTH,
+        prisonerNumber = "ABC345",
+        start = today().atStartOfDay(),
+      ),
+    )
+
+    verify(videoAppointmentRepository).findActiveVideoAppointments(
+      WANDSWORTH,
+      "ABC345",
+      appointmentDate = today(),
+      startTime = LocalTime.MIDNIGHT,
+    )
+
+    verifyNoInteractions(bookingFacade)
+  }
+
+  @Test
+  fun `should be a no-op when not a video link appointment`() {
+    handler.handle(
+      cancellationEvent(
+        prisonCode = WANDSWORTH,
+        prisonerNumber = "ABC345",
+        start = today().atStartOfDay(),
+        eventType = "NOT_VLB",
+      ),
+    )
+
+    verifyNoInteractions(videoAppointmentRepository)
+    verifyNoInteractions(bookingFacade)
+  }
+
+  private fun cancellationEvent(
+    prisonCode: String,
+    prisonerNumber: String,
+    start: LocalDateTime,
+    eventType: String = "VLB",
+  ) = PrisonerVideoAppointmentCancelledEvent(
+    personReference = PersonReference(identifiers = listOf(Identifier("NOMS", prisonerNumber))),
+    additionalInformation = AppointmentScheduleInformation(
+      scheduleEventId = 1,
+      scheduledStartTime = start,
+      scheduledEndTime = null,
+      scheduleEventSubType = eventType,
+      scheduleEventStatus = "",
+      recordDeleted = true,
+      agencyLocationId = prisonCode,
+    ),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerVideoAppointmentCancelledEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerVideoAppointmentCancelledEventHandlerTest.kt
@@ -7,33 +7,49 @@ import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.SERVICE_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.today
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.videoAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withMainCourtPrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withProbationPrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingFacade
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingHistoryService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.AppointmentScheduleInformation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.Identifier
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PrisonerVideoAppointmentCancelledEvent
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.util.*
 
 class PrisonerVideoAppointmentCancelledEventHandlerTest {
 
   private val videoAppointmentRepository: VideoAppointmentRepository = mock()
   private val bookingFacade: BookingFacade = mock()
-  private val handler = PrisonerVideoAppointmentCancelledEventHandler(videoAppointmentRepository, bookingFacade)
+  private val videoBookingRepository: VideoBookingRepository = mock()
+  private val prisonAppointmentRepository: PrisonAppointmentRepository = mock()
+  private val bookingHistoryService: BookingHistoryService = mock()
+  private val handler = PrisonerVideoAppointmentCancelledEventHandler(
+    videoAppointmentRepository,
+    bookingFacade,
+    videoBookingRepository,
+    prisonAppointmentRepository,
+    bookingHistoryService,
+  )
 
   @Test
-  fun `should attempt to cancel a court booking when main appointment`() {
+  fun `should attempt to cancel a court booking when main appointment removed in NOMIS`() {
     val courtBooking = courtBooking().withMainCourtPrisonAppointment(prisonerNumber = "ABC345", prisonCode = WANDSWORTH)
     val courtAppointment = videoAppointment(courtBooking, courtBooking.appointments().single())
 
@@ -66,7 +82,115 @@ class PrisonerVideoAppointmentCancelledEventHandlerTest {
   }
 
   @Test
-  fun `should attempt to cancel a probation booking`() {
+  fun `should attempt to remove a court booking appointment when pre-appointment removed in NOMIS`() {
+    val courtBooking = courtBooking()
+
+    val courtAppointment = videoAppointment(
+      courtBooking,
+      PrisonAppointment.newAppointment(
+        videoBooking = courtBooking,
+        prison = prison(),
+        prisonerNumber = "ABC345",
+        appointmentType = "VLB_COURT_PRE",
+        appointmentDate = today(),
+        startTime = LocalTime.MIDNIGHT,
+        endTime = LocalTime.MIDNIGHT,
+        locationId = UUID.randomUUID(),
+      ),
+    )
+
+    whenever(
+      videoAppointmentRepository.findActiveVideoAppointments(
+        prisonCode = WANDSWORTH,
+        prisonerNumber = "ABC345",
+        appointmentDate = today(),
+        startTime = LocalTime.MIDNIGHT,
+      ),
+    ) doReturn listOf(courtAppointment)
+
+    whenever(videoBookingRepository.findById(courtBooking.videoBookingId)) doReturn Optional.of(courtBooking)
+
+    handler.handle(
+      cancellationEvent(
+        prisonCode = WANDSWORTH,
+        prisonerNumber = "ABC345",
+        start = today().atStartOfDay(),
+      ),
+    )
+
+    inOrder(videoAppointmentRepository, prisonAppointmentRepository, videoBookingRepository, bookingHistoryService) {
+      verify(videoAppointmentRepository).findActiveVideoAppointments(
+        WANDSWORTH,
+        "ABC345",
+        appointmentDate = today(),
+        startTime = LocalTime.MIDNIGHT,
+      )
+
+      verify(prisonAppointmentRepository).deleteById(courtAppointment.prisonAppointmentId)
+      verify(prisonAppointmentRepository).flush()
+      verify(videoBookingRepository).findById(courtBooking.videoBookingId)
+      verify(bookingHistoryService).createBookingHistory(HistoryType.AMEND, courtBooking)
+    }
+
+    verifyNoInteractions(bookingFacade)
+  }
+
+  @Test
+  fun `should attempt to remove a court booking appointment when post-appointment removed in NOMIS`() {
+    val courtBooking = courtBooking()
+
+    val courtAppointment = videoAppointment(
+      courtBooking,
+      PrisonAppointment.newAppointment(
+        videoBooking = courtBooking,
+        prison = prison(),
+        prisonerNumber = "ABC345",
+        appointmentType = "VLB_COURT_POST",
+        appointmentDate = today(),
+        startTime = LocalTime.MIDNIGHT,
+        endTime = LocalTime.MIDNIGHT,
+        locationId = UUID.randomUUID(),
+      ),
+    )
+
+    whenever(
+      videoAppointmentRepository.findActiveVideoAppointments(
+        prisonCode = WANDSWORTH,
+        prisonerNumber = "ABC345",
+        appointmentDate = today(),
+        startTime = LocalTime.MIDNIGHT,
+      ),
+    ) doReturn listOf(courtAppointment)
+
+    whenever(videoBookingRepository.findById(courtBooking.videoBookingId)) doReturn Optional.of(courtBooking)
+
+    handler.handle(
+      cancellationEvent(
+        prisonCode = WANDSWORTH,
+        prisonerNumber = "ABC345",
+        start = today().atStartOfDay(),
+      ),
+    )
+
+    inOrder(videoAppointmentRepository, prisonAppointmentRepository, videoBookingRepository, bookingHistoryService) {
+      verify(videoAppointmentRepository).findActiveVideoAppointments(
+        WANDSWORTH,
+        "ABC345",
+        appointmentDate = today(),
+        startTime = LocalTime.MIDNIGHT,
+      )
+
+      verify(prisonAppointmentRepository).deleteById(courtAppointment.prisonAppointmentId)
+      verify(prisonAppointmentRepository).flush()
+      verify(videoBookingRepository).findById(courtBooking.videoBookingId)
+      verify(bookingHistoryService).createBookingHistory(HistoryType.AMEND, courtBooking)
+    }
+
+    verifyNoInteractions(bookingFacade)
+  }
+
+  @Test
+  fun `should attempt to cancel a probation booking removed in NOMIS`() {
     val probationBooking = probationBooking().withProbationPrisonAppointment(prisonerNumber = "DEF345", prisonCode = PENTONVILLE)
     val probationAppointment = videoAppointment(probationBooking, probationBooking.appointments().single())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingCancelledTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingCancelledTelemetryEventTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.serviceUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation2
@@ -101,6 +102,40 @@ class CourtBookingCancelledTelemetryEventTest {
       properties() containsEntriesExactlyInAnyOrder mapOf(
         "video_booking_id" to "0",
         "cancelled_by" to "prison",
+        "court_code" to DERBY_JUSTICE_CENTRE,
+        "hearing_type" to "APPEAL",
+        "prison_code" to WANDSWORTH,
+        "pre_location_id" to wandsworthLocation.id.toString(),
+        "pre_start" to tomorrow().atTime(LocalTime.of(9, 0)).toIsoDateTime(),
+        "pre_end" to tomorrow().atTime(LocalTime.of(10, 0)).toIsoDateTime(),
+        "main_location_id" to wandsworthLocation2.id.toString(),
+        "main_start" to tomorrow().atTime(LocalTime.of(10, 0)).toIsoDateTime(),
+        "main_end" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
+        "post_location_id" to wandsworthLocation3.id.toString(),
+        "post_start" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
+        "post_end" to tomorrow().atTime(LocalTime.of(12, 0)).toIsoDateTime(),
+        "cvp_link" to "true",
+      )
+
+      metrics() containsEntriesExactlyInAnyOrder mapOf(
+        "hoursBeforeStartTime" to hoursBetween(
+          booking.amendedTime!!,
+          tomorrow().atTime(LocalTime.of(10, 0)),
+        ).toDouble(),
+      )
+    }
+  }
+
+  @Test
+  fun `should raise a court booking cancelled telemetry event cancelled by service`() {
+    booking.cancel(serviceUser())
+
+    with(CourtBookingCancelledTelemetryEvent.user(booking, serviceUser())) {
+      eventType isEqualTo "BVLS-court-booking-cancelled"
+
+      properties() containsEntriesExactlyInAnyOrder mapOf(
+        "video_booking_id" to "0",
+        "cancelled_by" to "service",
         "court_code" to DERBY_JUSTICE_CENTRE,
         "hearing_type" to "APPEAL",
         "prison_code" to WANDSWORTH,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCancelledTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCancelledTelemetryEventTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.serviceUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -77,6 +78,34 @@ class ProbationBookingCancelledTelemetryEventTest {
       properties() containsEntriesExactlyInAnyOrder mapOf(
         "video_booking_id" to "0",
         "cancelled_by" to "prison",
+        "team_code" to BLACKPOOL_MC_PPOC,
+        "meeting_type" to "PSR",
+        "prison_code" to BIRMINGHAM,
+        "location_id" to birminghamLocation.id.toString(),
+        "start" to tomorrow().atTime(LocalTime.of(14, 0)).toIsoDateTime(),
+        "end" to tomorrow().atTime(LocalTime.of(15, 0)).toIsoDateTime(),
+        "cvp_link" to "true",
+      )
+
+      metrics() containsEntriesExactlyInAnyOrder mapOf(
+        "hoursBeforeStartTime" to hoursBetween(
+          booking.amendedTime!!,
+          tomorrow().atTime(LocalTime.of(14, 0)),
+        ).toDouble(),
+      )
+    }
+  }
+
+  @Test
+  fun `should raise a probation booking cancelled telemetry event cancelled by service`() {
+    booking.cancel(serviceUser())
+
+    with(ProbationBookingCancelledTelemetryEvent.user(booking, serviceUser())) {
+      eventType isEqualTo "BVLS-probation-booking-cancelled"
+
+      properties() containsEntriesExactlyInAnyOrder mapOf(
+        "video_booking_id" to "0",
+        "cancelled_by" to "service",
         "team_code" to BLACKPOOL_MC_PPOC,
         "meeting_type" to "PSR",
         "prison_code" to BIRMINGHAM,

--- a/src/test/resources/integration-test-data/seed-historic-booking.sql
+++ b/src/test/resources/integration-test-data/seed-historic-booking.sql
@@ -1,5 +1,5 @@
 insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
-values (-1, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
+values (-3, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
 
 insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
-values (-1, 1, 'ABCDEF', 'VLB_COURT_MAIN', 'comments about the hearing', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, current_date - 1, '12:00', '13:00');
+values (-3, 1, 'ABCDEF', 'VLB_COURT_MAIN', 'comments about the hearing', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, current_date - 1, '12:00', '13:00');

--- a/src/test/resources/integration-test-data/seed-prisoner-merge.sql
+++ b/src/test/resources/integration-test-data/seed-prisoner-merge.sql
@@ -1,23 +1,23 @@
 insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
-values (-1, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
+values (-100, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
 
 insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
-values (-1, 1, 'OLD123', 'VLB_COURT_MAIN', 'comments about the hearing', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, current_date, '12:00', '13:00');
+values (-100, 1, 'OLD123', 'VLB_COURT_MAIN', 'comments about the hearing', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, current_date, '12:00', '13:00');
 
 insert into booking_history (booking_history_id, video_booking_id, history_type, court_id, hearing_type, comments, created_by, created_time)
-values (-1, -1, 'CREATE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
+values (-1, -100, 'CREATE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
 
 insert into booking_history_appointment(booking_history_appointment_id, booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)
 values (-1, -1, 'PVI', 'OLD123', current_date, 'VLB_COURT_MAIN', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '12:00', '13:00');
 
 insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
-values (-2, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
+values (-200, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
 
 insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
-values (-2, 2, 'OLD123', 'VLB_COURT_MAIN', 'comments about the hearing', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, current_date, '09:00', '10:00');
+values (-200, 2, 'OLD123', 'VLB_COURT_MAIN', 'comments about the hearing', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, current_date, '09:00', '10:00');
 
 insert into booking_history (booking_history_id, video_booking_id, history_type, court_id, hearing_type, comments, created_by, created_time)
-values (-2, -2, 'CREATE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
+values (-2, -200, 'CREATE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
 
 insert into booking_history_appointment(booking_history_appointment_id, booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)
 values (-2, -2, 'PVI', 'OLD123', current_date, 'VLB_COURT_MAIN', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '09:00', '10:00');


### PR DESCRIPTION
There is a little bit of change to some of the method signatures for cancellation, we can now be more specific with the user type.  This will help prevent accidental calling of these methods with the wrong user type.