### PR TITLE
BAVL-390 re-enable processing of prisoner appointment cancelled event but now ignore if appointments serivce is rolled out for the prison raising the event.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments
 
 import org.slf4j.LoggerFactory
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
@@ -13,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeriesCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.RolloutPrisonPlan
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toHourMinuteStyle
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.CacheConfiguration
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -29,6 +31,7 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
+  @Cacheable(CacheConfiguration.ROLLED_OUT_PRISONS_CACHE_NAME)
   fun isAppointmentsRolledOutAt(prisonCode: String) =
     activitiesAppointmentsApiWebClient
       .get()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/CacheConfiguration.kt
@@ -23,6 +23,7 @@ class CacheConfiguration {
     const val NON_RESIDENTIAL_LOCATIONS_CACHE_NAME: String = "non_residential_locations"
     const val MIGRATION_LOCATIONS_CACHE_NAME: String = "locations_by_internal_id"
     const val MIGRATION_PRISONERS_CACHE_NAME: String = "prisoners_by_booking_id"
+    const val ROLLED_OUT_PRISONS_CACHE_NAME = "rolled_out_prisons"
   }
 
   @Bean
@@ -32,6 +33,7 @@ class CacheConfiguration {
       NON_RESIDENTIAL_LOCATIONS_CACHE_NAME,
       MIGRATION_LOCATIONS_CACHE_NAME,
       MIGRATION_PRISONERS_CACHE_NAME,
+      ROLLED_OUT_PRISONS_CACHE_NAME,
     )
 
   @CacheEvict(value = [VIDEO_LINK_LOCATIONS_CACHE_NAME])
@@ -58,5 +60,11 @@ class CacheConfiguration {
   @Scheduled(fixedDelay = 3, timeUnit = TimeUnit.HOURS)
   fun cacheEvictPrisonersByBookingId() {
     log.info("Evicting cache: $MIGRATION_PRISONERS_CACHE_NAME after 3 hours")
+  }
+
+  @CacheEvict(value = [ROLLED_OUT_PRISONS_CACHE_NAME])
+  @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.DAYS)
+  fun cacheEvictRolledOutPrisons() {
+    log.info("Evicting cache: $ROLLED_OUT_PRISONS_CACHE_NAME after 1 day")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsService.kt
@@ -37,12 +37,7 @@ class InboundEventsService(
       is VideoBookingCancelledEvent -> videoBookingCancelledEventHandler.handle(event)
       is VideoBookingCreatedEvent -> videoBookingCreatedEventHandler.handle(event)
       is MigrateVideoBookingEvent -> migrateVideoBookingEventHandler.handle(event)
-      is PrisonerVideoAppointmentCancelledEvent -> {
-        // Ignoring for now due to an issue with processing of the event.
-        if (event.isVideoLinkBooking()) {
-          log.info("Ignoring event ${event.additionalInformation}")
-        }
-      }
+      is PrisonerVideoAppointmentCancelledEvent -> prisonerVideoAppointmentCancelledEventHandler.handle(event)
       else -> log.warn("Unsupported domain event ${event.javaClass.name}")
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/InboundEventsIntegrationTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.resource
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.mockito.kotlin.argumentCaptor
@@ -271,7 +270,6 @@ class InboundEventsIntegrationTest : SqsIntegrationTestBase() {
     }
   }
 
-  @Disabled
   @Test
   fun `should cancel a video court booking on receipt of a prisoner appointment cancelled event`() {
     videoBookingRepository.findAll() hasSize 0
@@ -326,7 +324,6 @@ class InboundEventsIntegrationTest : SqsIntegrationTestBase() {
     notifications.isPresent("p@p.com", CancelledCourtBookingPrisonCourtEmail::class, persistedBooking)
   }
 
-  @Disabled
   @Test
   fun `should cancel a video probation booking on receipt of a prisoner appointment cancelled event`() {
     videoBookingRepository.findAll() hasSize 0

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsServiceTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -106,7 +105,6 @@ class InboundEventsServiceTest {
     verify(migrateVideoBookingEventHandler).handle(event)
   }
 
-  @Disabled
   @Test
   fun `should call prison video appointment cancelled handler when appointment cancelled event`() {
     val event = mock<PrisonerVideoAppointmentCancelledEvent>()


### PR DESCRIPTION
This change undoes this PR [here](https://github.com/ministryofjustice/hmpps-book-a-video-link-api/pull/266) and adds some extra logic/processing.

If the event to be processed is at a prison where A&A is rolled out the event will be completely ignored.  This avoids any conflicts with the event being raised by the A&A service.  If an appointment related to a booking is changed or cancelled in A&A then we will know anyway as it talks directly to our service.

Also caching calls to the A&A endpoint for rollout check as things don't change much here.
