### PR TITLE
BAVL-501 adding a bit more logic around what days reminder emails are sent and how far in the future to look.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -32,4 +32,4 @@ generic-prometheus-alerts:
     - "hmpps-book-a-video-link-dev-hmpps_book_a_video_link_domain_dlq"
 
 cron:
-  courtHearingLinkReminderJob: "0 15 * * 1-5"
+  courtHearingLinkReminderJob: "0 11 * * 1-5"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/TimeSourceConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/TimeSourceConfiguration.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Configuration
+class TimeSourceConfiguration {
+  @Bean
+  fun timeSource() = TimeSource { LocalDateTime.now(Clock.systemDefaultZone()) }
+}
+
+/**
+ * To be used for providing dates and times in the application. Enables control of time in the code (and unit tests).
+ */
+fun interface TimeSource {
+  fun now(): LocalDateTime
+
+  fun today(): LocalDate = now().toLocalDate()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
@@ -91,7 +91,7 @@ class BookingFacade(
     sendTelemetry(BookingAction.CANCEL, booking, cancelledBy)
   }
 
-  fun courtHearingLinkReminder(videoBooking: VideoBooking, user: User) {
+  fun courtHearingLinkReminder(videoBooking: VideoBooking, user: ServiceUser) {
     require(videoBooking.isCourtBooking()) { "Video booking with id ${videoBooking.videoBookingId} is not a court booking" }
     require(videoBooking.court!!.enabled) { "Video booking with id ${videoBooking.videoBookingId} is not with an enabled court" }
     require(videoBooking.appointments().any { it.appointmentDate > LocalDate.now() }) { "Video booking with id ${videoBooking.videoBookingId} has already taken place" }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/CourtHearingLinkReminderJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/CourtHearingLinkReminderJob.kt
@@ -1,28 +1,48 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.jobs
 
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingFacade
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserService.Companion.getServiceAsUser
-import java.time.LocalDate
+import java.time.DayOfWeek
 
 /**
- * This job will email the court for any court booking taking place tomorrow, which still does not have a court hearing link
+ * This job is responsible for emailing the courts for future court bookings missing video links.
+ *
+ * For Monday to Thursday and Sunday, emails will be sent for bookings missing links on the following day.
+ *
+ * For Friday, emails will be sent for the bookings missing links on the following Monday.
+ *
+ * No emails are sent on Saturday.
  */
 @Component
 class CourtHearingLinkReminderJob(
   private val prisonAppointmentRepository: PrisonAppointmentRepository,
   private val bookingFacade: BookingFacade,
+  private val timeSource: TimeSource,
 ) : JobDefinition(
   jobType = JobType.COURT_HEARING_LINK_REMINDER,
   block = {
-    // Migrated bookings will not have the court hearing link field populated, and most probably will have the hearing link provided in the comments
-    // Disabling this email for migrated bookings. This can be removed a few days after go-live once the majority of future bookings have taken place.
-    val tomorrow = LocalDate.now().plusDays(1)
-    prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(tomorrow)
-      .map { it.videoBooking }
-      .distinct()
-      .filter { it.isCourtBooking() && !it.isMigrated() && it.videoUrl == null && it.court!!.enabled && it.prisonIsEnabledForSelfService() }
-      .forEach { bookingFacade.courtHearingLinkReminder(it, getServiceAsUser()) }
+    val today = timeSource.today()
+
+    daysToRunOn[today.dayOfWeek]?.let { offset ->
+      prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(today.plusDays(offset))
+        .map { it.videoBooking }
+        .distinct()
+        // Migrated bookings will not have the court hearing link field populated, and most probably will have the hearing link provided in the comments
+        // Disabling this email for migrated bookings. This can be removed a few days after go-live once the majority of future bookings have taken place.
+        .filter { it.isCourtBooking() && !it.isMigrated() && it.videoUrl == null && it.court!!.enabled && it.prisonIsEnabledForSelfService() }
+        .forEach { bookingFacade.courtHearingLinkReminder(it, getServiceAsUser()) }
+    }
   },
+)
+
+private val daysToRunOn = mapOf(
+  DayOfWeek.MONDAY to 1L,
+  DayOfWeek.TUESDAY to 1L,
+  DayOfWeek.WEDNESDAY to 1L,
+  DayOfWeek.THURSDAY to 1L,
+  DayOfWeek.FRIDAY to 3L,
+  DayOfWeek.SUNDAY to 1L,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/JobRunner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/JobRunner.kt
@@ -16,7 +16,7 @@ class JobRunner(private val telemetryService: TelemetryService) {
   private fun run(jobDefinition: JobDefinition) {
     var timeElapsed = 0L
 
-    runCatching { timeElapsed = measureTimeMillis { jobDefinition.block() } }
+    runCatching { timeElapsed = measureTimeMillis { jobDefinition.runJob() } }
       .onSuccess { telemetryService.track(JobSuccessStandardTelemetryEvent(jobType = jobDefinition.jobType, timeElapsed = timeElapsed)) }
       .onFailure { exception ->
         run {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/Jobs.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/Jobs.kt
@@ -4,4 +4,8 @@ enum class JobType(val resultMessage: String) {
   COURT_HEARING_LINK_REMINDER("Court hearing link reminders job triggered"),
 }
 
-abstract class JobDefinition(val jobType: JobType, val block: () -> Unit)
+abstract class JobDefinition(val jobType: JobType, private val block: () -> Unit) {
+  fun runJob() {
+    block()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/CourtHearingLinkReminderJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/CourtHearingLinkReminderJobTest.kt
@@ -6,64 +6,108 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withMainCourtPrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withProbationPrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingFacade
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserService.Companion.getServiceAsUser
+import java.time.DayOfWeek
+import java.time.LocalDate
 
 class CourtHearingLinkReminderJobTest {
 
+  companion object {
+    val MONDAY = LocalDate.of(2024, 12, 2).also { require(it.dayOfWeek == DayOfWeek.MONDAY) { "Not Monday" } }
+    val TUESDAY = MONDAY.plusDays(1)
+    val WEDNESDAY = TUESDAY.plusDays(1)
+    val THURSDAY = WEDNESDAY.plusDays(1)
+    val FRIDAY = THURSDAY.plusDays(1)
+    val SATURDAY = FRIDAY.plusDays(1)
+    val SUNDAY = SATURDAY.plusDays(1)
+  }
+
+  private val courtBookingWithoutUrl = courtBooking().apply { videoUrl = null }.withMainCourtPrisonAppointment()
   private val prisonAppointmentRepository: PrisonAppointmentRepository = mock()
   private val bookingFacade: BookingFacade = mock()
-  private val courtHearingLinkReminderJob: CourtHearingLinkReminderJob = CourtHearingLinkReminderJob(prisonAppointmentRepository, bookingFacade)
 
   @Test
-  fun `should call court hearing link reminder for valid court bookings`() {
-    val booking = courtBooking().apply { videoUrl = null }.withMainCourtPrisonAppointment()
+  fun `should call court hearing link reminder on Mondays for valid court bookings`() {
+    whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(TUESDAY)) doReturn courtBookingWithoutUrl.appointments()
+    runJobOn(MONDAY)
+    verify(bookingFacade).courtHearingLinkReminder(courtBooking(), getServiceAsUser())
+  }
 
-    whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(tomorrow())) doReturn booking.appointments()
+  @Test
+  fun `should call court hearing link reminder on Tuesday for valid court bookings`() {
+    whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(WEDNESDAY)) doReturn courtBookingWithoutUrl.appointments()
+    runJobOn(TUESDAY)
+    verify(bookingFacade).courtHearingLinkReminder(courtBooking(), getServiceAsUser())
+  }
 
-    courtHearingLinkReminderJob.block()
+  @Test
+  fun `should call court hearing link reminder on Wednesday for valid court bookings`() {
+    whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(THURSDAY)) doReturn courtBookingWithoutUrl.appointments()
+    runJobOn(WEDNESDAY)
+    verify(bookingFacade).courtHearingLinkReminder(courtBooking(), getServiceAsUser())
+  }
 
+  @Test
+  fun `should call court hearing link reminder on Thursday for valid court bookings`() {
+    whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(FRIDAY)) doReturn courtBookingWithoutUrl.appointments()
+    runJobOn(THURSDAY)
+    verify(bookingFacade).courtHearingLinkReminder(courtBooking(), getServiceAsUser())
+  }
+
+  @Test
+  fun `should call court hearing link reminder on Friday for valid court bookings`() {
+    whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(FRIDAY.plusDays(3))) doReturn courtBookingWithoutUrl.appointments()
+    runJobOn(FRIDAY)
+    verify(bookingFacade).courtHearingLinkReminder(courtBooking(), getServiceAsUser())
+  }
+
+  @Test
+  fun `should not call court hearing link reminder on Saturdays`() {
+    runJobOn(SATURDAY)
+    verifyNoInteractions(bookingFacade)
+  }
+
+  @Test
+  fun `should call court hearing link reminder on Sunday for valid court bookings`() {
+    whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(SUNDAY.plusDays(1))) doReturn courtBookingWithoutUrl.appointments()
+    runJobOn(SUNDAY)
     verify(bookingFacade).courtHearingLinkReminder(courtBooking(), getServiceAsUser())
   }
 
   @Test
   fun `should not call court hearing link reminder for bookings with video URL`() {
     val booking = courtBooking().withMainCourtPrisonAppointment()
-
-    whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(tomorrow())) doReturn booking.appointments()
-
-    courtHearingLinkReminderJob.block()
-
+    whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(TUESDAY)) doReturn booking.appointments()
+    runJobOn(MONDAY)
     verify(bookingFacade, never()).courtHearingLinkReminder(any(), any())
   }
 
   @Test
   fun `should not call court hearing link reminder for non-court bookings`() {
     val booking = probationBooking().withProbationPrisonAppointment()
-
-    whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(tomorrow())) doReturn booking.appointments()
-
-    courtHearingLinkReminderJob.block()
-
+    whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(TUESDAY)) doReturn booking.appointments()
+    runJobOn(MONDAY)
     verify(bookingFacade, never()).courtHearingLinkReminder(any(), any())
   }
 
   @Test
   fun `should not call court hearing link reminder if court is disabled`() {
     val booking = courtBooking(court = court(enabled = false)).withMainCourtPrisonAppointment()
-
-    whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(tomorrow())) doReturn booking.appointments()
-
-    courtHearingLinkReminderJob.block()
-
+    whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(TUESDAY)) doReturn booking.appointments()
+    runJobOn(MONDAY)
     verify(bookingFacade, never()).courtHearingLinkReminder(any(), any())
+  }
+
+  private fun runJobOn(date: LocalDate) {
+    CourtHearingLinkReminderJob(prisonAppointmentRepository, bookingFacade) { date.atStartOfDay() }.runJob()
   }
 }


### PR DESCRIPTION
Reminder emails sent Monday to Thurs and Sunday look a day ahead.
Reminder emails sent Friday look at the following Monday.
Reminder emails are not sent on Saturday.