### PR TITLE
BAVL-534 temporarily removes the clashing booking check, as the availability check is called first in the UI.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AppointmentsService.kt
@@ -55,11 +55,6 @@ class AppointmentsService(
 
     appointments.checkCourtAppointmentTypesOnly()
     appointments.checkSuppliedCourtAppointmentDateAndTimesDoNotOverlap()
-
-    // Prison users can have overlapping appointments
-    if (user !is PrisonUser) {
-      appointments.checkExistingCourtAppointmentDateAndTimesDoNotOverlap(prisonCode, locations)
-    }
   }
 
   private fun List<Appointment>.checkCourtAppointmentTypesOnly() {
@@ -81,29 +76,6 @@ class AppointmentsService(
 
     require((pre == null || pre.isBefore(hearing)) && (post == null || hearing.isBefore(post))) {
       "Requested court booking appointments must not overlap."
-    }
-  }
-
-  private fun List<Appointment>.checkExistingCourtAppointmentDateAndTimesDoNotOverlap(prisonCode: String, locations: List<Location>) {
-    forEach { newAppointment ->
-      val locationId = locations.single { it.key == newAppointment.locationKey }.id
-
-      prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(
-        prisonCode,
-        locationId,
-        newAppointment.date!!,
-      ).forEach { existingAppointment ->
-        require(
-          !isTimesOverlap(
-            newAppointment.startTime!!,
-            newAppointment.endTime!!,
-            existingAppointment.startTime,
-            existingAppointment.endTime,
-          ),
-        ) {
-          "One or more requested court appointments overlaps with an existing appointment at location ${newAppointment.locationKey}"
-        }
-      }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
@@ -52,6 +52,7 @@ class BookingFacade(
   }
 
   fun create(bookingRequest: CreateVideoBookingRequest, createdBy: User): Long {
+    // TODO - add overlapping booking check hear
     val (booking, prisoner) = createVideoBookingService.create(bookingRequest, createdBy)
     outboundEventsService.send(DomainEventType.VIDEO_BOOKING_CREATED, booking.videoBookingId)
     sendBookingEmails(BookingAction.CREATE, booking, prisoner, createdBy)
@@ -60,6 +61,7 @@ class BookingFacade(
   }
 
   fun amend(videoBookingId: Long, bookingRequest: AmendVideoBookingRequest, amendedBy: User): Long {
+    // TODO - add overlapping booking check hear
     val (booking, prisoner) = amendVideoBookingService.amend(videoBookingId, bookingRequest, amendedBy)
     outboundEventsService.send(DomainEventType.VIDEO_BOOKING_AMENDED, videoBookingId)
     sendBookingEmails(BookingAction.AMEND, booking, prisoner, amendedBy)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
@@ -386,6 +387,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     notifications.isPresent(COURT_USER.email!!, NewCourtBookingUserEmail::class, persistedBooking)
   }
 
+  @Disabled("Temporary disabling as part of availability ticket BAVL-534. Will be moving clashing check into the facade")
   @Test
   fun `should fail to create a clashing court booking as court user`() {
     videoBookingRepository.findAll() hasSize 0
@@ -1108,6 +1110,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     notifications.isPresent(COURT_USER.email!!, AmendedCourtBookingUserEmail::class, persistedBooking)
   }
 
+  @Disabled("Temporary disabling as part of availability ticket BAVL-534. Will be moving clashing check into the facade")
   @Test
   fun `should fail to amend to a clashing court booking`() {
     videoBookingRepository.findAll() hasSize 0
@@ -1591,6 +1594,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     notifications.isPresent(PRISON_USER_BIRMINGHAM.email!!, CourtBookingRequestUserEmail::class)
   }
 
+  @Disabled("Temporary disabling as part of availability ticket BAVL-534. Will be moving clashing check into the facade")
   @Test
   fun `should fail to request a clashing court booking`() {
     videoBookingRepository.findAll() hasSize 0

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
 import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -454,6 +455,7 @@ class AmendVideoBookingServiceTest {
     assertThrows<CaseloadAccessException> { service.amend(1, mock<AmendVideoBookingRequest>(), PRISON_USER_RISLEY) }
   }
 
+  @Disabled("Temporary disabling as part of availability ticket BAVL-534. Will be moving clashing check into the facade")
   @Test
   fun `should fail to amend a court video booking when new appointment overlaps existing for court user`() {
     val prisonerNumber = "123456"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
 import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -479,6 +480,7 @@ class CreateVideoBookingServiceTest {
     error.message isEqualTo "Court bookings can only have one pre hearing, one hearing and one post hearing."
   }
 
+  @Disabled("Temporary disabling as part of availability ticket BAVL-534. Will be moving clashing check into the facade")
   @Test
   fun `should fail to create a court video booking when new appointment overlaps existing for court user`() {
     val prisonCode = BIRMINGHAM


### PR DESCRIPTION
We need to go back to this and add the clashing checking to the facade.

This change is safe in the short term as the UI performs an availability check prior to create or amend.