### PR TITLE
BAVL-572: Add additional location attributes to match against for DPS services matching video link bookings.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/ScheduleItem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/ScheduleItem.kt
@@ -91,13 +91,13 @@ data class ScheduleItem(
     description = "The location description where the appointment takes place. The localName from the locations-inside-prison service).",
     example = "VCC-crown-conference-room-1",
   )
-  val prisonLocDesc: String?,
+  val prisonLocDesc: String,
 
   @Schema(
     description = "The unique UUID for the location where the appointment takes place. The id field from the locations-inside-prison service.",
     example = "a4fe3fef-34fd-4354fde-a12efe",
   )
-  val dpsLocationId: UUID?,
+  val dpsLocationId: UUID,
 
   @Schema(description = "The date for this appointment ISO format (YYYY-MM-DD)", example = "2024-10-03")
   val appointmentDate: LocalDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/ScheduleMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/ScheduleMappers.kt
@@ -37,7 +37,7 @@ fun ScheduleItemEntity.toModel(locations: List<Location>) = ScheduleItem(
   appointmentDate = appointmentDate,
   startTime = startTime,
   endTime = endTime,
-  prisonLocDesc = locations.find { it.id == prisonLocationId }?.localName,
+  prisonLocDesc = locations.find { it.id == prisonLocationId }?.localName ?: throw IllegalArgumentException("Prison location with id $prisonLocationId not found in supplied set of locations"),
   dpsLocationId = prisonLocationId,
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ScheduleServiceTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -219,15 +218,5 @@ class ScheduleServiceTest {
       .containsOnly(BookingStatus.ACTIVE, BookingStatus.CANCELLED)
     assertThat(response).extracting("courtCode").containsOnly(courtCode, null)
     assertThat(response).extracting("probationTeamCode").containsOnly(probationTeamCode, null)
-  }
-
-  @Test
-  fun `Returns the additional fields for dpsLocationId and description for locations`() {
-    val response = service.getScheduleForPrison(PENTONVILLE, LocalDate.now(), false)
-    assertThat(response).isNotNull
-    assertThat(response).hasSize(3)
-    assertThat(response)
-      .extracting("dpsLocationId", "prisonLocDesc")
-      .contains(Tuple(pentonvilleLocation.id, pentonvilleLocation.localName))
   }
 }


### PR DESCRIPTION
This PR adds the `dpsLocationId` and `prisonLocDesc` to the schedules endpoints response type.
There is currently insufficient location information to accurately match against (only the location key was being returned). 