### PR TITLE
BAVL-412 and postgres test container so can run tests without having to run docker compose file.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("org.springframework.security:spring-security-test")
   testImplementation("org.testcontainers:localstack:1.20.3")
+  testImplementation("org.testcontainers:postgresql:1.20.3")
   testImplementation("org.wiremock:wiremock-standalone:3.9.2")
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
@@ -8,12 +8,15 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDO
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.manageusers.model.UserDetailsDto.AuthSource
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.container.PostgresContainer
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.ActivitiesAppointmentsApiExtension
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.LocationsInsidePrisonApiExtension
@@ -122,4 +125,18 @@ abstract class IntegrationTestBase {
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
       .expectBody(Long::class.java)
       .returnResult().responseBody!!
+
+  companion object {
+    private val pgContainer = PostgresContainer.instance
+
+    @JvmStatic
+    @DynamicPropertySource
+    fun properties(registry: DynamicPropertyRegistry) {
+      pgContainer?.run {
+        registry.add("spring.datasource.url", pgContainer::getJdbcUrl)
+        registry.add("spring.datasource.username", pgContainer::getUsername)
+        registry.add("spring.datasource.password", pgContainer::getPassword)
+      }
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/config/FeatureSwitchesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/config/FeatureSwitchesTest.kt
@@ -1,21 +1,20 @@
-package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.config
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Feature
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.InboundEventsListener
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
-@ActiveProfiles("test")
-class FeatureSwitchesTest {
+class FeatureSwitchesTest : IntegrationTestBase() {
 
   // Beans are mocked out so as not to interfere with the running of the tests. We do not want/need them on the context.
   @MockBean

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/container/PostgresContainer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/container/PostgresContainer.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.container
+
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.containers.wait.strategy.Wait
+import java.io.IOException
+import java.net.ServerSocket
+
+object PostgresContainer {
+  private val log = LoggerFactory.getLogger(this::class.java)
+  val instance: PostgreSQLContainer<Nothing>? by lazy { startPostgresqlIfNotRunning() }
+  private fun startPostgresqlIfNotRunning(): PostgreSQLContainer<Nothing>? {
+    if (isPostgresRunning()) {
+      return null
+    }
+
+    val logConsumer = Slf4jLogConsumer(log).withPrefix("postgresql")
+
+    return PostgreSQLContainer<Nothing>("postgres:16").apply {
+      withEnv("HOSTNAME_EXTERNAL", "localhost")
+      withDatabaseName("book-a-video-link-test-db")
+      withUsername("book-a-video-link")
+      withPassword("book-a-video-link")
+      setWaitStrategy(Wait.forListeningPort())
+      withReuse(false)
+      start()
+      followOutput(logConsumer)
+    }
+  }
+
+  private fun isPostgresRunning(): Boolean =
+    try {
+      val serverSocket = ServerSocket(5432)
+      serverSocket.localPort == 0
+    } catch (e: IOException) {
+      true
+    }
+}


### PR DESCRIPTION
If a container is already running then it will use it, if not a test container will be started.

This was bugging me a little, if I ran the tests in Intellij I had to make sure was running Postgres container manually.