### PR TITLE
BAVL-534 this changes adds the availability check to the core API end points, create, amend and request a booking.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingController.kt
@@ -187,7 +187,7 @@ class VideoLinkBookingController(
     }
   }
 
-  @Operation(summary = "Endpoint to support the request for a prison to create a video link booking for a prisoner due to arrive")
+  @Operation(summary = "Endpoint to allow external users request a prison to create a video link booking for a prisoner due to arrive")
   @ApiResponses(
     value = [
       ApiResponse(
@@ -205,7 +205,7 @@ class VideoLinkBookingController(
     @Parameter(description = "The request with the requested video link booking details", required = true)
     request: RequestVideoBookingRequest,
     httpRequest: HttpServletRequest,
-  ) = requestBookingService.request(request, httpRequest.getBvlsRequestContext().user)
+  ) = requestBookingService.request(request, httpRequest.getBvlsRequestContext().user as ExternalUser)
 
   @Operation(summary = "Endpoint to search for a unique matching video link booking.")
   @ApiResponses(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/RequestBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/RequestBookingService.kt
@@ -43,12 +43,21 @@ class RequestBookingService(
   private val referenceCodeRepository: ReferenceCodeRepository,
   private val notificationRepository: NotificationRepository,
   private val locationsInsidePrisonClient: LocationsInsidePrisonClient,
+  private val availabilityService: AvailabilityService,
 ) {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun request(request: RequestVideoBookingRequest, user: User) {
+  fun request(request: RequestVideoBookingRequest, user: ExternalUser) {
+    require(availabilityService.isAvailable(request)) {
+      if (request.bookingType == BookingType.COURT) {
+        "Unable to request court booking, booking overlaps with an existing appointment."
+      } else {
+        "Unable to request probation booking, booking overlaps with an existing appointment."
+      }
+    }
+
     when (request.bookingType!!) {
       BookingType.COURT -> processCourtBookingRequest(request, user)
       BookingType.PROBATION -> processProbationBookingRequest(request, user)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -311,6 +311,7 @@ fun amendCourtBookingRequest(
   endTime: LocalTime = LocalTime.now().plusHours(1),
   comments: String = "court booking comments",
   appointments: List<Appointment> = emptyList(),
+  appointmentDate: LocalDate = tomorrow(),
 ): AmendVideoBookingRequest {
   val prisoner = PrisonerDetails(
     prisonCode = prisonCode,
@@ -320,7 +321,7 @@ fun amendCourtBookingRequest(
         Appointment(
           type = AppointmentType.VLB_COURT_MAIN,
           locationKey = location?.key ?: "$prisonCode-$locationSuffix",
-          date = tomorrow(),
+          date = appointmentDate,
           startTime = startTime,
           endTime = endTime,
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityServiceTest.kt
@@ -12,6 +12,8 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationsInsidePrisonClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.amendCourtBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.amendProbationBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
@@ -364,6 +366,62 @@ class AvailabilityServiceTest {
       availabilityOk isBool true
       alternatives hasSize 0
     }
+
+    verifyNoInteractions(videoAppointmentRepository)
+    verifyNoInteractions(externalAppointmentsService)
+  }
+
+  @Test
+  fun `is available if request matches existing court booking main hearing booking date, time and location`() {
+    whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1)
+
+    val request = amendCourtBookingRequest(
+      prisonCode = WANDSWORTH,
+      appointmentDate = today(),
+      startTime = LocalTime.of(10, 0),
+      endTime = LocalTime.of(11, 0),
+      location = room1,
+    )
+
+    whenever(videoBookingRepository.findById(2L)) doReturn Optional.of(
+      courtBooking().withMainCourtPrisonAppointment(
+        date = today(),
+        prisonCode = WANDSWORTH,
+        location = room1,
+        startTime = LocalTime.of(10, 0),
+        endTime = LocalTime.of(11, 0),
+      ),
+    )
+
+    service.isAvailable(2, request) isBool true
+
+    verifyNoInteractions(videoAppointmentRepository)
+    verifyNoInteractions(externalAppointmentsService)
+  }
+
+  @Test
+  fun `is available if request matches existing probation booking meeting date, time and location`() {
+    whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room2)
+
+    val request = amendProbationBookingRequest(
+      prisonCode = WANDSWORTH,
+      appointmentDate = today(),
+      startTime = LocalTime.of(11, 0),
+      endTime = LocalTime.of(12, 0),
+      location = room2,
+    )
+
+    whenever(videoBookingRepository.findById(3L)) doReturn Optional.of(
+      probationBooking().withProbationPrisonAppointment(
+        date = today(),
+        prisonCode = WANDSWORTH,
+        location = room2,
+        startTime = LocalTime.of(11, 0),
+        endTime = LocalTime.of(12, 0),
+      ),
+    )
+
+    service.isAvailable(3, request) isBool true
 
     verifyNoInteractions(videoAppointmentRepository)
     verifyNoInteractions(externalAppointmentsService)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingServiceTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
 import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -478,45 +477,6 @@ class CreateVideoBookingServiceTest {
     val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, COURT_USER) }
 
     error.message isEqualTo "Court bookings can only have one pre hearing, one hearing and one post hearing."
-  }
-
-  @Disabled("Temporary disabling as part of availability ticket BAVL-534. Will be moving clashing check into the facade")
-  @Test
-  fun `should fail to create a court video booking when new appointment overlaps existing for court user`() {
-    val prisonCode = BIRMINGHAM
-    val prisonerNumber = "123456"
-    val courtBookingRequest = courtBookingRequest(
-      prisonCode = prisonCode,
-      prisonerNumber = prisonerNumber,
-      appointments = listOf(
-        Appointment(
-          type = AppointmentType.VLB_COURT_MAIN,
-          locationKey = birminghamLocation.key,
-          date = tomorrow(),
-          startTime = LocalTime.of(9, 30),
-          endTime = LocalTime.of(10, 0),
-        ),
-      ),
-    )
-
-    val overlappingAppointment: PrisonAppointment = mock {
-      on { startTime } doReturn LocalTime.of(9, 0)
-      on { endTime } doReturn LocalTime.of(10, 0)
-    }
-
-    val requestedCourt = court(courtBookingRequest.courtCode!!)
-
-    whenever(courtRepository.findByCode(courtBookingRequest.courtCode!!)) doReturn requestedCourt
-    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
-    whenever(prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(BIRMINGHAM, birminghamLocation.id, tomorrow())) doReturn listOf(overlappingAppointment)
-    whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
-    whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
-    whenever(locationValidator.validatePrisonLocations(BIRMINGHAM, setOf(birminghamLocation.key))) doReturn listOf(birminghamLocation)
-    whenever(locationsInsidePrisonClient.getLocationsByKeys(setOf(birminghamLocation.key))) doReturn listOf(birminghamLocation)
-
-    val error = assertThrows<IllegalArgumentException> { service.create(courtBookingRequest, COURT_USER) }
-
-    error.message isEqualTo "One or more requested court appointments overlaps with an existing appointment at location ${birminghamLocation.key}"
   }
 
   @Test


### PR DESCRIPTION
This change replaces what was temporarily removed, a check of clashing prison appointment times (in BVLS only).

**Note this does go further and checks external clashes as well. Do we want to switch the external check off in these cases?**