### PR TITLE
BAVL-522 using timestamp instead of date_booked (date_booked is the same for all events related to a booking).

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/VideoBookingEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/VideoBookingEventRepository.kt
@@ -21,7 +21,7 @@ interface VideoBookingEventRepository : ReadOnlyRepository<VideoBookingEvent, Lo
   @Query(
     value = """
       FROM VideoBookingEvent vbe 
-      WHERE (vbe.dateOfBooking >= :fromDate AND vbe.dateOfBooking < :toDate)
+      WHERE (cast(vbe.timestamp AS LocalDate) >= :fromDate AND vbe.dateOfBooking < :toDate)
       AND   vbe.courtBooking = :isCourtBooking
       ORDER BY vbe.eventId
     """,


### PR DESCRIPTION
Use timestamp (AKA creation timestamp) instead of date_booked for query.

date_booked would be the same for all events for a booking even if they occurred on different days.