### PR TITLE
BAVL-531 filter out return to unit locations from calls to locations API as these are not bookable locations.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationsInsidePrisonClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationsInsidePrisonClient.kt
@@ -16,6 +16,8 @@ import java.util.UUID
 
 inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>() {}
 
+private const val RETURN_TO_UNIT = "RTU"
+
 @Component
 class LocationsInsidePrisonClient(private val locationsInsidePrisonApiWebClient: WebClient) {
   companion object {
@@ -54,7 +56,7 @@ class LocationsInsidePrisonClient(private val locationsInsidePrisonApiWebClient:
     .bodyToMono(typeReference<List<Location>>())
     .doOnError { error -> log.info("Error looking up non-residential appointment locations by prison code $prisonCode in locations inside prison client", error) }
     .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
-    .block() ?: emptyList()
+    .block()?.filterNot { it.code == RETURN_TO_UNIT } ?: emptyList()
 
   @Cacheable(CacheConfiguration.VIDEO_LINK_LOCATIONS_CACHE_NAME)
   fun getVideoLinkLocationsAtPrison(prisonCode: String): List<Location> = locationsInsidePrisonApiWebClient.get()
@@ -63,7 +65,7 @@ class LocationsInsidePrisonClient(private val locationsInsidePrisonApiWebClient:
     .bodyToMono(typeReference<List<Location>>())
     .doOnError { error -> log.info("Error looking up video link locations by prison code $prisonCode in locations inside prison client", error) }
     .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
-    .block()?.filter(Location::leafLevel) ?: emptyList()
+    .block()?.filterNot { it.code == RETURN_TO_UNIT }?.filter(Location::leafLevel) ?: emptyList()
 }
 
 @Component

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationsInsidePrisonClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationsInsidePrisonClientTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.location
@@ -56,6 +57,18 @@ class LocationsInsidePrisonClientTest {
 
     server.stubNonResidentialAppointmentLocationsAtPrison(PENTONVILLE, pentonvilleLocation.copy(leafLevel = false))
     client.getNonResidentialAppointmentLocationsAtPrison(PENTONVILLE).single().key isEqualTo pentonvilleLocation.key
+  }
+
+  @Test
+  fun `should filter out return to unit from video link locations as these are not bookable`() {
+    server.stubVideoLinkLocationsAtPrison(WANDSWORTH, wandsworthLocation.copy(leafLevel = true, code = "NOT_RTU"), wandsworthLocation.copy(leafLevel = true, code = "RTU"))
+    client.getVideoLinkLocationsAtPrison(WANDSWORTH) containsExactlyInAnyOrder setOf(wandsworthLocation.copy(leafLevel = true, code = "NOT_RTU"))
+  }
+
+  @Test
+  fun `should filter out return to unit from non-residential locations as these are not bookable`() {
+    server.stubNonResidentialAppointmentLocationsAtPrison(WANDSWORTH, wandsworthLocation.copy(leafLevel = true, code = "NOT_RTU"), wandsworthLocation.copy(leafLevel = true, code = "RTU"))
+    client.getNonResidentialAppointmentLocationsAtPrison(WANDSWORTH) containsExactlyInAnyOrder setOf(wandsworthLocation.copy(leafLevel = true, code = "NOT_RTU"))
   }
 
   @AfterEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/LocationsInsidePrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/LocationsInsidePrisonApiMockServer.kt
@@ -193,6 +193,21 @@ class LocationsInsidePrisonApiMockServer : MockServer(8091) {
         ),
     )
   }
+
+  fun stubVideoLinkLocationsAtPrison(
+    prisonCode: String = WANDSWORTH,
+    vararg locations: Location,
+  ) {
+    stubFor(
+      get("/locations/prison/$prisonCode/location-type/VIDEO_LINK")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(mapper.writeValueAsString(locations))
+            .withStatus(200),
+        ),
+    )
+  }
 }
 
 class LocationsInsidePrisonApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {


### PR DESCRIPTION
This change resolves an issue whereby a user was able to make a booking into a location that is not a really bookable, `return to unit`.

As a result when an attempt was made to sync a booking with this location into NOMIS via A&A an error was being thrown preventing the appointment ever being synced.

I think strictly speaking this should not be returned by the locations API as a bookable location.  However for safety we are also filtering it out in our service.
