### PR TITLE
BAVL-840: Enable matching criteria to a CANCELLED video booking, distinct by the latestUpdated booking where many CANCELLED bookings match the criteria

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoAppointment.kt
@@ -43,6 +43,8 @@ data class VideoAppointment(
   override val startTime: LocalTime,
 
   override val endTime: LocalTime,
+
+  val lastCreatedOrAmended: LocalDateTime,
 ) : AppointmentSlot {
   fun start(): LocalDateTime = appointmentDate.atTime(startTime)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/VideoBookingSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/VideoBookingSearchRequest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingStatus
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -39,4 +40,7 @@ data class VideoBookingSearchRequest(
   @Schema(description = "End time for the appointment on the day", example = "11:45")
   @JsonFormat(pattern = "HH:mm")
   val endTime: LocalTime?,
+
+  @Schema(description = "The status of the booking to match, defaults to ACTIVE", example = "ACTIVE")
+  val statusCode: BookingStatus? = BookingStatus.ACTIVE,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/VideoAppointmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/VideoAppointmentRepository.kt
@@ -47,6 +47,27 @@ interface VideoAppointmentRepository : ReadOnlyRepository<VideoAppointment, Long
   @Query(
     value = """
       FROM VideoAppointment va 
+      WHERE va.prisonerNumber = :prisonerNumber
+      AND va.appointmentDate = :appointmentDate
+      AND va.prisonLocationId = :prisonLocationId
+      AND va.startTime = :startTime
+      AND va.endTime = :endTime
+      AND va.statusCode = 'CANCELLED'
+      ORDER BY va.lastCreatedOrAmended DESC
+      LIMIT 1
+    """,
+  )
+  fun findLatestCancelledVideoAppointment(
+    prisonerNumber: String,
+    appointmentDate: LocalDate,
+    prisonLocationId: UUID,
+    startTime: LocalTime,
+    endTime: LocalTime,
+  ): VideoAppointment?
+
+  @Query(
+    value = """
+      FROM VideoAppointment va 
       WHERE va.prisonCode = :prisonCode
       AND va.prisonerNumber = :prisonerNumber
       AND va.appointmentDate = :appointmentDate

--- a/src/main/resources/migrations/common/R__v_video_appointments.sql
+++ b/src/main/resources/migrations/common/R__v_video_appointments.sql
@@ -13,7 +13,8 @@ select
   pa.prison_location_id,
   pa.appointment_date,
   pa.start_time,
-  pa.end_time
+  pa.end_time,
+  COALESCE(vlb.amended_time, vlb.created_time) as last_created_or_amended
 from video_booking vlb
   left join court c on c.court_id = vlb.court_id and c.enabled = true
   left join probation_team pt on pt.probation_team_id = vlb.probation_team_id and pt.enabled = true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -194,6 +194,7 @@ fun videoAppointment(
     appointmentDate = prisonAppointment.appointmentDate,
     startTime = prisonAppointment.startTime,
     endTime = prisonAppointment.endTime,
+    lastCreatedOrAmended = booking.amendedTime ?: booking.createdTime,
   )
 
 fun videoRoomAttributesWithSchedule(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -60,6 +60,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateV
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.RequestVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.VideoBookingSearchRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.VideoLinkBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.BookingHistoryRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.NotificationRepository
@@ -1771,6 +1772,26 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
       ),
       COURT_USER,
     ).videoLinkBookingId isEqualTo 3000
+  }
+
+  @Test
+  @Sql("classpath:integration-test-data/seed-search-for-booking.sql")
+  fun `should find matching CANCELLED court video link bookings`() {
+    val location = pentonvilleLocation.copy(id = UUID.fromString("ba0df03b-7864-47d5-9729-0301b74ecbe2"), key = "PVI-78910")
+    locationsInsidePrisonApi().stubGetLocationByKey(location)
+    locationsInsidePrisonApi().stubGetLocationById(location)
+
+    webTestClient.searchForBooking(
+      VideoBookingSearchRequest(
+        prisonerNumber = "78910",
+        locationKey = location.key,
+        date = tomorrow(),
+        startTime = LocalTime.of(9, 0),
+        endTime = LocalTime.of(10, 0),
+        statusCode = BookingStatus.CANCELLED,
+      ),
+      COURT_USER,
+    ).videoLinkBookingId isEqualTo 4000
   }
 
   private fun WebTestClient.createBookingFails(request: CreateVideoBookingRequest, user: User) =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailabilityServiceTest.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoAppoi
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
 import java.time.Duration
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 import java.util.Optional
 import java.util.UUID
@@ -80,6 +81,7 @@ class AvailabilityServiceTest {
       appointmentDate = LocalDate.now(),
       startTime = startTime,
       endTime = endTime,
+      lastCreatedOrAmended = LocalDateTime.now(),
     )
 
   private val room1 = location(WANDSWORTH, "VCC-1")

--- a/src/test/resources/integration-test-data/seed-search-for-booking.sql
+++ b/src/test/resources/integration-test-data/seed-search-for-booking.sql
@@ -4,7 +4,7 @@ insert into prison_appointment (video_booking_id, prison_id, prisoner_number, ap
 values (1000, 17, '123456', 'VLB_COURT_MAIN', 'comments about the hearing', 'b13f9018-f22d-456f-a690-d80e3d0feb5f'::uuid, current_date, '12:00', '13:00');
 
 insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
-values (2000, 'COURT', 'CANCELLED', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
+values (2000, 'COURT', 'CANCELLED', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp - interval '1 second');
 insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
 values (2000, 17, '78910', 'VLB_COURT_MAIN', 'comments about the hearing', 'ba0df03b-7864-47d5-9729-0301b74ecbe2'::uuid, current_date + 1, '9:00', '10:00');
 
@@ -12,3 +12,8 @@ insert into video_booking (video_booking_id, booking_type, status_code, court_id
 values (3000, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
 insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
 values (3000, 17, '78910', 'VLB_COURT_MAIN', 'comments about the hearing', 'ba0df03b-7864-47d5-9729-0301b74ecbe2'::uuid, current_date + 1, '9:00', '10:00');
+
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
+values (4000, 'COURT', 'CANCELLED', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+values (4000, 17, '78910', 'VLB_COURT_MAIN', 'comments about the hearing', 'ba0df03b-7864-47d5-9729-0301b74ecbe2'::uuid, current_date + 1, '9:00', '10:00');


### PR DESCRIPTION
When a CANCELLED appointment is opened in A&A, we need to be able to match it to a CANCELLED video booking.

Since it is possible, in theory, to have many identical CANCELLED bookings, I have decided to match the appointment to the booking which is most recently cancelled booking.