### PR TITLE
BAVL-463: Fix some data where Gartree bookings are not synced with nomis

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
       ddl-auto: none
 
   flyway:
-    locations: classpath:/migrations/common
+    locations: classpath:/migrations/common,classpath:/migrations/prod
 
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"

--- a/src/main/resources/migrations/prod/V2024.12.02__uncancel-hmp-gartree-bookings.sql
+++ b/src/main/resources/migrations/prod/V2024.12.02__uncancel-hmp-gartree-bookings.sql
@@ -1,0 +1,17 @@
+-- Uncancel some bookings at HMP Gartree which were cancelled by mistake during a migration of the activities and appointments service
+-- Stems from the issue in A&A resolved here https://github.com/ministryofjustice/hmpps-activities-management-api/blob/main/src/main/resources/migrations/prod/V2024.10.31__gartree_appts_undelete.sql
+WITH
+    updated_booking AS (
+        UPDATE video_booking
+        SET status_code = 'ACTIVE'
+        WHERE video_booking_id IN (164324, 164422)
+        RETURNING video_booking_id
+    ),
+    deleted_booking_history AS (
+        DELETE FROM booking_history
+        WHERE video_booking_id IN (SELECT video_booking_id FROM updated_booking)
+        AND history_type = 'CANCEL'
+        RETURNING booking_history_id
+    )
+DELETE FROM booking_history_appointment
+WHERE booking_history_id IN (SELECT booking_history_id FROM deleted_booking_history);


### PR DESCRIPTION
Before we synced data from Whereabouts, the A&A team did a data fix where they accidentally cancelled some appointments at Gartree, and they reverted that delete [here](https://github.com/ministryofjustice/hmpps-activities-management-api/blob/main/src/main/resources/migrations/prod/V2024.10.31__gartree_appts_undelete.sql)

The trouble is, they did not also fix the data in Whereabouts, so we have migrated across the bad data. We are fixing the bad data here post-migration