### PR TITLE
BAVL-405 increase the async timeout to one minute for CSV downloads.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,6 +89,10 @@ spring:
         max-size: 4
         queue-capacity: 50
 
+  mvc:
+    async:
+      request-timeout: 60000 # one minute request timeout
+
 server:
   port: 8080
   servlet:


### PR DESCRIPTION
The CSV download was failing to download a years worth of data on migrated bookings in preprod.

Increasing the async timeout to see if this helps alleviate the issue.  Also added some progress logging for downloads.