### PR TITLE
Fix cache eviction - all entries should be evicted

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/CacheConfiguration.kt
@@ -32,19 +32,19 @@ class CacheConfiguration {
       ROLLED_OUT_PRISONS_CACHE_NAME,
     )
 
-  @CacheEvict(value = [VIDEO_LINK_LOCATIONS_CACHE_NAME])
+  @CacheEvict(value = [VIDEO_LINK_LOCATIONS_CACHE_NAME], allEntries = true)
   @Scheduled(fixedDelay = 5, timeUnit = TimeUnit.MINUTES)
   fun cacheEvictVideoLinkLocations() {
     log.info("Evicting cache: $VIDEO_LINK_LOCATIONS_CACHE_NAME after 5 mins")
   }
 
-  @CacheEvict(value = [NON_RESIDENTIAL_LOCATIONS_CACHE_NAME])
+  @CacheEvict(value = [NON_RESIDENTIAL_LOCATIONS_CACHE_NAME], allEntries = true)
   @Scheduled(fixedDelay = 5, timeUnit = TimeUnit.MINUTES)
   fun cacheEvictNonResidentialLocations() {
     log.info("Evicting cache: $NON_RESIDENTIAL_LOCATIONS_CACHE_NAME after 5 mins")
   }
 
-  @CacheEvict(value = [ROLLED_OUT_PRISONS_CACHE_NAME])
+  @CacheEvict(value = [ROLLED_OUT_PRISONS_CACHE_NAME], allEntries = true)
   @Scheduled(fixedDelay = 5, timeUnit = TimeUnit.MINUTES)
   fun cacheEvictRolledOutPrisons() {
     log.info("Evicting cache: $ROLLED_OUT_PRISONS_CACHE_NAME after 5 mins")


### PR DESCRIPTION
`@CacheEvict` accepts several parameters:

`value`: Specifies the cache name(s) to operate on.
`allEntries` (default false): If true, all entries in the cache are evicted.
`key`: Specifies the cache key(s) to evict, if you want to evict specific entries.

With `allEntries = false` (default), the cache won't be evicted because no key is provided and Spring doesn't know which entry to evict.