### PR TITLE
BAVL-413 alter approach checking for published messages so can run integration test in the CI pipeline.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/SqsIntegrationTestBase.kt
@@ -1,26 +1,18 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.awaitility.Awaitility
 import org.awaitility.kotlin.await
-import org.awaitility.kotlin.matches
-import org.awaitility.kotlin.untilCallTo
-import org.junit.jupiter.api.BeforeEach
+import org.awaitility.kotlin.untilAsserted
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
-import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
-import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.container.LocalStackContainer
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.container.LocalStackContainer.setLocalStackProperties
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.DomainEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.EventType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.Message
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.MessageAttributes
-import uk.gov.justice.hmpps.sqs.HmppsQueue
-import uk.gov.justice.hmpps.sqs.HmppsQueueService
-import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
@@ -29,32 +21,6 @@ abstract class SqsIntegrationTestBase : IntegrationTestBase() {
 
   @Autowired
   protected lateinit var mapper: ObjectMapper
-
-  @Autowired
-  protected lateinit var hmppsQueueService: HmppsQueueService
-
-  protected val eventsQueue by lazy { hmppsQueueService.findByQueueId("bvls") as HmppsQueue }
-
-  protected val eventsClient by lazy { eventsQueue.sqsClient }
-
-  @BeforeEach
-  fun `clear queue`() {
-    Awaitility.setDefaultPollDelay(1, TimeUnit.MILLISECONDS)
-    Awaitility.setDefaultPollInterval(10, TimeUnit.MILLISECONDS)
-    eventsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(eventsQueue.queueUrl).build()).get()
-    await untilCallTo { countAllMessagesOnQueue() } matches { it == 0 }
-    Awaitility.setDefaultPollInterval(50, TimeUnit.MILLISECONDS)
-  }
-
-  protected fun waitForMessagesOnQueue(numberOfMessages: Int) {
-    await untilCallTo { countAllMessagesOnQueue().also { println("number messages on queue - $it") } } matches { it == numberOfMessages }
-  }
-
-  protected fun countAllMessagesOnQueue(): Int = eventsClient.countAllMessagesOnQueue(eventsQueue.queueUrl).get()
-
-  protected fun receiveEvent(message: DomainEvent<*>) {
-    eventsClient.sendMessage(SendMessageRequest.builder().queueUrl(eventsQueue.queueUrl).messageBody(raw(message)).build()).get()
-  }
 
   protected fun raw(event: DomainEvent<*>): String =
     mapper.writeValueAsString(
@@ -65,6 +31,14 @@ abstract class SqsIntegrationTestBase : IntegrationTestBase() {
         MessageAttributes(EventType(Type = "String", Value = event.eventType)),
       ),
     )
+
+  protected fun waitUntil(fn: () -> Unit) {
+    // Default wait is 10 seconds, so dropping down to 5.
+    await.atMost(5, TimeUnit.SECONDS) untilAsserted {
+      fn()
+    }
+  }
+
   companion object {
     private val localStackContainer = LocalStackContainer.instance
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/container/LocalStackContainer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/container/LocalStackContainer.kt
@@ -36,8 +36,7 @@ object LocalStackContainer {
 
     return LocalStackContainer(DockerImageName.parse("localstack/localstack").withTag("3"))
       .apply {
-        withServices(SNS)
-        withServices(SQS)
+        withServices(SNS, SQS)
         withEnv("HOSTNAME_EXTERNAL", "localhost")
         withEnv("DEFAULT_REGION", "eu-west-2")
         waitingFor(Wait.forLogMessage(".*Ready.*", 1))

--- a/src/test/resources/application-test-localstack.yml
+++ b/src/test/resources/application-test-localstack.yml
@@ -3,9 +3,6 @@ spring:
   main:
     allow-bean-definition-overriding: true
 
-  jpa:
-    show-sql: true
-
   datasource:
     url: 'jdbc:postgresql://localhost:5432/book-a-video-link-test-db'
     username: book-a-video-link


### PR DESCRIPTION
Instead of checking the actual queues for published messages we are waiting and checking the publisher is called instead.

This seems to be far more reliable/stable and runs every time on my local machine.