### PR TITLE
BAVL-428 feature toggled support for the probation meeting type VLPM.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ sonar-project.properties
 
 # Environment variables
 .env
+
+# Localstack
+volume/
+

--- a/docker-compose-localstack.yml
+++ b/docker-compose-localstack.yml
@@ -1,0 +1,31 @@
+version: "3"
+services:
+  db:
+    image: postgres:latest
+    networks:
+      - hmpps
+    container_name: book-a-video-link-db
+    restart: always
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: book-a-video-link-db
+      POSTGRES_USER: book-a-video-link
+      POSTGRES_PASSWORD: book-a-video-link
+    volumes:
+      - ./docker-init.sql:/docker-entrypoint-initdb.d/init.sql
+
+  local-stack-aws:
+    image: localstack/localstack:3
+    networks:
+      - hmpps
+    container_name: local-sqs
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=sns,sqs
+    volumes:
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+
+networks:
+  hmpps:

--- a/helm_deploy/hmpps-book-a-video-link-api/values.yaml
+++ b/helm_deploy/hmpps-book-a-video-link-api/values.yaml
@@ -39,7 +39,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     DB_SSL_MODE: "verify-full"
     HMPPS_SQS_USE_WEB_TOKEN: true
-    FEATURE_PROBATION_LIVE: false
+    FEATURE_MASTER_VLPM_TYPES: false
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/hmpps-book-a-video-link-api/values.yaml
+++ b/helm_deploy/hmpps-book-a-video-link-api/values.yaml
@@ -39,6 +39,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     DB_SSL_MODE: "verify-full"
     HMPPS_SQS_USE_WEB_TOKEN: true
+    FEATURE_PROBATION_LIVE: false
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/run-localstack.sh
+++ b/run-localstack.sh
@@ -1,0 +1,24 @@
+#
+# This script is used to run the BVLS API locally.
+#
+# It runs with a combination of properties from the default spring profile (in application.yaml) and supplemented
+# with the -local and -localstack profiles. The latter overrides some of the defaults.
+#
+# The environment variables here will also override values supplied in spring profile properties, specifically
+# around removing the SSL connection to the database and setting the DB properties, SERVER_PORT and client credentials
+# to match those used in the docker-compose files.
+#
+
+# Provide the DB connection details to local container-hosted Postgresql DB running
+export DB_SERVER=localhost
+export DB_NAME=book-a-video-link-db
+export DB_USER=book-a-video-link
+export DB_PASS=book-a-video-link
+export DB_SSL_MODE=prefer
+export $(cat .env | xargs)  # If you want to set or update the current shell environment e.g. system client and secret.
+
+# Run the application with stdout and local profiles active
+SPRING_PROFILES_ACTIVE=stdout,localstack ./gradlew bootRun
+
+# End
+

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAndAppointmentsExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAndAppointmentsExt.kt
@@ -1,12 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments
 
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSearchResult
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingHistoryAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import java.time.LocalTime
 
-fun AppointmentSearchResult.isAppointmentType(appointmentType: AppointmentType) = category.code == appointmentType.code
+fun AppointmentSearchResult.isAppointmentType(appointmentType: SupportedAppointmentTypes.Type) = category.code == appointmentType.code
 
 fun AppointmentSearchResult.isTimesAreTheSame(appointment: PrisonAppointment) =
   appointment.startTime == LocalTime.parse(startTime) && appointment.endTime == LocalTime.parse(endTime)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAndAppointmentsExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAndAppointmentsExt.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments
+
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSearchResult
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingHistoryAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
+import java.time.LocalTime
+
+fun AppointmentSearchResult.isAppointmentType(appointmentType: AppointmentType) = category.code == appointmentType.code
+
+fun AppointmentSearchResult.isTimesAreTheSame(appointment: PrisonAppointment) =
+  appointment.startTime == LocalTime.parse(startTime) && appointment.endTime == LocalTime.parse(endTime)
+
+fun AppointmentSearchResult.isTimesAreTheSame(bha: BookingHistoryAppointment) =
+  bha.startTime == LocalTime.parse(startTime) && bha.endTime == LocalTime.parse(endTime)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAndAppointmentsExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAndAppointmentsExt.kt
@@ -6,10 +6,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingHistory
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import java.time.LocalTime
 
-fun AppointmentSearchResult.isAppointmentType(appointmentType: SupportedAppointmentTypes.Type) = category.code == appointmentType.code
+fun AppointmentSearchResult.isTheSameAppointmentType(appointmentType: SupportedAppointmentTypes.Type) = category.code == appointmentType.code
 
-fun AppointmentSearchResult.isTimesAreTheSame(appointment: PrisonAppointment) =
+fun AppointmentSearchResult.isTheSameTime(appointment: PrisonAppointment) =
   appointment.startTime == LocalTime.parse(startTime) && appointment.endTime == LocalTime.parse(endTime)
 
-fun AppointmentSearchResult.isTimesAreTheSame(bha: BookingHistoryAppointment) =
+fun AppointmentSearchResult.isTheSameTime(bha: BookingHistoryAppointment) =
   bha.startTime == LocalTime.parse(startTime) && bha.endTime == LocalTime.parse(endTime)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
@@ -13,12 +13,11 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeries
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeriesCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.RolloutPrisonPlan
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toHourMinuteStyle
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.CacheConfiguration
 import java.time.LocalDate
 import java.time.LocalTime
-
-const val VIDEO_LINK_BOOKING = "VLB"
 
 inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>() {}
 
@@ -26,7 +25,6 @@ const val CANCELLED_BY_EXTERNAL_SERVICE = 4L
 
 @Component
 class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClient: WebClient) {
-
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
@@ -49,6 +47,7 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
     endTime: LocalTime,
     internalLocationId: Long,
     comments: String?,
+    appointmentType: AppointmentType,
   ): AppointmentSeries? =
     activitiesAppointmentsApiWebClient.post()
       .uri("/appointment-series")
@@ -57,7 +56,7 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
           appointmentType = AppointmentSeriesCreateRequest.AppointmentType.INDIVIDUAL,
           prisonCode = prisonCode,
           prisonerNumbers = listOf(prisonerNumber),
-          categoryCode = VIDEO_LINK_BOOKING,
+          categoryCode = appointmentType.code,
           tierCode = AppointmentSeriesCreateRequest.TierCode.TIER_1,
           inCell = false,
           startDate = startDate,
@@ -71,25 +70,27 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
       .bodyToMono(AppointmentSeries::class.java)
       .block()
 
+  /**
+   * Returns all matching appointment (types) for a prisoner, not just video link bookings.
+   */
   fun getPrisonersAppointmentsAtLocations(prisonCode: String, prisonerNumber: String, onDate: LocalDate, vararg locationIds: Long) =
     if (locationIds.isNotEmpty()) {
       log.info("A&A CLIENT: query params - prisonCode=$prisonCode, prisonerNumber=$prisonerNumber, onDate=$onDate, locationIds=${locationIds.toList()}")
       getPrisonersAppointments(prisonCode, prisonerNumber, onDate)
         .also { log.info("A&A CLIENT: matches pre-location filter: $it") }
-        .filter { locationIds.toList().contains(it.internalLocation?.id) && it.category.code == VIDEO_LINK_BOOKING }
+        .filter { locationIds.toList().contains(it.internalLocation?.id) }
         .also { log.info("A&A CLIENT: matches post-location filter: $it") }
     } else {
       emptyList()
     }
 
-  private fun getPrisonersAppointments(prisonCode: String, prisonerNumber: String, onDate: LocalDate): List<AppointmentSearchResult> =
+  private fun getPrisonersAppointments(prisonCode: String, prisonerNumber: String, onDate: LocalDate) =
     activitiesAppointmentsApiWebClient.post()
       .uri("/appointments/{prisonCode}/search", prisonCode)
       .bodyValue(
         AppointmentSearchRequest(
           appointmentType = AppointmentSearchRequest.AppointmentType.INDIVIDUAL,
           startDate = onDate,
-          categoryCode = VIDEO_LINK_BOOKING,
           prisonerNumbers = listOf(prisonerNumber),
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
@@ -21,6 +21,7 @@ import java.time.LocalTime
 
 inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>() {}
 
+// These constants map to values in the A&A DB appointment cancellation reasons.
 const val CANCELLED_BY_EXTERNAL_SERVICE = 4L
 const val CANCELLED_BY_USER = 2L
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeries
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeriesCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.RolloutPrisonPlan
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toHourMinuteStyle
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.CacheConfiguration
 import java.time.LocalDate
@@ -47,7 +47,7 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
     endTime: LocalTime,
     internalLocationId: Long,
     comments: String?,
-    appointmentType: AppointmentType,
+    appointmentType: SupportedAppointmentTypes.Type,
   ): AppointmentSeries? =
     activitiesAppointmentsApiWebClient.post()
       .uri("/appointment-series")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
@@ -123,13 +123,13 @@ data class PrisonerSchedule(
   val startTime: LocalDateTime,
   val endTime: LocalDateTime?,
 ) {
-  fun isAppointmentType(appointmentType: SupportedAppointmentTypes.Type) = event == appointmentType.code
+  fun isTheSameAppointmentType(appointmentType: SupportedAppointmentTypes.Type) = event == appointmentType.code
 
-  fun isTimesAreTheSame(appointment: PrisonAppointment) =
+  fun isTheSameTime(appointment: PrisonAppointment) =
     startTime == appointment.appointmentDate.atTime(appointment.startTime) &&
       appointment.appointmentDate.atTime(appointment.endTime) == endTime
 
-  fun isTimesAreTheSame(bha: BookingHistoryAppointment) =
+  fun isTheSameTime(bha: BookingHistoryAppointment) =
     startTime == bha.appointmentDate.atTime(bha.startTime) && bha.appointmentDate.atTime(bha.endTime) == endTime
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
@@ -8,13 +8,14 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import org.springframework.web.util.UriBuilder
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.NewAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDate
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingHistoryAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-
-const val VIDEO_LINK_BOOKING = "VLB"
 
 inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>() {}
 
@@ -22,7 +23,6 @@ const val DO_NOT_PROPAGATE = true.toString()
 
 @Component
 class PrisonApiClient(private val prisonApiWebClient: WebClient) {
-
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
@@ -34,6 +34,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
     startTime: LocalTime,
     endTime: LocalTime,
     comments: String? = null,
+    appointmentType: AppointmentType,
   ): ScheduledEvent? =
     prisonApiWebClient
       .post()
@@ -41,7 +42,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .header("no-event-propagation", DO_NOT_PROPAGATE)
       .bodyValue(
         NewAppointment(
-          appointmentType = VIDEO_LINK_BOOKING,
+          appointmentType = appointmentType.code,
           locationId = locationId,
           startTime = appointmentDate.atTime(startTime).toIsoDateTime(),
           endTime = appointmentDate.atTime(endTime).toIsoDateTime(),
@@ -52,12 +53,15 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .bodyToMono(ScheduledEvent::class.java)
       .block()
 
+  /**
+   * Returns all matching appointment (types) for a prisoner, not just video link bookings.
+   */
   fun getPrisonersAppointmentsAtLocations(prisonCode: String, prisonerNumber: String, onDate: LocalDate, vararg locationIds: Long): List<PrisonerSchedule> =
     if (locationIds.isNotEmpty()) {
       log.info("PRISON-API CLIENT: query params - prisonCode=$prisonCode, prisonerNumber=$prisonerNumber, onDate=$onDate, locationIds=${locationIds.toList()}")
       getPrisonersAppointments(prisonCode, prisonerNumber, onDate)
         .also { log.info("PRISON-API CLIENT: matches pre-location filter: $it") }
-        .filter { locationIds.contains(it.locationId) && it.event == VIDEO_LINK_BOOKING }
+        .filter { locationIds.contains(it.locationId) }
         .also { log.info("PRISON-API CLIENT matches post-location filter: $it") }
     } else {
       emptyList()
@@ -118,7 +122,16 @@ data class PrisonerSchedule(
   val event: String,
   val startTime: LocalDateTime,
   val endTime: LocalDateTime?,
-)
+) {
+  fun isAppointmentType(appointmentType: AppointmentType) = event == appointmentType.code
+
+  fun isTimesAreTheSame(appointment: PrisonAppointment) =
+    startTime == appointment.appointmentDate.atTime(appointment.startTime) &&
+      appointment.appointmentDate.atTime(appointment.endTime) == endTime
+
+  fun isTimesAreTheSame(bha: BookingHistoryAppointment) =
+    startTime == bha.appointmentDate.atTime(bha.startTime) && bha.appointmentDate.atTime(bha.endTime) == endTime
+}
 
 data class ScheduledAppointment(
   val id: Long,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
@@ -8,7 +8,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import org.springframework.web.util.UriBuilder
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.NewAppointment
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDate
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingHistoryAppointment
@@ -34,7 +34,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
     startTime: LocalTime,
     endTime: LocalTime,
     comments: String? = null,
-    appointmentType: AppointmentType,
+    appointmentType: SupportedAppointmentTypes.Type,
   ): ScheduledEvent? =
     prisonApiWebClient
       .post()
@@ -123,7 +123,7 @@ data class PrisonerSchedule(
   val startTime: LocalDateTime,
   val endTime: LocalDateTime?,
 ) {
-  fun isAppointmentType(appointmentType: AppointmentType) = event == appointmentType.code
+  fun isAppointmentType(appointmentType: SupportedAppointmentTypes.Type) = event == appointmentType.code
 
   fun isTimesAreTheSame(appointment: PrisonAppointment) =
     startTime == appointment.appointmentDate.atTime(appointment.startTime) &&

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/AppointmentType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/AppointmentType.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common
+
+enum class AppointmentType(val code: String) {
+  COURT("VLB"),
+  PROBATION("VLPM"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/AppointmentType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/AppointmentType.kt
@@ -1,6 +1,0 @@
-package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common
-
-enum class AppointmentType(val code: String) {
-  COURT("VLB"),
-  PROBATION("VLPM"),
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/SupportedAppointmentTypes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/SupportedAppointmentTypes.kt
@@ -14,13 +14,13 @@ class SupportedAppointmentTypes(private val featureSwitches: FeatureSwitches) {
   }
 
   fun typeOf(type: BookingType) =
-    when (featureSwitches.isEnabled(Feature.FEATURE_PROBATION_LIVE)) {
+    when (featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) {
       true -> Type.COURT.takeIf { type.isCourtBooking() } ?: Type.PROBATION
       false -> Type.COURT
     }
 
-  fun isVideoLinkBooking(appointmentType: String) =
-    when (featureSwitches.isEnabled(Feature.FEATURE_PROBATION_LIVE)) {
+  fun isSupported(appointmentType: String) =
+    when (featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) {
       true -> Type.entries.map(Type::code).contains(appointmentType)
       false -> Type.COURT.code == appointmentType
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/SupportedAppointmentTypes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/SupportedAppointmentTypes.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Feature
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType
+
+@Component
+class SupportedAppointmentTypes(private val featureSwitches: FeatureSwitches) {
+
+  enum class Type(val code: String) {
+    COURT("VLB"),
+    PROBATION("VLPM"),
+  }
+
+  fun typeOf(type: BookingType) =
+    when (featureSwitches.isEnabled(Feature.FEATURE_PROBATION_LIVE)) {
+      true -> Type.COURT.takeIf { type.isCourtBooking() } ?: Type.PROBATION
+      false -> Type.COURT
+    }
+
+  fun isVideoLinkBooking(appointmentType: String) =
+    when (featureSwitches.isEnabled(Feature.FEATURE_PROBATION_LIVE)) {
+      true -> Type.entries.map(Type::code).contains(appointmentType)
+      false -> Type.COURT.code == appointmentType
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/SupportedAppointmentTypes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/SupportedAppointmentTypes.kt
@@ -14,9 +14,13 @@ class SupportedAppointmentTypes(private val featureSwitches: FeatureSwitches) {
   }
 
   fun typeOf(type: BookingType) =
-    when (featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) {
-      true -> Type.COURT.takeIf { type.isCourtBooking() } ?: Type.PROBATION
-      false -> Type.COURT
+    if (featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) {
+      when (type) {
+        BookingType.COURT -> Type.COURT
+        BookingType.PROBATION -> Type.PROBATION
+      }
+    } else {
+      Type.COURT
     }
 
   fun isSupported(appointmentType: String) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/FeatureSwitches.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/FeatureSwitches.kt
@@ -29,4 +29,6 @@ class FeatureSwitches(private val environment: Environment) {
     }
 }
 
-enum class Feature(val label: String)
+enum class Feature(val label: String) {
+  FEATURE_PROBATION_LIVE("feature.probation.live"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/FeatureSwitches.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/FeatureSwitches.kt
@@ -30,5 +30,5 @@ class FeatureSwitches(private val environment: Environment) {
 }
 
 enum class Feature(val label: String) {
-  FEATURE_PROBATION_LIVE("feature.probation.live"),
+  FEATURE_MASTER_VLPM_TYPES("feature.master.vlpm.types"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/BookingHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/BookingHistory.kt
@@ -108,7 +108,9 @@ data class BookingHistoryAppointment(
   val startTime: LocalTime,
 
   val endTime: LocalTime,
-) {
+) : BookingType {
+  override fun isCourtBooking() = bookingHistory.courtId != null
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/BookingHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/BookingHistory.kt
@@ -84,12 +84,6 @@ class BookingHistory(
  * related to a single video link booking - the co-defendant coses. At present, the user journeys for
  * create and amend cannot have more than one prisoner per booking, but this is future-proofing it.
  */
-
-const val APPOINTMENT_TYPE_COURT_PRE = "VLB_COURT_PRE"
-const val APPOINTMENT_TYPE_COURT_MAIN = "VLB_COURT_MAIN"
-const val APPOINTMENT_TYPE_COURT_POST = "VLB_COURT_POST"
-const val APPOINTMENT_TYPE_PROBATION = "VLB_PROBATION"
-
 @Entity
 @Table(name = "booking_history_appointment")
 data class BookingHistoryAppointment(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/BookingHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/BookingHistory.kt
@@ -108,8 +108,8 @@ data class BookingHistoryAppointment(
   val startTime: LocalTime,
 
   val endTime: LocalTime,
-) : BookingType {
-  override fun isCourtBooking() = bookingHistory.courtId != null
+) {
+  fun bookingType() = if (bookingHistory.courtId != null) BookingType.COURT else BookingType.PROBATION
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/BookingType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/BookingType.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity
+
+fun interface BookingType {
+  fun isCourtBooking(): Boolean
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/BookingType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/BookingType.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity
 
-fun interface BookingType {
-  fun isCourtBooking(): Boolean
+enum class BookingType {
+  COURT,
+  PROBATION,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/PrisonAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/PrisonAppointment.kt
@@ -43,7 +43,7 @@ class PrisonAppointment private constructor(
   val startTime: LocalTime,
 
   val endTime: LocalTime,
-) {
+) : BookingType {
 
   fun prisonCode() = prison.code
 
@@ -52,6 +52,7 @@ class PrisonAppointment private constructor(
   fun start(): LocalDateTime = appointmentDate.atTime(startTime)
 
   fun end(): LocalDateTime = appointmentDate.atTime(endTime)
+  override fun isCourtBooking() = videoBooking.isCourtBooking()
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/PrisonAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/PrisonAppointment.kt
@@ -43,7 +43,7 @@ class PrisonAppointment private constructor(
   val startTime: LocalTime,
 
   val endTime: LocalTime,
-) : BookingType {
+) {
 
   fun prisonCode() = prison.code
 
@@ -52,7 +52,8 @@ class PrisonAppointment private constructor(
   fun start(): LocalDateTime = appointmentDate.atTime(startTime)
 
   fun end(): LocalDateTime = appointmentDate.atTime(endTime)
-  override fun isCourtBooking() = videoBooking.isCourtBooking()
+
+  fun bookingType() = if (videoBooking.isCourtBooking()) BookingType.COURT else BookingType.PROBATION
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
@@ -205,7 +205,7 @@ class ExternalAppointmentsService(
     nomisMappingClient.getNomisLocationMappingBy(location)
       ?.let { prisonApiClient.getScheduledAppointments(prisonCode, date, it.nomisLocationId) }
       ?.filter { it.endTime != null }
-      ?.filterNot { supportedAppointmentTypes.isVideoLinkBooking(it.appointmentTypeCode) }
+      ?.filterNot { supportedAppointmentTypes.isSupported(it.appointmentTypeCode) }
       ?.map { ExternalAppointmentSlot(location, it.offenderNo, it.startTime.toLocalDate(), it.startTime.toLocalTime(), it.endTime!!.toLocalTime()) }
       ?: emptyList()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsid
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping.NomisMappingClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonApiClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.AppointmentSlot
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AmendVideoBookingRequest
@@ -193,6 +194,7 @@ class AvailabilityService(
 class ExternalAppointmentsService(
   private val prisonApiClient: PrisonApiClient,
   private val nomisMappingClient: NomisMappingClient,
+  private val supportedAppointmentTypes: SupportedAppointmentTypes,
 ) {
   /**
    * Get the prison appointments on a date at a specific internal location ID in the prison
@@ -203,7 +205,7 @@ class ExternalAppointmentsService(
     nomisMappingClient.getNomisLocationMappingBy(location)
       ?.let { prisonApiClient.getScheduledAppointments(prisonCode, date, it.nomisLocationId) }
       ?.filter { it.endTime != null }
-      ?.filter { it.appointmentTypeCode != "VLB" }
+      ?.filterNot { supportedAppointmentTypes.isVideoLinkBooking(it.appointmentTypeCode) }
       ?.map { ExternalAppointmentSlot(location, it.offenderNo, it.startTime.toLocalDate(), it.startTime.toLocalTime(), it.endTime!!.toLocalTime()) }
       ?: emptyList()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/DomainEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/DomainEvents.kt
@@ -80,7 +80,8 @@ class PrisonerVideoAppointmentCancelledEvent(
   additionalInformation: AppointmentScheduleInformation,
 ) :
   DomainEvent<AppointmentScheduleInformation>(DomainEventType.PRISONER_VIDEO_APPOINTMENT_CANCELLED, additionalInformation) {
-  fun isVideoLinkBooking() = additionalInformation.scheduleEventSubType == "VLB"
+
+  fun appointmentType() = additionalInformation.scheduleEventSubType
 
   fun prisonCode() = additionalInformation.agencyLocationId
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
@@ -66,7 +66,7 @@ class ManageExternalAppointmentsService(
               endTime = appointment.endTime,
               internalLocationId = internalLocationId,
               comments = appointment.comments,
-              appointmentType = typeOf(appointment),
+              appointmentType = typeOf(appointment).also { log.info("EXTERNAL APPOINTMENTS: creating appointment with appointment type ${it.code} in A&A") },
             )?.let { appointmentSeries ->
               log.info("EXTERNAL APPOINTMENTS: created activities and appointments series ${appointmentSeries.id} for prison appointment $prisonAppointmentId")
             }
@@ -92,7 +92,7 @@ class ManageExternalAppointmentsService(
               startTime = appointment.startTime,
               endTime = appointment.endTime,
               comments = appointment.comments,
-              appointmentType = typeOf(appointment),
+              appointmentType = typeOf(appointment).also { log.info("EXTERNAL APPOINTMENTS: creating appointment with appointment type ${it.code} in prison-api") },
             )?.let { event ->
               log.info("EXTERNAL APPOINTMENTS: created prison api event ${event.eventId} for prison appointment $prisonAppointmentId")
             }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
@@ -176,7 +176,7 @@ class ManageExternalAppointmentsService(
 
   private fun Collection<AppointmentSearchResult>.findMatchingAppointments(appointment: PrisonAppointment): List<AppointmentSearchResult> =
     filter { searchResult ->
-      searchResult.isTimesAreTheSame(appointment) && searchResult.isAppointmentType(typeOf(appointment))
+      searchResult.isTimesAreTheSame(appointment) && searchResult.isAppointmentType(typeOf(appointment)) && searchResult.isCancelled.not()
     }.ifEmpty {
       emptyList<AppointmentSearchResult>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in A&A for prison appointment ${appointment.prisonAppointmentId}") }
@@ -184,7 +184,7 @@ class ManageExternalAppointmentsService(
 
   private fun Collection<AppointmentSearchResult>.findMatchingAppointments(bha: BookingHistoryAppointment): List<AppointmentSearchResult> =
     filter { searchResult ->
-      searchResult.isTimesAreTheSame(bha) && searchResult.isAppointmentType(typeOf(bha))
+      searchResult.isTimesAreTheSame(bha) && searchResult.isAppointmentType(typeOf(bha)) && searchResult.isCancelled.not()
     }.ifEmpty {
       emptyList<AppointmentSearchResult>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in A&A for booking history appointment ${bha.bookingHistoryAppointmentId}") }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
@@ -64,7 +64,7 @@ class ManageExternalAppointmentsService(
               endTime = appointment.endTime,
               internalLocationId = internalLocationId,
               comments = appointment.comments,
-              appointmentType = supportedAppointmentTypes.typeOf(appointment).also { log.info("EXTERNAL APPOINTMENTS: creating appointment with appointment type ${it.code} in A&A") },
+              appointmentType = supportedAppointmentTypes.typeOf(appointment.bookingType()).also { log.info("EXTERNAL APPOINTMENTS: creating appointment with appointment type ${it.code} in A&A") },
             )?.let { appointmentSeries ->
               log.info("EXTERNAL APPOINTMENTS: created activities and appointments series ${appointmentSeries.id} for prison appointment $prisonAppointmentId")
             }
@@ -90,7 +90,7 @@ class ManageExternalAppointmentsService(
               startTime = appointment.startTime,
               endTime = appointment.endTime,
               comments = appointment.comments,
-              appointmentType = supportedAppointmentTypes.typeOf(appointment).also { log.info("EXTERNAL APPOINTMENTS: creating appointment with appointment type ${it.code} in prison-api") },
+              appointmentType = supportedAppointmentTypes.typeOf(appointment.bookingType()).also { log.info("EXTERNAL APPOINTMENTS: creating appointment with appointment type ${it.code} in prison-api") },
             )?.let { event ->
               log.info("EXTERNAL APPOINTMENTS: created prison api event ${event.eventId} for prison appointment $prisonAppointmentId")
             }
@@ -174,7 +174,7 @@ class ManageExternalAppointmentsService(
 
   private fun Collection<AppointmentSearchResult>.findMatchingAppointments(appointment: PrisonAppointment): List<AppointmentSearchResult> =
     filter { searchResult ->
-      searchResult.isTheSameTime(appointment) && searchResult.isTheSameAppointmentType(supportedAppointmentTypes.typeOf(appointment)) && searchResult.isCancelled.not()
+      searchResult.isTheSameTime(appointment) && searchResult.isTheSameAppointmentType(supportedAppointmentTypes.typeOf(appointment.bookingType())) && searchResult.isCancelled.not()
     }.ifEmpty {
       emptyList<AppointmentSearchResult>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in A&A for prison appointment ${appointment.prisonAppointmentId}") }
@@ -182,7 +182,7 @@ class ManageExternalAppointmentsService(
 
   private fun Collection<AppointmentSearchResult>.findMatchingAppointments(bha: BookingHistoryAppointment): List<AppointmentSearchResult> =
     filter { searchResult ->
-      searchResult.isTheSameTime(bha) && searchResult.isTheSameAppointmentType(supportedAppointmentTypes.typeOf(bha)) && searchResult.isCancelled.not()
+      searchResult.isTheSameTime(bha) && searchResult.isTheSameAppointmentType(supportedAppointmentTypes.typeOf(bha.bookingType())) && searchResult.isCancelled.not()
     }.ifEmpty {
       emptyList<AppointmentSearchResult>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in A&A for booking history appointment ${bha.bookingHistoryAppointmentId}") }
@@ -190,7 +190,7 @@ class ManageExternalAppointmentsService(
 
   private fun Collection<PrisonerSchedule>.findMatchingPrisonApi(appointment: PrisonAppointment): List<PrisonerSchedule> =
     filter { schedule ->
-      schedule.isTheSameTime(appointment) && schedule.isTheSameAppointmentType(supportedAppointmentTypes.typeOf(appointment))
+      schedule.isTheSameTime(appointment) && schedule.isTheSameAppointmentType(supportedAppointmentTypes.typeOf(appointment.bookingType()))
     }.ifEmpty {
       emptyList<PrisonerSchedule>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in prison-api for prison appointment ${appointment.prisonAppointmentId}") }
@@ -198,7 +198,7 @@ class ManageExternalAppointmentsService(
 
   private fun Collection<PrisonerSchedule>.findMatchingPrisonApi(bha: BookingHistoryAppointment): List<PrisonerSchedule> =
     filter { schedule ->
-      schedule.isTheSameTime(bha) && schedule.isTheSameAppointmentType(supportedAppointmentTypes.typeOf(bha))
+      schedule.isTheSameTime(bha) && schedule.isTheSameAppointmentType(supportedAppointmentTypes.typeOf(bha.bookingType()))
     }.ifEmpty {
       emptyList<PrisonerSchedule>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in prison-api for booking history appointment ${bha.bookingHistoryAppointmentId}") }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
@@ -4,8 +4,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.ActivitiesAppointmentsClient
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.isAppointmentType
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.isTimesAreTheSame
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.isTheSameAppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.isTheSameTime
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSearchResult
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping.NomisMappingClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonApiClient
@@ -174,7 +174,7 @@ class ManageExternalAppointmentsService(
 
   private fun Collection<AppointmentSearchResult>.findMatchingAppointments(appointment: PrisonAppointment): List<AppointmentSearchResult> =
     filter { searchResult ->
-      searchResult.isTimesAreTheSame(appointment) && searchResult.isAppointmentType(supportedAppointmentTypes.typeOf(appointment)) && searchResult.isCancelled.not()
+      searchResult.isTheSameTime(appointment) && searchResult.isTheSameAppointmentType(supportedAppointmentTypes.typeOf(appointment)) && searchResult.isCancelled.not()
     }.ifEmpty {
       emptyList<AppointmentSearchResult>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in A&A for prison appointment ${appointment.prisonAppointmentId}") }
@@ -182,7 +182,7 @@ class ManageExternalAppointmentsService(
 
   private fun Collection<AppointmentSearchResult>.findMatchingAppointments(bha: BookingHistoryAppointment): List<AppointmentSearchResult> =
     filter { searchResult ->
-      searchResult.isTimesAreTheSame(bha) && searchResult.isAppointmentType(supportedAppointmentTypes.typeOf(bha)) && searchResult.isCancelled.not()
+      searchResult.isTheSameTime(bha) && searchResult.isTheSameAppointmentType(supportedAppointmentTypes.typeOf(bha)) && searchResult.isCancelled.not()
     }.ifEmpty {
       emptyList<AppointmentSearchResult>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in A&A for booking history appointment ${bha.bookingHistoryAppointmentId}") }
@@ -190,7 +190,7 @@ class ManageExternalAppointmentsService(
 
   private fun Collection<PrisonerSchedule>.findMatchingPrisonApi(appointment: PrisonAppointment): List<PrisonerSchedule> =
     filter { schedule ->
-      schedule.isTimesAreTheSame(appointment) && schedule.isAppointmentType(supportedAppointmentTypes.typeOf(appointment))
+      schedule.isTheSameTime(appointment) && schedule.isTheSameAppointmentType(supportedAppointmentTypes.typeOf(appointment))
     }.ifEmpty {
       emptyList<PrisonerSchedule>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in prison-api for prison appointment ${appointment.prisonAppointmentId}") }
@@ -198,7 +198,7 @@ class ManageExternalAppointmentsService(
 
   private fun Collection<PrisonerSchedule>.findMatchingPrisonApi(bha: BookingHistoryAppointment): List<PrisonerSchedule> =
     filter { schedule ->
-      schedule.isTimesAreTheSame(bha) && schedule.isAppointmentType(supportedAppointmentTypes.typeOf(bha))
+      schedule.isTheSameTime(bha) && schedule.isTheSameAppointmentType(supportedAppointmentTypes.typeOf(bha))
     }.ifEmpty {
       emptyList<PrisonerSchedule>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in prison-api for booking history appointment ${bha.bookingHistoryAppointmentId}") }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
@@ -4,15 +4,19 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.ActivitiesAppointmentsClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.isAppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.isTimesAreTheSame
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSearchResult
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping.NomisMappingClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonApiClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonerSchedule
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Feature
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingHistoryAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
-import java.time.LocalTime
 
 /**
  * This service is responsible for create/update/cancel of appointments relating to BVLS bookings in
@@ -29,8 +33,8 @@ class ManageExternalAppointmentsService(
   private val prisonApiClient: PrisonApiClient,
   private val prisonerSearchClient: PrisonerSearchClient,
   private val nomisMappingClient: NomisMappingClient,
+  private val featureSwitches: FeatureSwitches,
 ) {
-
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
@@ -62,6 +66,7 @@ class ManageExternalAppointmentsService(
               endTime = appointment.endTime,
               internalLocationId = internalLocationId,
               comments = appointment.comments,
+              appointmentType = typeOf(appointment),
             )?.let { appointmentSeries ->
               log.info("EXTERNAL APPOINTMENTS: created activities and appointments series ${appointmentSeries.id} for prison appointment $prisonAppointmentId")
             }
@@ -87,6 +92,7 @@ class ManageExternalAppointmentsService(
               startTime = appointment.startTime,
               endTime = appointment.endTime,
               comments = appointment.comments,
+              appointmentType = typeOf(appointment),
             )?.let { event ->
               log.info("EXTERNAL APPOINTMENTS: created prison api event ${event.eventId} for prison appointment $prisonAppointmentId")
             }
@@ -169,34 +175,32 @@ class ManageExternalAppointmentsService(
   }
 
   private fun Collection<AppointmentSearchResult>.findMatchingAppointments(appointment: PrisonAppointment): List<AppointmentSearchResult> =
-    filter {
-      appointment.startTime == LocalTime.parse(it.startTime) && appointment.endTime == LocalTime.parse(it.endTime)
+    filter { searchResult ->
+      searchResult.isTimesAreTheSame(appointment) && searchResult.isAppointmentType(typeOf(appointment))
     }.ifEmpty {
       emptyList<AppointmentSearchResult>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in A&A for prison appointment ${appointment.prisonAppointmentId}") }
     }
 
   private fun Collection<AppointmentSearchResult>.findMatchingAppointments(bha: BookingHistoryAppointment): List<AppointmentSearchResult> =
-    filter {
-      bha.startTime == LocalTime.parse(it.startTime) && bha.endTime == LocalTime.parse(it.endTime)
+    filter { searchResult ->
+      searchResult.isTimesAreTheSame(bha) && searchResult.isAppointmentType(typeOf(bha))
     }.ifEmpty {
       emptyList<AppointmentSearchResult>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in A&A for booking history appointment ${bha.bookingHistoryAppointmentId}") }
     }
 
   private fun Collection<PrisonerSchedule>.findMatchingPrisonApi(appointment: PrisonAppointment): List<PrisonerSchedule> =
-    filter {
-      it.startTime == appointment.appointmentDate.atTime(appointment.startTime) &&
-        appointment.appointmentDate.atTime(appointment.endTime) == it.endTime
+    filter { schedule ->
+      schedule.isTimesAreTheSame(appointment) && schedule.isAppointmentType(typeOf(appointment))
     }.ifEmpty {
       emptyList<PrisonerSchedule>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in prison-api for prison appointment ${appointment.prisonAppointmentId}") }
     }
 
   private fun Collection<PrisonerSchedule>.findMatchingPrisonApi(bha: BookingHistoryAppointment): List<PrisonerSchedule> =
-    filter {
-      it.startTime == bha.appointmentDate.atTime(bha.startTime) &&
-        bha.appointmentDate.atTime(bha.endTime) == it.endTime
+    filter { schedule ->
+      schedule.isTimesAreTheSame(bha) && schedule.isAppointmentType(typeOf(bha))
     }.ifEmpty {
       emptyList<PrisonerSchedule>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in prison-api for booking history appointment ${bha.bookingHistoryAppointmentId}") }
@@ -215,4 +219,16 @@ class ManageExternalAppointmentsService(
   private fun BookingHistoryAppointment.internalLocationId() =
     nomisMappingClient.getNomisLocationMappingBy(prisonLocationId)?.nomisLocationId
       ?: throw NullPointerException("EXTERNAL APPOINTMENTS: Internal location id for key $prisonLocationId not found for prison appointment ${bookingHistoryAppointmentId}Id")
+
+  private fun typeOf(appointment: PrisonAppointment) =
+    when (featureSwitches.isEnabled(Feature.FEATURE_PROBATION_LIVE)) {
+      true -> AppointmentType.COURT.takeIf { appointment.videoBooking.isCourtBooking() } ?: AppointmentType.PROBATION
+      false -> AppointmentType.COURT
+    }
+
+  private fun typeOf(appointment: BookingHistoryAppointment) =
+    when (featureSwitches.isEnabled(Feature.FEATURE_PROBATION_LIVE)) {
+      true -> AppointmentType.COURT.takeIf { appointment.bookingHistory.courtId != null } ?: AppointmentType.PROBATION
+      false -> AppointmentType.COURT
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerVideoAppointmentCancelledEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerVideoAppointmentCancelledEventHandler.kt
@@ -46,7 +46,7 @@ class PrisonerVideoAppointmentCancelledEventHandler(
 
   @Transactional
   override fun handle(event: PrisonerVideoAppointmentCancelledEvent) {
-    if (supportedAppointmentTypes.isVideoLinkBooking(event.appointmentType()) && appointmentsNotManagedExternallyAt(event.prisonCode())) {
+    if (supportedAppointmentTypes.isSupported(event.appointmentType()) && appointmentsNotManagedExternallyAt(event.prisonCode())) {
       val activeAppointments = videoAppointmentRepository.findActiveVideoAppointments(
         prisonCode = event.prisonCode(),
         prisonerNumber = event.prisonerNumber(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerVideoAppointmentCancelledEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerVideoAppointmentCancelledEventHandler.kt
@@ -4,6 +4,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.ActivitiesAppointmentsClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
@@ -25,7 +26,7 @@ import java.time.LocalDateTime
  * If zero or more than one matching appointment is found then we log and ignore this event entirely.
  *
  * For A&A rolled out prisons we can safely ignore this event. Appointments cannot be changed in NOMIS for rolled out
- * prisons, the screens are disabled. However the event still gets raised on the back of syncing from A&A when we delete
+ * prisons, the screens are disabled. However, the event still gets raised on the back of syncing from A&A when we delete
  * appointments in BVLS and then in A&A.
  */
 @Component
@@ -36,6 +37,7 @@ class PrisonerVideoAppointmentCancelledEventHandler(
   private val videoBookingRepository: VideoBookingRepository,
   private val prisonAppointmentRepository: PrisonAppointmentRepository,
   private val bookingHistoryService: BookingHistoryService,
+  private val supportedAppointmentTypes: SupportedAppointmentTypes,
 ) : DomainEventHandler<PrisonerVideoAppointmentCancelledEvent> {
 
   companion object {
@@ -44,7 +46,7 @@ class PrisonerVideoAppointmentCancelledEventHandler(
 
   @Transactional
   override fun handle(event: PrisonerVideoAppointmentCancelledEvent) {
-    if (event.isVideoLinkBooking() && appointmentsNotManagedExternallyAt(event.prisonCode())) {
+    if (supportedAppointmentTypes.isVideoLinkBooking(event.appointmentType()) && appointmentsNotManagedExternallyAt(event.prisonCode())) {
       val activeAppointments = videoAppointmentRepository.findActiveVideoAppointments(
         prisonCode = event.prisonCode(),
         prisonerNumber = event.prisonerNumber(),

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -35,3 +35,5 @@ feature:
   check:
     external-availability:
       enabled: true
+  probation:
+    live: false

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -35,5 +35,6 @@ feature:
   check:
     external-availability:
       enabled: true
-  probation:
-    live: true
+  master:
+    vlpm:
+      types: true

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -35,8 +35,9 @@ feature:
   check:
     external-availability:
       enabled: true
-  probation:
-    live: false
+  master:
+    vlpm:
+      types: true
 
 hmpps.sqs:
   provider: localstack

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -36,4 +36,30 @@ feature:
     external-availability:
       enabled: true
   probation:
-    live: true
+    live: false
+
+hmpps.sqs:
+  provider: localstack
+  queues:
+    bvls:
+      queueName: bvls-queue
+      subscribeFilter: '{"eventType":[ "book-a-video-link.video-booking.created", "book-a-video-link.video-booking.amended", "book-a-video-link.video-booking.cancelled", "book-a-video-link.appointment.created", "prisoner-offender-search.prisoner.released", "prison-offender-events.prisoner.merged", "prison-offender-events.prisoner.video-appointment.cancelled"]}'
+      dlqName: bvls-dead-letter-queue
+      subscribeTopicId: domainevents
+      dlqMaxReceiveCount: 1
+      visibilityTimeout: 1
+    domaineventsqueue:
+      queueName: domainevents-queue
+      subscribeTopicId: domainevents
+    outboundtestqueue:
+      dlqName: ${random.uuid}
+      queueName: ${random.uuid}
+      subscribeTopicId: outboundtopic
+      subscribeFilter: '{"eventType":[ "test.type"] }'
+    audit:
+      queueName: ${random.uuid}
+  topics:
+    domainevents:
+      arn: arn:aws:sns:eu-west-2:000000000000:domainevents-topic
+    outboundtopic:
+      arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClientTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesapp
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.client.WebClient
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
@@ -30,7 +30,7 @@ class ActivitiesAppointmentsClientTest {
       endTime = LocalTime.MIDNIGHT.plusHours(1),
       internalLocationId = 1,
       extraInformation = "extra info",
-      appointmentType = AppointmentType.COURT,
+      appointmentType = SupportedAppointmentTypes.Type.COURT,
     )
 
     client.createAppointment(
@@ -41,7 +41,7 @@ class ActivitiesAppointmentsClientTest {
       endTime = LocalTime.MIDNIGHT.plusHours(1),
       internalLocationId = 1,
       comments = "extra info",
-      appointmentType = AppointmentType.COURT,
+      appointmentType = SupportedAppointmentTypes.Type.COURT,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClientTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesapp
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
@@ -29,6 +30,7 @@ class ActivitiesAppointmentsClientTest {
       endTime = LocalTime.MIDNIGHT.plusHours(1),
       internalLocationId = 1,
       extraInformation = "extra info",
+      appointmentType = AppointmentType.COURT,
     )
 
     client.createAppointment(
@@ -39,6 +41,7 @@ class ActivitiesAppointmentsClientTest {
       endTime = LocalTime.MIDNIGHT.plusHours(1),
       internalLocationId = 1,
       comments = "extra info",
+      appointmentType = AppointmentType.COURT,
     )
   }
 
@@ -69,21 +72,6 @@ class ActivitiesAppointmentsClientTest {
 
     appointments hasSize 2
     appointments.map { it.internalLocation?.id } containsExactlyInAnyOrder setOf(2000, 3000)
-  }
-
-  @Test
-  fun `should get no prisoner appointments at locations when not video link locations`() {
-    server.stubGetPrisonersAppointments(
-      prisonCode = BIRMINGHAM,
-      prisonerNumber = "123456",
-      date = tomorrow(),
-      locationType = "NOT_VLB",
-      locationIds = setOf(1000, 2000, 3000),
-    )
-
-    val appointments = client.getPrisonersAppointmentsAtLocations(BIRMINGHAM, "123456", tomorrow(), 1000, 2000, 3000)
-
-    appointments hasSize 0
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClientTest.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.client.WebClient
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
@@ -23,7 +23,7 @@ class PrisonApiClientTest {
   fun `should post appointment`() {
     server.stubPostCreateAppointment(
       bookingId = 1,
-      appointmentType = AppointmentType.COURT,
+      appointmentType = SupportedAppointmentTypes.Type.COURT,
       locationId = 2,
       appointmentDate = LocalDate.now(),
       startTime = LocalTime.MIDNIGHT,
@@ -36,7 +36,7 @@ class PrisonApiClientTest {
       appointmentDate = LocalDate.now(),
       startTime = LocalTime.MIDNIGHT,
       endTime = LocalTime.MIDNIGHT.plusHours(1),
-      appointmentType = AppointmentType.COURT,
+      appointmentType = SupportedAppointmentTypes.Type.COURT,
     )
 
     assertThat(response).isNotNull

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClientTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
@@ -22,7 +23,7 @@ class PrisonApiClientTest {
   fun `should post appointment`() {
     server.stubPostCreateAppointment(
       bookingId = 1,
-      appointmentType = "VLB",
+      appointmentType = AppointmentType.COURT,
       locationId = 2,
       appointmentDate = LocalDate.now(),
       startTime = LocalTime.MIDNIGHT,
@@ -35,6 +36,7 @@ class PrisonApiClientTest {
       appointmentDate = LocalDate.now(),
       startTime = LocalTime.MIDNIGHT,
       endTime = LocalTime.MIDNIGHT.plusHours(1),
+      appointmentType = AppointmentType.COURT,
     )
 
     assertThat(response).isNotNull
@@ -57,15 +59,6 @@ class PrisonApiClientTest {
 
     appointments hasSize 2
     appointments.map { it.locationId } containsExactlyInAnyOrder setOf(2000, 3000)
-  }
-
-  @Test
-  fun `should get no prisoner appointments at locations when not video link locations`() {
-    server.stubGetPrisonersAppointments(prisonCode = BIRMINGHAM, prisonerNumber = "123456", date = tomorrow(), locationType = "NOT_VLB", locationIds = setOf(1000, 2000, 3000))
-
-    val appointments = client.getPrisonersAppointmentsAtLocations(BIRMINGHAM, "123456", tomorrow(), 1000, 2000, 3000)
-
-    appointments hasSize 0
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/SupportedAppointmentTypesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/SupportedAppointmentTypesTest.kt
@@ -14,8 +14,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 
 class SupportedAppointmentTypesTest {
-  private val courtBookingType = BookingType { true }
-  private val probationBookingType = BookingType { false }
   private val featureSwitches: FeatureSwitches = mock()
   private val supportedAppointmentTypes = SupportedAppointmentTypes(featureSwitches)
 
@@ -45,8 +43,8 @@ class SupportedAppointmentTypesTest {
 
     @Test
     fun `should support court appointment type only`() {
-      supportedAppointmentTypes.typeOf(courtBookingType) isEqualTo SupportedAppointmentTypes.Type.COURT
-      supportedAppointmentTypes.typeOf(probationBookingType) isEqualTo SupportedAppointmentTypes.Type.COURT
+      supportedAppointmentTypes.typeOf(BookingType.COURT) isEqualTo SupportedAppointmentTypes.Type.COURT
+      supportedAppointmentTypes.typeOf(BookingType.PROBATION) isEqualTo SupportedAppointmentTypes.Type.COURT
     }
   }
 
@@ -70,8 +68,8 @@ class SupportedAppointmentTypesTest {
 
     @Test
     fun `should support court and probation appointment type`() {
-      supportedAppointmentTypes.typeOf(courtBookingType) isEqualTo SupportedAppointmentTypes.Type.COURT
-      supportedAppointmentTypes.typeOf(probationBookingType) isEqualTo SupportedAppointmentTypes.Type.PROBATION
+      supportedAppointmentTypes.typeOf(BookingType.COURT) isEqualTo SupportedAppointmentTypes.Type.COURT
+      supportedAppointmentTypes.typeOf(BookingType.PROBATION) isEqualTo SupportedAppointmentTypes.Type.PROBATION
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/SupportedAppointmentTypesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/SupportedAppointmentTypesTest.kt
@@ -1,0 +1,77 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Feature
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+
+class SupportedAppointmentTypesTest {
+  private val courtBookingType = BookingType { true }
+  private val probationBookingType = BookingType { false }
+  private val featureSwitches: FeatureSwitches = mock()
+  private val supportedAppointmentTypes = SupportedAppointmentTypes(featureSwitches)
+
+  @Test
+  fun `should match on appointment types`() {
+    SupportedAppointmentTypes.Type.COURT.code isEqualTo "VLB"
+    SupportedAppointmentTypes.Type.PROBATION.code isEqualTo "VLPM"
+  }
+
+  @Nested
+  @DisplayName("VLPM feature toggle off")
+  inner class ToggleOff {
+    @BeforeEach
+    fun before() {
+      whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn false
+    }
+
+    @Test
+    fun `should support VLB appointment type`() {
+      supportedAppointmentTypes.isSupported("VLB") isBool true
+    }
+
+    @Test
+    fun `should not support VLPM appointment type`() {
+      supportedAppointmentTypes.isSupported("VLPM") isBool false
+    }
+
+    @Test
+    fun `should support court appointment type only`() {
+      supportedAppointmentTypes.typeOf(courtBookingType) isEqualTo SupportedAppointmentTypes.Type.COURT
+      supportedAppointmentTypes.typeOf(probationBookingType) isEqualTo SupportedAppointmentTypes.Type.COURT
+    }
+  }
+
+  @Nested
+  @DisplayName("VLPM feature toggle on")
+  inner class ToggleOn {
+    @BeforeEach
+    fun before() {
+      whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn true
+    }
+
+    @Test
+    fun `should support VLB appointment type`() {
+      supportedAppointmentTypes.isSupported("VLB") isBool true
+    }
+
+    @Test
+    fun `should support VLPM appointment type`() {
+      supportedAppointmentTypes.isSupported("VLPM") isBool true
+    }
+
+    @Test
+    fun `should support court and probation appointment type`() {
+      supportedAppointmentTypes.typeOf(courtBookingType) isEqualTo SupportedAppointmentTypes.Type.COURT
+      supportedAppointmentTypes.typeOf(probationBookingType) isEqualTo SupportedAppointmentTypes.Type.PROBATION
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/config/FeatureSwitchesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/config/FeatureSwitchesTest.kt
@@ -23,7 +23,7 @@ class FeatureSwitchesTest : IntegrationTestBase() {
   @MockBean
   private lateinit var listener: InboundEventsListener
 
-  @TestPropertySource(properties = ["feature.probation.live=true"])
+  @TestPropertySource(properties = ["feature.master.vlpm.types=true"])
   @Nested
   @DisplayName("Features are enabled when set")
   inner class EnabledFeatures(@Autowired val featureSwitches: FeatureSwitches) {
@@ -51,7 +51,7 @@ class FeatureSwitchesTest : IntegrationTestBase() {
   inner class DefaultedFeatures(@Autowired val featureSwitches: FeatureSwitches) {
     @Test
     fun `different feature types can be defaulted `() {
-      featureSwitches.isEnabled(Feature.FEATURE_PROBATION_LIVE, true) isBool true
+      featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES, true) isBool true
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/config/FeatureSwitchesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/config/FeatureSwitchesTest.kt
@@ -9,6 +9,7 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.TestPropertySource
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Feature
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.InboundEventsListener
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
@@ -22,7 +23,7 @@ class FeatureSwitchesTest : IntegrationTestBase() {
   @MockBean
   private lateinit var listener: InboundEventsListener
 
-  @TestPropertySource(properties = ["feature.enabled=true"])
+  @TestPropertySource(properties = ["feature.probation.live=true"])
   @Nested
   @DisplayName("Features are enabled when set")
   inner class EnabledFeatures(@Autowired val featureSwitches: FeatureSwitches) {
@@ -42,6 +43,15 @@ class FeatureSwitchesTest : IntegrationTestBase() {
       Feature.entries.forEach {
         assertThat(featureSwitches.isEnabled(it)).withFailMessage("${it.label} enabled").isFalse
       }
+    }
+  }
+
+  @Nested
+  @DisplayName("Features can be defaulted when not present")
+  inner class DefaultedFeatures(@Autowired val featureSwitches: FeatureSwitches) {
+    @Test
+    fun `different feature types can be defaulted `() {
+      featureSwitches.isEnabled(Feature.FEATURE_PROBATION_LIVE, true) isBool true
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ActivitiesAppointmentsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ActivitiesAppointmentsApiMockServer.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeries
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeriesCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.RolloutPrisonPlan
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toHourMinuteStyle
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import java.time.LocalDate
@@ -34,7 +34,7 @@ class ActivitiesAppointmentsApiMockServer : MockServer(8089) {
     endTime: LocalTime,
     internalLocationId: Long,
     extraInformation: String,
-    appointmentType: AppointmentType,
+    appointmentType: SupportedAppointmentTypes.Type,
   ) {
     val request = AppointmentSeriesCreateRequest(
       appointmentType = AppointmentSeriesCreateRequest.AppointmentType.INDIVIDUAL,
@@ -106,7 +106,7 @@ class ActivitiesAppointmentsApiMockServer : MockServer(8089) {
     prisonCode: String,
     prisonerNumber: String,
     date: LocalDate,
-    appointmentType: AppointmentType = AppointmentType.COURT,
+    appointmentType: SupportedAppointmentTypes.Type = SupportedAppointmentTypes.Type.COURT,
     locationIds: Set<Long> = setOf(-1),
   ) {
     val appointments = locationIds.map { locationId ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ActivitiesAppointmentsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ActivitiesAppointmentsApiMockServer.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.VIDEO_LINK_BOOKING
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.Appointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentAttendee
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentAttendeeSearchResult
@@ -18,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeries
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSeriesCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.RolloutPrisonPlan
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toHourMinuteStyle
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import java.time.LocalDate
@@ -34,12 +34,13 @@ class ActivitiesAppointmentsApiMockServer : MockServer(8089) {
     endTime: LocalTime,
     internalLocationId: Long,
     extraInformation: String,
+    appointmentType: AppointmentType,
   ) {
     val request = AppointmentSeriesCreateRequest(
       appointmentType = AppointmentSeriesCreateRequest.AppointmentType.INDIVIDUAL,
       prisonCode = prisonCode,
       prisonerNumbers = listOf(prisonerNumber),
-      categoryCode = VIDEO_LINK_BOOKING,
+      categoryCode = appointmentType.code,
       tierCode = AppointmentSeriesCreateRequest.TierCode.TIER_1,
       inCell = false,
       startDate = startDate,
@@ -105,7 +106,7 @@ class ActivitiesAppointmentsApiMockServer : MockServer(8089) {
     prisonCode: String,
     prisonerNumber: String,
     date: LocalDate,
-    locationType: String = VIDEO_LINK_BOOKING,
+    appointmentType: AppointmentType = AppointmentType.COURT,
     locationIds: Set<Long> = setOf(-1),
   ) {
     val appointments = locationIds.map { locationId ->
@@ -121,7 +122,7 @@ class ActivitiesAppointmentsApiMockServer : MockServer(8089) {
         appointmentSeriesId = 1,
         appointmentName = "appointment name",
         attendees = listOf(AppointmentAttendeeSearchResult(1, prisonerNumber, 1)),
-        category = AppointmentCategorySummary(locationType, "video link booking"),
+        category = AppointmentCategorySummary(appointmentType.code, appointmentType.name),
         inCell = false,
         isRepeat = false,
         maxSequenceNumber = 1,
@@ -140,7 +141,6 @@ class ActivitiesAppointmentsApiMockServer : MockServer(8089) {
               AppointmentSearchRequest(
                 appointmentType = AppointmentSearchRequest.AppointmentType.INDIVIDUAL,
                 startDate = date,
-                categoryCode = VIDEO_LINK_BOOKING,
                 prisonerNumbers = listOf(prisonerNumber),
               ),
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.ExtensionContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonerSchedule
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.ScheduledEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.NewAppointment
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDate
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import java.time.LocalDate
@@ -19,7 +19,7 @@ class PrisonApiMockServer : MockServer(8094) {
 
   fun stubPostCreateAppointment(
     bookingId: Long,
-    appointmentType: AppointmentType,
+    appointmentType: SupportedAppointmentTypes.Type,
     locationId: Long,
     appointmentDate: LocalDate,
     startTime: LocalTime,
@@ -56,7 +56,7 @@ class PrisonApiMockServer : MockServer(8094) {
     prisonCode: String,
     prisonerNumber: String,
     date: LocalDate,
-    appointmentType: AppointmentType = AppointmentType.COURT,
+    appointmentType: SupportedAppointmentTypes.Type = SupportedAppointmentTypes.Type.COURT,
     locationIds: Set<Long> = setOf(-1),
   ) {
     val locations = locationIds.map { locationId ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonerSchedule
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.ScheduledEvent
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.VIDEO_LINK_BOOKING
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.NewAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDate
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import java.time.LocalDate
@@ -19,7 +19,7 @@ class PrisonApiMockServer : MockServer(8094) {
 
   fun stubPostCreateAppointment(
     bookingId: Long,
-    appointmentType: String,
+    appointmentType: AppointmentType,
     locationId: Long,
     appointmentDate: LocalDate,
     startTime: LocalTime,
@@ -32,7 +32,7 @@ class PrisonApiMockServer : MockServer(8094) {
           WireMock.equalToJson(
             mapper.writeValueAsString(
               NewAppointment(
-                appointmentType = appointmentType,
+                appointmentType = appointmentType.code,
                 locationId = locationId,
                 startTime = appointmentDate.atTime(startTime).toIsoDateTime(),
                 endTime = appointmentDate.atTime(endTime).toIsoDateTime(),
@@ -56,7 +56,7 @@ class PrisonApiMockServer : MockServer(8094) {
     prisonCode: String,
     prisonerNumber: String,
     date: LocalDate,
-    locationType: String = VIDEO_LINK_BOOKING,
+    appointmentType: AppointmentType = AppointmentType.COURT,
     locationIds: Set<Long> = setOf(-1),
   ) {
     val locations = locationIds.map { locationId ->
@@ -65,7 +65,7 @@ class PrisonApiMockServer : MockServer(8094) {
         locationId = locationId,
         firstName = "JOHN",
         lastName = "DOE",
-        event = locationType,
+        event = appointmentType.code,
         startTime = date.atStartOfDay(),
         endTime = date.atStartOfDay().plusHours(1),
         eventId = 1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsServiceTest.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.Pris
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonerSchedule
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerSearchClient
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toHourMinuteStyle
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Feature
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
@@ -52,6 +52,7 @@ class ManageExternalAppointmentsServiceTest {
   private val prisonerSearchClient: PrisonerSearchClient = mock()
   private val nomisMappingClient: NomisMappingClient = mock()
   private val featureSwitches: FeatureSwitches = mock()
+  private val supportedAppointmentTypes = SupportedAppointmentTypes(featureSwitches)
   private val birminghamLocation = Location(
     locationId = 123456,
     locationType = "VLB",
@@ -88,7 +89,7 @@ class ManageExternalAppointmentsServiceTest {
       prisonApiClient,
       prisonerSearchClient,
       nomisMappingClient,
-      featureSwitches,
+      supportedAppointmentTypes,
     )
 
   @Nested
@@ -117,7 +118,7 @@ class ManageExternalAppointmentsServiceTest {
         endTime = LocalTime.of(11, 30),
         internalLocationId = 123456,
         comments = "Court hearing comments",
-        appointmentType = AppointmentType.COURT,
+        appointmentType = SupportedAppointmentTypes.Type.COURT,
       )
     }
 
@@ -150,7 +151,7 @@ class ManageExternalAppointmentsServiceTest {
         endTime = LocalTime.of(11, 30),
         internalLocationId = 123456,
         comments = null,
-        appointmentType = AppointmentType.COURT,
+        appointmentType = SupportedAppointmentTypes.Type.COURT,
       )
     }
 
@@ -285,7 +286,7 @@ class ManageExternalAppointmentsServiceTest {
         startTime = LocalTime.of(11, 0),
         endTime = LocalTime.of(11, 30),
         comments = "Court hearing comments",
-        appointmentType = AppointmentType.COURT,
+        appointmentType = SupportedAppointmentTypes.Type.COURT,
       )
     }
 
@@ -321,7 +322,7 @@ class ManageExternalAppointmentsServiceTest {
         startTime = LocalTime.of(11, 0),
         endTime = LocalTime.of(11, 30),
         comments = null,
-        appointmentType = AppointmentType.COURT,
+        appointmentType = SupportedAppointmentTypes.Type.COURT,
       )
     }
 
@@ -346,7 +347,7 @@ class ManageExternalAppointmentsServiceTest {
         startTime = LocalTime.of(11, 0),
         endTime = LocalTime.of(11, 30),
         comments = "Probation meeting comments",
-        appointmentType = AppointmentType.COURT,
+        appointmentType = SupportedAppointmentTypes.Type.COURT,
       )
     }
 
@@ -371,7 +372,7 @@ class ManageExternalAppointmentsServiceTest {
         startTime = LocalTime.of(11, 0),
         endTime = LocalTime.of(11, 30),
         comments = "Probation meeting comments",
-        appointmentType = AppointmentType.COURT,
+        appointmentType = SupportedAppointmentTypes.Type.COURT,
       )
     }
   }
@@ -402,7 +403,7 @@ class ManageExternalAppointmentsServiceTest {
         endTime = LocalTime.of(11, 30),
         internalLocationId = 123456,
         comments = "Court hearing comments",
-        appointmentType = AppointmentType.COURT,
+        appointmentType = SupportedAppointmentTypes.Type.COURT,
       )
     }
 
@@ -427,7 +428,7 @@ class ManageExternalAppointmentsServiceTest {
         startTime = LocalTime.of(11, 0),
         endTime = LocalTime.of(11, 30),
         comments = "Court hearing comments",
-        appointmentType = AppointmentType.COURT,
+        appointmentType = SupportedAppointmentTypes.Type.COURT,
       )
     }
 
@@ -452,7 +453,7 @@ class ManageExternalAppointmentsServiceTest {
         startTime = LocalTime.of(11, 0),
         endTime = LocalTime.of(11, 30),
         comments = "Probation meeting comments",
-        appointmentType = AppointmentType.PROBATION,
+        appointmentType = SupportedAppointmentTypes.Type.PROBATION,
       )
     }
 
@@ -477,7 +478,7 @@ class ManageExternalAppointmentsServiceTest {
         startTime = LocalTime.of(11, 0),
         endTime = LocalTime.of(11, 30),
         comments = "Probation meeting comments",
-        appointmentType = AppointmentType.PROBATION,
+        appointmentType = SupportedAppointmentTypes.Type.PROBATION,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsServiceTest.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events
 
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.kotlin.any
@@ -22,7 +25,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.Pris
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonerSchedule
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toHourMinuteStyle
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Feature
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingHistory
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingHistoryAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
@@ -45,6 +51,7 @@ class ManageExternalAppointmentsServiceTest {
   private val prisonApiClient: PrisonApiClient = mock()
   private val prisonerSearchClient: PrisonerSearchClient = mock()
   private val nomisMappingClient: NomisMappingClient = mock()
+  private val featureSwitches: FeatureSwitches = mock()
   private val birminghamLocation = Location(
     locationId = 123456,
     locationType = "VLB",
@@ -81,198 +88,347 @@ class ManageExternalAppointmentsServiceTest {
       prisonApiClient,
       prisonerSearchClient,
       nomisMappingClient,
+      featureSwitches,
     )
 
-  @Test
-  fun `should create court appointment via activities client when appointments rolled out`() {
-    whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(courtAppointment)
-    whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn true
-    whenever(nomisMappingClient.getNomisLocationMappingBy(courtAppointment.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = birminghamLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
+  @Nested
+  @DisplayName("Map correct appointment type for bookings when probation feature is not live")
+  inner class MapCourtAppointmentType {
+    @BeforeEach
+    fun before() {
+      whenever(featureSwitches.isEnabled(Feature.FEATURE_PROBATION_LIVE)) doReturn false
+    }
 
-    service.createAppointment(1)
+    @Test
+    fun `should create court appointment via activities client when appointments rolled out`() {
+      whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(courtAppointment)
+      whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn true
+      whenever(nomisMappingClient.getNomisLocationMappingBy(courtAppointment.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = birminghamLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
 
-    verify(nomisMappingClient).getNomisLocationMappingBy(courtAppointment.prisonLocationId)
+      service.createAppointment(1)
 
-    verify(activitiesAppointmentsClient).createAppointment(
-      prisonCode = BIRMINGHAM,
-      prisonerNumber = "123456",
-      startDate = LocalDate.of(2100, 1, 1),
-      startTime = LocalTime.of(11, 0),
-      endTime = LocalTime.of(11, 30),
-      internalLocationId = 123456,
-      comments = "Court hearing comments",
-    )
-  }
-
-  @Test
-  fun `should create court appointment without comments via activities client when appointments rolled out`() {
-    val courtAppointmentWithoutComments = appointment(
-      booking = courtBooking.apply { comments = null },
-      prisonCode = BIRMINGHAM,
-      prisonerNumber = "123456",
-      appointmentType = "VLB_COURT_PRE",
-      date = LocalDate.of(2100, 1, 1),
-      startTime = LocalTime.of(11, 0),
-      endTime = LocalTime.of(11, 30),
-      locationId = UUID.randomUUID(),
-    )
-
-    whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(courtAppointmentWithoutComments)
-    whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn true
-    whenever(nomisMappingClient.getNomisLocationMappingBy(courtAppointmentWithoutComments.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = birminghamLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
-
-    service.createAppointment(1)
-
-    verify(nomisMappingClient).getNomisLocationMappingBy(courtAppointmentWithoutComments.prisonLocationId)
-
-    verify(activitiesAppointmentsClient).createAppointment(
-      prisonCode = BIRMINGHAM,
-      prisonerNumber = "123456",
-      startDate = LocalDate.of(2100, 1, 1),
-      startTime = LocalTime.of(11, 0),
-      endTime = LocalTime.of(11, 30),
-      internalLocationId = 123456,
-      comments = null,
-    )
-  }
-
-  @Test
-  fun `should not create court appointment via activities client when appointment already exists`() {
-    whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(courtAppointment)
-    whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn true
-    whenever(nomisMappingClient.getNomisLocationMappingBy(courtAppointment.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = birminghamLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
-    whenever(
-      activitiesAppointmentsClient.getPrisonersAppointmentsAtLocations(
-        prisonCode = courtAppointment.prisonCode(),
-        prisonerNumber = courtAppointment.prisonerNumber,
-        onDate = courtAppointment.appointmentDate,
-        birminghamLocation.locationId,
-      ),
-    ) doReturn listOf(
-      AppointmentSearchResult(
-        appointmentType = AppointmentSearchResult.AppointmentType.INDIVIDUAL,
-        startDate = courtAppointment.appointmentDate,
-        startTime = courtAppointment.startTime.toHourMinuteStyle(),
-        endTime = courtAppointment.endTime.toHourMinuteStyle(),
-        isCancelled = false,
-        isExpired = false,
-        isEdited = false,
-        appointmentId = 99,
-        appointmentSeriesId = 1,
-        appointmentName = "appointment name",
-        attendees = listOf(AppointmentAttendeeSearchResult(1, courtAppointment.prisonerNumber, 1)),
-        category = AppointmentCategorySummary("VLB", "video link booking"),
-        inCell = false,
-        isRepeat = false,
-        maxSequenceNumber = 1,
-        prisonCode = courtAppointment.prisonCode(),
-        sequenceNumber = 1,
-        internalLocation = AppointmentLocationSummary(
-          birminghamLocation.locationId,
-          courtAppointment.prisonCode(),
-          "VIDEO LINK",
-        ),
-        timeSlot = AppointmentSearchResult.TimeSlot.AM,
-      ),
-    )
-
-    service.createAppointment(1)
-
-    inOrder(nomisMappingClient, activitiesAppointmentsClient) {
       verify(nomisMappingClient).getNomisLocationMappingBy(courtAppointment.prisonLocationId)
-      verify(activitiesAppointmentsClient).getPrisonersAppointmentsAtLocations(
-        prisonCode = courtAppointment.prisonCode(),
-        prisonerNumber = courtAppointment.prisonerNumber,
-        onDate = courtAppointment.appointmentDate,
-        birminghamLocation.locationId,
+
+      verify(activitiesAppointmentsClient).createAppointment(
+        prisonCode = BIRMINGHAM,
+        prisonerNumber = "123456",
+        startDate = LocalDate.of(2100, 1, 1),
+        startTime = LocalTime.of(11, 0),
+        endTime = LocalTime.of(11, 30),
+        internalLocationId = 123456,
+        comments = "Court hearing comments",
+        appointmentType = AppointmentType.COURT,
       )
     }
 
-    verify(activitiesAppointmentsClient, never()).createAppointment(any(), any(), any(), any(), any(), any(), any())
+    @Test
+    fun `should create court appointment without comments via activities client when appointments rolled out`() {
+      val courtAppointmentWithoutComments = appointment(
+        booking = courtBooking.apply { comments = null },
+        prisonCode = BIRMINGHAM,
+        prisonerNumber = "123456",
+        appointmentType = "VLB_COURT_PRE",
+        date = LocalDate.of(2100, 1, 1),
+        startTime = LocalTime.of(11, 0),
+        endTime = LocalTime.of(11, 30),
+        locationId = UUID.randomUUID(),
+      )
+
+      whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(courtAppointmentWithoutComments)
+      whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn true
+      whenever(nomisMappingClient.getNomisLocationMappingBy(courtAppointmentWithoutComments.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = birminghamLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
+
+      service.createAppointment(1)
+
+      verify(nomisMappingClient).getNomisLocationMappingBy(courtAppointmentWithoutComments.prisonLocationId)
+
+      verify(activitiesAppointmentsClient).createAppointment(
+        prisonCode = BIRMINGHAM,
+        prisonerNumber = "123456",
+        startDate = LocalDate.of(2100, 1, 1),
+        startTime = LocalTime.of(11, 0),
+        endTime = LocalTime.of(11, 30),
+        internalLocationId = 123456,
+        comments = null,
+        appointmentType = AppointmentType.COURT,
+      )
+    }
+
+    @Test
+    fun `should not create court appointment via activities client when appointment already exists`() {
+      whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(courtAppointment)
+      whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn true
+      whenever(nomisMappingClient.getNomisLocationMappingBy(courtAppointment.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = birminghamLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
+      whenever(
+        activitiesAppointmentsClient.getPrisonersAppointmentsAtLocations(
+          prisonCode = courtAppointment.prisonCode(),
+          prisonerNumber = courtAppointment.prisonerNumber,
+          onDate = courtAppointment.appointmentDate,
+          birminghamLocation.locationId,
+        ),
+      ) doReturn listOf(
+        AppointmentSearchResult(
+          appointmentType = AppointmentSearchResult.AppointmentType.INDIVIDUAL,
+          startDate = courtAppointment.appointmentDate,
+          startTime = courtAppointment.startTime.toHourMinuteStyle(),
+          endTime = courtAppointment.endTime.toHourMinuteStyle(),
+          isCancelled = false,
+          isExpired = false,
+          isEdited = false,
+          appointmentId = 99,
+          appointmentSeriesId = 1,
+          appointmentName = "appointment name",
+          attendees = listOf(AppointmentAttendeeSearchResult(1, courtAppointment.prisonerNumber, 1)),
+          category = AppointmentCategorySummary("VLB", "video link booking"),
+          inCell = false,
+          isRepeat = false,
+          maxSequenceNumber = 1,
+          prisonCode = courtAppointment.prisonCode(),
+          sequenceNumber = 1,
+          internalLocation = AppointmentLocationSummary(
+            birminghamLocation.locationId,
+            courtAppointment.prisonCode(),
+            "VIDEO LINK",
+          ),
+          timeSlot = AppointmentSearchResult.TimeSlot.AM,
+        ),
+      )
+
+      service.createAppointment(1)
+
+      inOrder(nomisMappingClient, activitiesAppointmentsClient) {
+        verify(nomisMappingClient).getNomisLocationMappingBy(courtAppointment.prisonLocationId)
+        verify(activitiesAppointmentsClient).getPrisonersAppointmentsAtLocations(
+          prisonCode = courtAppointment.prisonCode(),
+          prisonerNumber = courtAppointment.prisonerNumber,
+          onDate = courtAppointment.appointmentDate,
+          birminghamLocation.locationId,
+        )
+      }
+
+      verify(activitiesAppointmentsClient, never()).createAppointment(any(), any(), any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `should create court appointment via prison api client when appointments not rolled out`() {
+      whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(courtAppointment)
+      whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn false
+      whenever(prisonerSearchClient.getPrisoner(courtAppointment.prisonerNumber)) doReturn prisonerSearchPrisoner(
+        prisonerNumber = courtAppointment.prisonerNumber,
+        prisonCode = courtAppointment.prisonCode(),
+        bookingId = 1,
+      )
+      whenever(nomisMappingClient.getNomisLocationMappingBy(courtAppointment.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = birminghamLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
+
+      service.createAppointment(1)
+
+      verify(activitiesAppointmentsClient, never()).createAppointment(any(), any(), any(), any(), any(), any(), any(), any())
+      verify(prisonApiClient).createAppointment(
+        bookingId = 1,
+        locationId = 123456,
+        appointmentDate = LocalDate.of(2100, 1, 1),
+        startTime = LocalTime.of(11, 0),
+        endTime = LocalTime.of(11, 30),
+        comments = "Court hearing comments",
+        appointmentType = AppointmentType.COURT,
+      )
+    }
+
+    @Test
+    fun `should create court appointment without comments via prison api client when appointments not rolled out`() {
+      val courtAppointmentWithoutComments = appointment(
+        booking = courtBooking.apply { comments = null },
+        prisonCode = BIRMINGHAM,
+        prisonerNumber = "123456",
+        appointmentType = "VLB_COURT_PRE",
+        date = LocalDate.of(2100, 1, 1),
+        startTime = LocalTime.of(11, 0),
+        endTime = LocalTime.of(11, 30),
+        locationId = UUID.randomUUID(),
+      )
+
+      whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(courtAppointmentWithoutComments)
+      whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn false
+      whenever(prisonerSearchClient.getPrisoner(courtAppointment.prisonerNumber)) doReturn prisonerSearchPrisoner(
+        prisonerNumber = courtAppointment.prisonerNumber,
+        prisonCode = courtAppointment.prisonCode(),
+        bookingId = 1,
+      )
+      whenever(nomisMappingClient.getNomisLocationMappingBy(courtAppointmentWithoutComments.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = birminghamLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
+
+      service.createAppointment(1)
+
+      verify(activitiesAppointmentsClient, never()).createAppointment(any(), any(), any(), any(), any(), any(), any(), any())
+      verify(prisonApiClient).createAppointment(
+        bookingId = 1,
+        locationId = 123456,
+        appointmentDate = LocalDate.of(2100, 1, 1),
+        startTime = LocalTime.of(11, 0),
+        endTime = LocalTime.of(11, 30),
+        comments = null,
+        appointmentType = AppointmentType.COURT,
+      )
+    }
+
+    @Test
+    fun `should create probation appointment via prison api client when appointments not rolled out`() {
+      whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(probationAppointment)
+      whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(WANDSWORTH)) doReturn false
+      whenever(prisonerSearchClient.getPrisoner(probationAppointment.prisonerNumber)) doReturn prisonerSearchPrisoner(
+        prisonerNumber = probationAppointment.prisonerNumber,
+        prisonCode = probationAppointment.prisonCode(),
+        bookingId = 1,
+      )
+      whenever(nomisMappingClient.getNomisLocationMappingBy(probationAppointment.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = wandsworthLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
+
+      service.createAppointment(1)
+
+      verify(activitiesAppointmentsClient, never()).createAppointment(any(), any(), any(), any(), any(), any(), any(), any())
+      verify(prisonApiClient).createAppointment(
+        bookingId = 1,
+        locationId = 123456,
+        appointmentDate = LocalDate.of(2100, 1, 1),
+        startTime = LocalTime.of(11, 0),
+        endTime = LocalTime.of(11, 30),
+        comments = "Probation meeting comments",
+        appointmentType = AppointmentType.COURT,
+      )
+    }
+
+    @Test
+    fun `should create probation appointment via activities api client when appointments rolled out`() {
+      whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(probationAppointment)
+      whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(WANDSWORTH)) doReturn false
+      whenever(prisonerSearchClient.getPrisoner(probationAppointment.prisonerNumber)) doReturn prisonerSearchPrisoner(
+        prisonerNumber = probationAppointment.prisonerNumber,
+        prisonCode = probationAppointment.prisonCode(),
+        bookingId = 1,
+      )
+      whenever(nomisMappingClient.getNomisLocationMappingBy(probationAppointment.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = wandsworthLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
+
+      service.createAppointment(1)
+
+      verify(activitiesAppointmentsClient, never()).createAppointment(any(), any(), any(), any(), any(), any(), any(), any())
+      verify(prisonApiClient).createAppointment(
+        bookingId = 1,
+        locationId = 123456,
+        appointmentDate = LocalDate.of(2100, 1, 1),
+        startTime = LocalTime.of(11, 0),
+        endTime = LocalTime.of(11, 30),
+        comments = "Probation meeting comments",
+        appointmentType = AppointmentType.COURT,
+      )
+    }
+  }
+
+  @Nested
+  @DisplayName("Map correct appointment type for bookings when probation feature is live")
+  inner class MapCourtAndProbationAppointmentType {
+    @BeforeEach
+    fun before() {
+      whenever(featureSwitches.isEnabled(Feature.FEATURE_PROBATION_LIVE)) doReturn true
+    }
+
+    @Test
+    fun `should create court appointment via activities client when appointments rolled out`() {
+      whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(courtAppointment)
+      whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn true
+      whenever(nomisMappingClient.getNomisLocationMappingBy(courtAppointment.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = birminghamLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
+
+      service.createAppointment(1)
+
+      verify(nomisMappingClient).getNomisLocationMappingBy(courtAppointment.prisonLocationId)
+
+      verify(activitiesAppointmentsClient).createAppointment(
+        prisonCode = BIRMINGHAM,
+        prisonerNumber = "123456",
+        startDate = LocalDate.of(2100, 1, 1),
+        startTime = LocalTime.of(11, 0),
+        endTime = LocalTime.of(11, 30),
+        internalLocationId = 123456,
+        comments = "Court hearing comments",
+        appointmentType = AppointmentType.COURT,
+      )
+    }
+
+    @Test
+    fun `should create court appointment via prison api client when appointments not rolled out`() {
+      whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(courtAppointment)
+      whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn false
+      whenever(prisonerSearchClient.getPrisoner(courtAppointment.prisonerNumber)) doReturn prisonerSearchPrisoner(
+        prisonerNumber = courtAppointment.prisonerNumber,
+        prisonCode = courtAppointment.prisonCode(),
+        bookingId = 1,
+      )
+      whenever(nomisMappingClient.getNomisLocationMappingBy(courtAppointment.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = birminghamLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
+
+      service.createAppointment(1)
+
+      verify(activitiesAppointmentsClient, never()).createAppointment(any(), any(), any(), any(), any(), any(), any(), any())
+      verify(prisonApiClient).createAppointment(
+        bookingId = 1,
+        locationId = 123456,
+        appointmentDate = LocalDate.of(2100, 1, 1),
+        startTime = LocalTime.of(11, 0),
+        endTime = LocalTime.of(11, 30),
+        comments = "Court hearing comments",
+        appointmentType = AppointmentType.COURT,
+      )
+    }
+
+    @Test
+    fun `should create probation appointment via prison api client when appointments not rolled out`() {
+      whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(probationAppointment)
+      whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(WANDSWORTH)) doReturn false
+      whenever(prisonerSearchClient.getPrisoner(probationAppointment.prisonerNumber)) doReturn prisonerSearchPrisoner(
+        prisonerNumber = probationAppointment.prisonerNumber,
+        prisonCode = probationAppointment.prisonCode(),
+        bookingId = 1,
+      )
+      whenever(nomisMappingClient.getNomisLocationMappingBy(probationAppointment.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = wandsworthLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
+
+      service.createAppointment(1)
+
+      verify(activitiesAppointmentsClient, never()).createAppointment(any(), any(), any(), any(), any(), any(), any(), any())
+      verify(prisonApiClient).createAppointment(
+        bookingId = 1,
+        locationId = 123456,
+        appointmentDate = LocalDate.of(2100, 1, 1),
+        startTime = LocalTime.of(11, 0),
+        endTime = LocalTime.of(11, 30),
+        comments = "Probation meeting comments",
+        appointmentType = AppointmentType.PROBATION,
+      )
+    }
+
+    @Test
+    fun `should create probation appointment via activities api client when appointments rolled out`() {
+      whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(probationAppointment)
+      whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(WANDSWORTH)) doReturn false
+      whenever(prisonerSearchClient.getPrisoner(probationAppointment.prisonerNumber)) doReturn prisonerSearchPrisoner(
+        prisonerNumber = probationAppointment.prisonerNumber,
+        prisonCode = probationAppointment.prisonCode(),
+        bookingId = 1,
+      )
+      whenever(nomisMappingClient.getNomisLocationMappingBy(probationAppointment.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = wandsworthLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
+
+      service.createAppointment(1)
+
+      verify(activitiesAppointmentsClient, never()).createAppointment(any(), any(), any(), any(), any(), any(), any(), any())
+      verify(prisonApiClient).createAppointment(
+        bookingId = 1,
+        locationId = 123456,
+        appointmentDate = LocalDate.of(2100, 1, 1),
+        startTime = LocalTime.of(11, 0),
+        endTime = LocalTime.of(11, 30),
+        comments = "Probation meeting comments",
+        appointmentType = AppointmentType.PROBATION,
+      )
+    }
   }
 
   @Test
-  fun `should create probation appointment via activities client when appointments rolled out`() {
-    whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(probationAppointment)
-    whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(WANDSWORTH)) doReturn true
-    whenever(nomisMappingClient.getNomisLocationMappingBy(probationAppointment.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = wandsworthLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
-
-    service.createAppointment(1)
-
-    verify(nomisMappingClient).getNomisLocationMappingBy(probationAppointment.prisonLocationId)
-
-    verify(activitiesAppointmentsClient).createAppointment(
-      prisonCode = WANDSWORTH,
-      prisonerNumber = "654321",
-      startDate = LocalDate.of(2100, 1, 1),
-      startTime = LocalTime.of(11, 0),
-      endTime = LocalTime.of(11, 30),
-      internalLocationId = 123456,
-      comments = "Probation meeting comments",
-    )
-  }
-
-  @Test
-  fun `should create court appointment via prison api client when appointments not rolled out`() {
-    whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(courtAppointment)
-    whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn false
-    whenever(prisonerSearchClient.getPrisoner(courtAppointment.prisonerNumber)) doReturn prisonerSearchPrisoner(
-      prisonerNumber = courtAppointment.prisonerNumber,
-      prisonCode = courtAppointment.prisonCode(),
-      bookingId = 1,
-    )
-    whenever(nomisMappingClient.getNomisLocationMappingBy(courtAppointment.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = birminghamLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
-
-    service.createAppointment(1)
-
-    verify(activitiesAppointmentsClient, never()).createAppointment(any(), any(), any(), any(), any(), any(), any())
-    verify(prisonApiClient).createAppointment(
-      bookingId = 1,
-      locationId = 123456,
-      appointmentDate = LocalDate.of(2100, 1, 1),
-      startTime = LocalTime.of(11, 0),
-      endTime = LocalTime.of(11, 30),
-      comments = "Court hearing comments",
-    )
-  }
-
-  @Test
-  fun `should create court appointment without comments via prison api client when appointments not rolled out`() {
-    val courtAppointmentWithoutComments = appointment(
-      booking = courtBooking.apply { comments = null },
-      prisonCode = BIRMINGHAM,
-      prisonerNumber = "123456",
-      appointmentType = "VLB_COURT_PRE",
-      date = LocalDate.of(2100, 1, 1),
-      startTime = LocalTime.of(11, 0),
-      endTime = LocalTime.of(11, 30),
-      locationId = UUID.randomUUID(),
-    )
-
-    whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(courtAppointmentWithoutComments)
-    whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn false
-    whenever(prisonerSearchClient.getPrisoner(courtAppointment.prisonerNumber)) doReturn prisonerSearchPrisoner(
-      prisonerNumber = courtAppointment.prisonerNumber,
-      prisonCode = courtAppointment.prisonCode(),
-      bookingId = 1,
-    )
-    whenever(nomisMappingClient.getNomisLocationMappingBy(courtAppointmentWithoutComments.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = birminghamLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
-
-    service.createAppointment(1)
-
-    verify(activitiesAppointmentsClient, never()).createAppointment(any(), any(), any(), any(), any(), any(), any())
-    verify(prisonApiClient).createAppointment(
-      bookingId = 1,
-      locationId = 123456,
-      appointmentDate = LocalDate.of(2100, 1, 1),
-      startTime = LocalTime.of(11, 0),
-      endTime = LocalTime.of(11, 30),
-      comments = null,
-    )
-  }
-
-  @Test
-  fun `should not create court appointment via prison api client when appointment already exists`() {
+  fun `should not create appointment via prison api client when appointment already exists`() {
     whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(courtAppointment)
     whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(BIRMINGHAM)) doReturn false
     whenever(prisonerSearchClient.getPrisoner(courtAppointment.prisonerNumber)) doReturn prisonerSearchPrisoner(
@@ -313,31 +469,7 @@ class ManageExternalAppointmentsServiceTest {
       )
     }
 
-    verify(prisonApiClient, never()).createAppointment(any(), any(), any(), any(), any(), any())
-  }
-
-  @Test
-  fun `should create probation appointment via prison api client when appointments not rolled out`() {
-    whenever(prisonAppointmentRepository.findById(1)) doReturn Optional.of(probationAppointment)
-    whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(WANDSWORTH)) doReturn false
-    whenever(prisonerSearchClient.getPrisoner(probationAppointment.prisonerNumber)) doReturn prisonerSearchPrisoner(
-      prisonerNumber = probationAppointment.prisonerNumber,
-      prisonCode = probationAppointment.prisonCode(),
-      bookingId = 1,
-    )
-    whenever(nomisMappingClient.getNomisLocationMappingBy(probationAppointment.prisonLocationId)) doReturn NomisDpsLocationMapping(nomisLocationId = wandsworthLocation.locationId, dpsLocationId = courtAppointment.prisonLocationId)
-
-    service.createAppointment(1)
-
-    verify(activitiesAppointmentsClient, never()).createAppointment(any(), any(), any(), any(), any(), any(), any())
-    verify(prisonApiClient).createAppointment(
-      bookingId = 1,
-      locationId = 123456,
-      appointmentDate = LocalDate.of(2100, 1, 1),
-      startTime = LocalTime.of(11, 0),
-      endTime = LocalTime.of(11, 30),
-      comments = "Probation meeting comments",
-    )
+    verify(prisonApiClient, never()).createAppointment(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsServiceTest.kt
@@ -97,7 +97,7 @@ class ManageExternalAppointmentsServiceTest {
   inner class MapCourtAppointmentType {
     @BeforeEach
     fun before() {
-      whenever(featureSwitches.isEnabled(Feature.FEATURE_PROBATION_LIVE)) doReturn false
+      whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn false
     }
 
     @Test
@@ -382,7 +382,7 @@ class ManageExternalAppointmentsServiceTest {
   inner class MapCourtAndProbationAppointmentType {
     @BeforeEach
     fun before() {
-      whenever(featureSwitches.isEnabled(Feature.FEATURE_PROBATION_LIVE)) doReturn true
+      whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn true
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsServiceTest.kt
@@ -628,7 +628,7 @@ class ManageExternalAppointmentsServiceTest {
 
       service.cancelCurrentAppointment(1)
 
-      verify(activitiesAppointmentsClient, never()).cancelAppointment(any())
+      verify(activitiesAppointmentsClient, never()).cancelAppointment(any(), any())
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerVideoAppointmentCancelledEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerVideoAppointmentCancelledEventHandlerTest.kt
@@ -10,6 +10,8 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.ActivitiesAppointmentsClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
@@ -45,6 +47,8 @@ class PrisonerVideoAppointmentCancelledEventHandlerTest {
   private val videoBookingRepository: VideoBookingRepository = mock()
   private val prisonAppointmentRepository: PrisonAppointmentRepository = mock()
   private val bookingHistoryService: BookingHistoryService = mock()
+  private val featureSwitches: FeatureSwitches = mock()
+  private val supportedAppointmentTypes = SupportedAppointmentTypes(featureSwitches)
   private val handler = PrisonerVideoAppointmentCancelledEventHandler(
     activitiesAppointmentsClient,
     videoAppointmentRepository,
@@ -52,6 +56,7 @@ class PrisonerVideoAppointmentCancelledEventHandlerTest {
     videoBookingRepository,
     prisonAppointmentRepository,
     bookingHistoryService,
+    supportedAppointmentTypes,
   )
 
   @BeforeEach


### PR DESCRIPTION
This change introduces support for the dedicated probation meeting type (which ultimately ends up in NOMIS after sync).

The change is feature toggled so by default it is switched off.

Included in this PR is adding support for running locally with Localstack, this enabled me to see the events being raised and consumed and ultimately sent to both prison-api and activities and appointments.