### PR TITLE
BAVL-557 use alternative Activities and Appointments endpoint for determining if a prison is rolled out.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,8 +17,9 @@ generic-service:
     API_BASE_URL_PRISON_API: "https://prison-api-dev.prison.service.justice.gov.uk"
     API_BASE_URL_PRISONER_SEARCH: "https://prisoner-search-dev.prison.service.justice.gov.uk"
     API_BASE_URL_NOMIS_MAPPING: "https://nomis-sync-prisoner-mapping-dev.hmpps.service.justice.gov.uk"
-    BVLS_FRONTEND_URL: "https://book-a-video-link-dev.prison.service.justice.gov.uk"
     FEATURE_EVENTS_SNS_ENABLED: true
+    FRONTEND_BASE_URL_ACTIVITIES_APPOINTMENTS: "https://activities-dev.prison.service.justice.gov.uk"
+    FRONTEND_BASE_URL_BVLS: "https://book-a-video-link-dev.prison.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,8 +16,9 @@ generic-service:
     API_BASE_URL_PRISON_API: "https://prison-api-preprod.prison.service.justice.gov.uk"
     API_BASE_URL_PRISONER_SEARCH: "https://prisoner-search-preprod.prison.service.justice.gov.uk"
     API_BASE_URL_NOMIS_MAPPING: "https://nomis-sync-prisoner-mapping-preprod.hmpps.service.justice.gov.uk"
-    BVLS_FRONTEND_URL: "https://book-a-video-link-preprod.prison.service.justice.gov.uk"
     FEATURE_EVENTS_SNS_ENABLED: true
+    FRONTEND_BASE_URL_ACTIVITIES_APPOINTMENTS: "https://activities-preprod.prison.service.justice.gov.uk"
+    FRONTEND_BASE_URL_BVLS: "https://book-a-video-link-preprod.prison.service.justice.gov.uk"
 
   allowlist:
     pen-tester-1: 80.195.27.199/32

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -13,8 +13,9 @@ generic-service:
     API_BASE_URL_PRISON_API: "https://prison-api.prison.service.justice.gov.uk"
     API_BASE_URL_PRISONER_SEARCH: "https://prisoner-search.prison.service.justice.gov.uk"
     API_BASE_URL_NOMIS_MAPPING: "https://nomis-sync-prisoner-mapping.hmpps.service.justice.gov.uk"
-    BVLS_FRONTEND_URL: "https://book-a-video-link.prison.service.justice.gov.uk"
     FEATURE_EVENTS_SNS_ENABLED: true
+    FRONTEND_BASE_URL_ACTIVITIES_APPOINTMENTS: "https://activities.prison.service.justice.gov.uk"
+    FRONTEND_BASE_URL_BVLS: "https://book-a-video-link.prison.service.justice.gov.uk"
 
     postgresDatabaseRestore:
       enabled: true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
@@ -110,7 +110,7 @@ class EmailConfiguration(
   }
 
   @Bean
-  fun emailService(@Value("\${bvls.frontend.url}") frontendDomain: String) =
+  fun emailService(@Value("\${frontend.base.url.bvls}") frontendDomain: String) =
     if (apiKey.isBlank()) {
       EmailService { email -> Result.success(UUID.randomUUID() to "fake template id").also { log.info("Email ${email.javaClass.simpleName} not sent.") } }.also { log.info("Gov Notify emails are disabled") }
     } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/WebClientConfiguration.kt
@@ -3,8 +3,10 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
 import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
 import uk.gov.justice.hmpps.kotlin.auth.authorisedWebClient
 import uk.gov.justice.hmpps.kotlin.auth.healthWebClient
 import java.time.Duration
@@ -12,6 +14,7 @@ import java.time.Duration
 @Configuration
 class WebClientConfiguration(
   @Value("\${api.base.url.activities-appointments}") val activitiesAppointmentsApiBaseUri: String,
+  @Value("\${frontend.base.url.activities-appointments}") val activitiesAppointmentsFrontendUri: String,
   @Value("\${api.base.url.hmpps-auth}") val hmppsAuthBaseUri: String,
   @Value("\${api.base.url.locations-inside-prison}") val locationsInsidePrisonApiBaseUri: String,
   @Value("\${api.base.url.manage-users}") private val manageUsersBaseUri: String,
@@ -66,4 +69,8 @@ class WebClientConfiguration(
   @Bean
   fun prisonerSearchApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder) =
     builder.authorisedWebClient(authorizedClientManager, "prisoner-search", prisonerSearchBaseUri, timeout)
+
+  @Bean
+  fun activitiesAppointmentsFrontendWebClient(builder: WebClient.Builder): WebClient =
+    builder.baseUrl(activitiesAppointmentsFrontendUri).clientConnector(ReactorClientHttpConnector(HttpClient.create().responseTimeout(healthTimeout))).build()
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -27,9 +27,12 @@ api:
       prison-api: https://prison-api-dev.prison.service.justice.gov.uk
       prisoner-search: https://prisoner-search-dev.prison.service.justice.gov.uk
       nomis-mapping: https://nomis-sync-prisoner-mapping-dev.hmpps.service.justice.gov.uk
-bvls:
-  frontend:
-    url: http://localhost:3000
+
+frontend:
+  base:
+    url:
+      bvls: http://localhost:3000
+      activities-appointments: "https://activities-dev.prison.service.justice.gov.uk"
 
 feature:
   check:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.risleyLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.container.PostgresContainer
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.ActivitiesAppointmentsApiExtension
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.ActivitiesAppointmentsFrontendExtension
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.LocationsInsidePrisonApiExtension
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock.ManageUsersApiExtension
@@ -38,6 +39,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
 @ActiveProfiles("test")
 @ExtendWith(
   ActivitiesAppointmentsApiExtension::class,
+  ActivitiesAppointmentsFrontendExtension::class,
   HmppsAuthApiExtension::class,
   LocationsInsidePrisonApiExtension::class,
   ManageUsersApiExtension::class,
@@ -56,6 +58,11 @@ abstract class IntegrationTestBase {
 
   @Autowired
   protected lateinit var jwtAuthHelper: JwtAuthHelper
+
+  @BeforeEach
+  fun `stub rolled out prisons`() {
+    activitiesAndAppointmentsFrontEnd().stubRolledOutPrisons()
+  }
 
   @BeforeEach
   fun `stub default users`() {
@@ -89,7 +96,10 @@ abstract class IntegrationTestBase {
     nomisMappingApi().stubHealthPing(status)
   }
 
+  protected fun activitiesAndAppointmentsFrontEnd() = ActivitiesAppointmentsFrontendExtension.server
+
   protected fun prisonerApi() = PrisonApiExtension.server
+
   protected fun prisonSearchApi() = PrisonerSearchApiExtension.server
 
   protected fun locationsInsidePrisonApi() = LocationsInsidePrisonApiExtension.server

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ActivitiesAppointmentsFrontEndMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ActivitiesAppointmentsFrontEndMockServer.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.ActivitiesAppointmentsClient.ActivitiesAndAppointmentsInformation
+
+class ActivitiesAppointmentsFrontendMockServer : MockServer(3001) {
+
+  fun stubRolledOutPrisons(vararg prisonCodes: String) {
+    stubFor(
+      WireMock.get("/info")
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(mapper.writeValueAsString(ActivitiesAndAppointmentsInformation(listOfNotNull(*prisonCodes))))
+            .withStatus(200),
+        ),
+    )
+  }
+}
+
+class ActivitiesAppointmentsFrontendExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
+  companion object {
+    @JvmField
+    val server = ActivitiesAppointmentsFrontendMockServer()
+  }
+
+  override fun beforeAll(context: ExtensionContext) {
+    server.start()
+  }
+
+  override fun beforeEach(context: ExtensionContext) {
+    server.resetAll()
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    server.stop()
+  }
+}

--- a/src/test/resources/application-test-localstack.yml
+++ b/src/test/resources/application-test-localstack.yml
@@ -29,6 +29,12 @@ api:
       prison-api:  http://localhost:8094
       nomis-mapping: http://localhost:8096
 
+frontend:
+  base:
+    url:
+      bvls: http://localhost:3000
+      activities-appointments: http://localhost:3001
+
 hmpps.sqs:
   provider: localstack
   queues:
@@ -44,7 +50,3 @@ feature:
   events:
     sns:
       enabled: true
-
-bvls:
-  frontend:
-    url: http://localhost:3000

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,6 +32,8 @@ api:
       prison-api: http://localhost:8094
       nomis-mapping: http://localhost:8096
 
-bvls:
-  frontend:
-    url: http://localhost:3000
+frontend:
+  base:
+    url:
+      bvls: http://localhost:3000
+      activities-appointments: http://localhost:3001


### PR DESCRIPTION
After a live issue with the rolled out prison check against the activities API we have been advised to use an alternative endpoint to work out if a prison is rolled out or not.

Note the issue itself was with A&A not BVLS.  Either way it has been recommended we make this change anyway.

**This PR is DRAFT as we are not 100% convinced this is the best approach.  This type of information would ideally come from the API.**