### PR TITLE
BAVL-522 changes to support clashing checks with bookings in BVLS and external appointments. This sits behind a feature toggle.

### DIFF
--- a/helm_deploy/hmpps-book-a-video-link-api/values.yaml
+++ b/helm_deploy/hmpps-book-a-video-link-api/values.yaml
@@ -40,6 +40,7 @@ generic-service:
     DB_SSL_MODE: "verify-full"
     FEATURE_EVENTS_SNS_ENABLED: false
     HMPPS_SQS_USE_WEB_TOKEN: true
+    FEATURE_CHECK_EXTERNAL_AVAILABILITY: false
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,6 +20,7 @@ generic-service:
     API_BASE_URL_NOMIS_MAPPING: "https://nomis-sync-prisoner-mapping-dev.hmpps.service.justice.gov.uk"
     BVLS_FRONTEND_URL: "https://book-a-video-link-dev.prison.service.justice.gov.uk"
     FEATURE_EVENTS_SNS_ENABLED: true
+    FEATURE_CHECK_EXTERNAL_AVAILABILITY: true
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
@@ -89,8 +89,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
   }
 
   /**
-   * This will only return appointments that have an end time. We need this so we can match it to booked appointments in
-   * BVLS should we have to.
+   * Gets appointments in this prison, on this date, at a specific internal location ID.
    */
   fun getScheduledAppointments(prisonCode: String, date: LocalDate, locationId: Long) =
     prisonApiWebClient.get()
@@ -103,7 +102,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       }
       .retrieve()
       .bodyToMono(typeReference<List<ScheduledAppointment>>())
-      .block()?.filter { it.endTime != null } ?: emptyList()
+      .block() ?: emptyList()
 }
 
 // Overriding due to deserialisation issues from generated type. Only including fields we are interested in.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
@@ -5,6 +5,7 @@ import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.util.UriBuilder
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.NewAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDate
@@ -86,6 +87,23 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
       .block()
   }
+
+  /**
+   * This will only return appointments that have an end time. We need this so we can match it to booked appointments in
+   * BVLS should we have to.
+   */
+  fun getScheduledAppointments(prisonCode: String, date: LocalDate, locationId: Long) =
+    prisonApiWebClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/api/schedules/{prisonCode}/appointments")
+          .queryParam("date", date)
+          .queryParam("locationId", locationId)
+          .build(prisonCode)
+      }
+      .retrieve()
+      .bodyToMono(typeReference<List<ScheduledAppointment>>())
+      .block()?.filter { it.endTime != null } ?: emptyList()
 }
 
 // Overriding due to deserialisation issues from generated type. Only including fields we are interested in.
@@ -101,4 +119,19 @@ data class PrisonerSchedule(
   val event: String,
   val startTime: LocalDateTime,
   val endTime: LocalDateTime?,
+)
+
+data class ScheduledAppointment(
+  val id: Long,
+  val agencyId: String,
+  val locationId: Long,
+  val locationDescription: String,
+  val appointmentTypeCode: String,
+  val appointmentTypeDescription: String,
+  val startTime: LocalDateTime,
+  val endTime: LocalDateTime?,
+  val offenderNo: String,
+  val firstName: String,
+  val lastName: String,
+  val createUserId: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoAppointment.kt
@@ -31,13 +31,13 @@ data class VideoAppointment(
 
   val prisonCode: String,
 
-  val prisonerNumber: String,
+  override val prisonerNumber: String,
 
   val appointmentType: String,
 
   override val prisonLocationId: UUID,
 
-  val appointmentDate: LocalDate,
+  override val appointmentDate: LocalDate,
 
   override val startTime: LocalTime,
 
@@ -46,6 +46,10 @@ data class VideoAppointment(
 
 interface AppointmentSlot {
   val prisonLocationId: UUID
+
+  val prisonerNumber: String
+
+  val appointmentDate: LocalDate
 
   val startTime: LocalTime
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/AvailabilityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/AvailabilityController.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PostMapping
@@ -22,7 +23,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.AvailabilityS
 @RestController
 @RequestMapping(value = ["availability"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses
-class AvailabilityController(val availabilityService: AvailabilityService) {
+class AvailabilityController(
+  private val availabilityService: AvailabilityService,
+  @Value("\${feature.check.external-availability.enabled:false}") val externalAvailabilityEnabled: Boolean,
+) {
 
   @Operation(summary = "Endpoint to assess booking availability and to suggest alternatives")
   @ApiResponses(
@@ -46,5 +50,5 @@ class AvailabilityController(val availabilityService: AvailabilityService) {
     @RequestBody
     @Parameter(description = "The request containing the times and locations of hearings to check for availability", required = true)
     request: AvailabilityRequest,
-  ) = availabilityService.checkAvailability(request)
+  ) = availabilityService.checkAvailability(request, externalAvailabilityEnabled)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
@@ -3,19 +3,89 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationsInsidePrisonClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping.NomisMappingClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonApiClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.AppointmentSlot
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AvailabilityRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AvailabilityResponse
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoAppointmentRepository
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.UUID
 
 @Service
 class AvailabilityService(
   private val videoAppointmentRepository: VideoAppointmentRepository,
   private val locationsInsidePrisonClient: LocationsInsidePrisonClient,
   private val availabilityFinderService: AvailabilityFinderService,
+  private val externalAppointmentsService: ExternalAppointmentsService,
 ) {
 
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  /**
+   * Assumptions:
+   *  - current booking journeys for BVLS allows only one person at one prison per booking.
+   *  - we consider ONLY the prison locations in the request for alternative times (we do not consider others - yet)
+   *  - the decision about whether a user is allowed to book into a locations is still the users own.
+   *  - we assume all appointments for this booking are on the same day and at the same prison
+   *
+   * To consider later:
+   *  - Get other VCC-enabled rooms at these prison(s) and offer them?
+   *  - Incorporate prison room decoration logic here, to find other rooms?
+   */
+  fun checkAvailability(request: AvailabilityRequest, includeExternalAppointments: Boolean = false): AvailabilityResponse {
+    if (!includeExternalAppointments) {
+      log.info("Availability check looking in BVLS only")
+      return checkAvailability(request)
+    }
+
+    log.info("Availability check looking in BVLS and external.")
+
+    // Gather the distinct list of locations from the request
+    val locationKeys = setOfNotNull(
+      request.preAppointment?.prisonLocKey,
+      request.postAppointment?.prisonLocKey,
+      request.mainAppointment!!.prisonLocKey,
+    )
+
+    log.info("Checking availability for locationKeys $locationKeys")
+
+    val requestedLocations = locationsInsidePrisonClient.getLocationsByKeys(locationKeys)
+
+    // Get the existing VLB appointments at these locations, on this date
+    val (bvlsAppointmentSlotsToInclude: List<AppointmentSlot>, appointmentsToExclude: List<AppointmentSlot>) = videoAppointmentRepository.findVideoAppointmentsAtPrison(
+      forDate = request.date!!,
+      forPrison = request.prisonCode!!,
+      forLocationIds = requestedLocations.map { it.id },
+    ).partition { vlb -> vlb.videoBookingId != request.vlbIdToExclude }
+
+    log.info("Found ${bvlsAppointmentSlotsToInclude.size}, including appointments in these rooms")
+    log.info("Found ${appointmentsToExclude.size}, excluding appointments in these rooms")
+
+    val externalAppointmentSlotsToInclude: List<AppointmentSlot> =
+      requestedLocations
+        .flatMap { externalAppointmentsService.getAppointmentSlots(request.prisonCode, request.date, it.id) }
+        .filterNot { external ->
+          // We can only match on these values, there is no direct match between a BVLS appointment and what is in NOMIS
+          appointmentsToExclude.any { internal ->
+            internal.prisonerNumber == external.prisonerNumber &&
+              internal.appointmentDate == external.appointmentDate &&
+              internal.startTime == external.startTime &&
+              internal.endTime == external.endTime
+          }
+        }
+
+    log.info("Found ${externalAppointmentSlotsToInclude.size}, including external appointments in these rooms")
+
+    // Check if the requested times are free, and offer alternatives if not
+    return availabilityFinderService.getOptions(
+      request,
+      bvlsAppointmentSlotsToInclude.plus(externalAppointmentSlotsToInclude),
+      requestedLocations,
+    )
   }
 
   /**
@@ -31,8 +101,7 @@ class AvailabilityService(
    *  - Get other VCC-enabled rooms at these prison(s) and offer them?
    *  - Incorporate prison room decoration logic here, to find other rooms?
    */
-
-  fun checkAvailability(request: AvailabilityRequest): AvailabilityResponse {
+  private fun checkAvailability(request: AvailabilityRequest): AvailabilityResponse {
     // Gather the distinct list of locations from the request
     val locationKeys = setOfNotNull(
       request.preAppointment?.prisonLocKey,
@@ -56,4 +125,24 @@ class AvailabilityService(
     // Check if the requested times are free, and offer alternatives if not
     return availabilityFinderService.getOptions(request, videoAppointments, locations)
   }
+}
+
+@Service
+class ExternalAppointmentsService(
+  private val prisonApiClient: PrisonApiClient,
+  private val nomisMappingClient: NomisMappingClient,
+) {
+  fun getAppointmentSlots(prisonCode: String, date: LocalDate, location: UUID) =
+    nomisMappingClient.getNomisLocationMappingBy(location)
+      ?.let { prisonApiClient.getScheduledAppointments(prisonCode, date, it.nomisLocationId) }
+      ?.map { ExternalAppointmentSlot(location, it.offenderNo, it.startTime.toLocalDate(), it.startTime.toLocalTime(), it.endTime!!.toLocalTime()) }
+      ?: emptyList()
+
+  class ExternalAppointmentSlot(
+    override val prisonLocationId: UUID,
+    override val prisonerNumber: String,
+    override val appointmentDate: LocalDate,
+    override val startTime: LocalTime,
+    override val endTime: LocalTime,
+  ) : AppointmentSlot
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -31,3 +31,8 @@ api:
 bvls:
   frontend:
     url: http://localhost:3000
+
+feature:
+  check:
+    external-availability:
+      enabled: true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityServiceTest.kt
@@ -26,6 +26,7 @@ import java.util.UUID
 class AvailabilityServiceTest {
   private val videoAppointmentRepository: VideoAppointmentRepository = mock()
   private val locationsInsidePrisonClient: LocationsInsidePrisonClient = mock()
+  private val externalAppointmentsService: ExternalAppointmentsService = mock()
 
   private val availabilityOptionsGenerator = AvailabilityOptionsGenerator(
     dayStart = LocalTime.of(9, 0),
@@ -39,6 +40,7 @@ class AvailabilityServiceTest {
     videoAppointmentRepository,
     locationsInsidePrisonClient,
     availabilityFinderService,
+    externalAppointmentsService,
   )
 
   private fun createVideoAppointment(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityServiceTest.kt
@@ -110,7 +110,7 @@ class AvailabilityServiceTest {
 
     whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1, room2, room3)
 
-    val response = service.checkAvailability(request)
+    val response = service.checkAvailabilityVlbOnly(request)
 
     assertThat(response).isNotNull
     with(response) {
@@ -135,7 +135,7 @@ class AvailabilityServiceTest {
 
     whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1, room2, room3)
 
-    val response = service.checkAvailability(request)
+    val response = service.checkAvailabilityVlbOnly(request)
 
     assertThat(response).isNotNull
     with(response) {
@@ -184,7 +184,7 @@ class AvailabilityServiceTest {
 
     whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1, room2, room3)
 
-    val response = service.checkAvailability(request)
+    val response = service.checkAvailabilityVlbOnly(request)
 
     assertThat(response).isNotNull
     with(response) {
@@ -225,7 +225,7 @@ class AvailabilityServiceTest {
 
     whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1, room2, room3)
 
-    val response = service.checkAvailability(request)
+    val response = service.checkAvailabilityVlbOnly(request)
 
     // Room3 is busy all day
     assertThat(response).isNotNull
@@ -252,7 +252,7 @@ class AvailabilityServiceTest {
 
     whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1, room2, room3)
 
-    val response = service.checkAvailability(request)
+    val response = service.checkAvailabilityVlbOnly(request)
 
     // We should exclude appointments with videoBookingId == 2L
     assertThat(response).isNotNull
@@ -279,7 +279,7 @@ class AvailabilityServiceTest {
 
     whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1, room2, room3)
 
-    val response = service.checkAvailability(request)
+    val response = service.checkAvailabilityVlbOnly(request)
 
     // We should not exclude appointments with videoBookingId == 2L (conflict exists)
     assertThat(response).isNotNull


### PR DESCRIPTION
Changes to support booking/appointment clashes in both BVLS and externally e.g. NOMIS.

This feature is only enabled in DEV, will fall back to original process in other environments.