### PR TITLE
BAVL-522 preparation PR for the clashing appointments fix. Pulling out common interface in availability check to combine data from multiple sources.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoAppointment.kt
@@ -35,11 +35,19 @@ data class VideoAppointment(
 
   val appointmentType: String,
 
-  val prisonLocationId: UUID,
+  override val prisonLocationId: UUID,
 
   val appointmentDate: LocalDate,
 
-  val startTime: LocalTime,
+  override val startTime: LocalTime,
 
-  val endTime: LocalTime,
-)
+  override val endTime: LocalTime,
+) : AppointmentSlot
+
+interface AppointmentSlot {
+  val prisonLocationId: UUID
+
+  val startTime: LocalTime
+
+  val endTime: LocalTime
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityFinderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityFinderService.kt
@@ -3,13 +3,13 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.AppointmentSlot
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AvailabilityRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Interval
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AvailabilityResponse
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingOption
 import java.time.LocalTime
-import java.util.TreeMap
+import java.util.*
 
 @Service
 class AvailabilityFinderService(
@@ -19,7 +19,7 @@ class AvailabilityFinderService(
   private val maxAlternatives: Int = 3,
 ) {
 
-  fun getOptions(request: AvailabilityRequest, appointments: List<VideoAppointment>, locations: List<Location>): AvailabilityResponse {
+  fun getOptions(request: AvailabilityRequest, appointments: List<AppointmentSlot>, locations: List<Location>): AvailabilityResponse {
     // Create a Map of <PrisonLocKey, Timeline> from the existing appointments - so we can check and find gaps
     val timelinesByLocation = timelinesByLocationKey(appointments, locations)
 
@@ -49,14 +49,14 @@ class AvailabilityFinderService(
         .toLocationsAndIntervals()
         .all { timelinesByLocationId[it.prisonLocKey]?.isFreeForInterval(it.interval) ?: true }
 
-    fun timelinesByLocationKey(appointments: List<VideoAppointment>, locations: List<Location>): Map<String, Timeline> =
-      appointments
+    fun timelinesByLocationKey(slots: List<AppointmentSlot>, locations: List<Location>): Map<String, Timeline> =
+      slots
         .groupBy { a -> locations.single { it.id == a.prisonLocationId }.key }
         .mapValues { (_, appointments) -> appointments.flatMap(::toEvents) }
         .mapValues { Timeline(it.value) }
 
-    private fun toEvents(appointment: VideoAppointment) =
-      listOf(StartEvent(appointment.startTime), EndEvent(appointment.endTime))
+    private fun toEvents(slot: AppointmentSlot) =
+      listOf(StartEvent(slot.startTime), EndEvent(slot.endTime))
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/JobTriggerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/JobTriggerIntegrationTest.kt
@@ -152,14 +152,17 @@ class JobTriggerIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  @Sql("classpath:integration-test-data/seed-migrated-bookings.sql")
+  @Sql("classpath:test_data/clean-all-data.sql", "classpath:integration-test-data/seed-migrated-bookings.sql")
   fun `should not send an email to the court to remind them to add the court hearing link if the booking has been migrated`() {
-    notificationRepository.findAll() hasSize 0
+    assumingThat(today().dayOfWeek in listOf(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, SUNDAY)) {
+      notificationRepository.findAll() hasSize 0
 
-    webTestClient.triggerJob(JobType.COURT_HEARING_LINK_REMINDER).also { it isEqualTo "Court hearing link reminders job triggered" }
+      webTestClient.triggerJob(JobType.COURT_HEARING_LINK_REMINDER)
+        .also { it isEqualTo "Court hearing link reminders job triggered" }
 
-    // There should be 0 notifications
-    notificationRepository.findAll().also { it hasSize 0 }
+      // There should be 0 notifications
+      notificationRepository.findAll().also { it hasSize 0 }
+    }
   }
 
   @Test


### PR DESCRIPTION
Behavior should be the same as a result of this PR i.e. we are still only looking locally for clashing appointments.

Following PR will combine with appointment data not mastered in BVLS.