### PR TITLE
BAVL-599 support soft and hard delete of A&A appointments for amend and cancel operations via BLVS.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
@@ -23,6 +23,7 @@ const val VIDEO_LINK_BOOKING = "VLB"
 inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>() {}
 
 const val CANCELLED_BY_EXTERNAL_SERVICE = 4L
+const val CANCELLED_BY_USER = 2L
 
 @Component
 class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClient: WebClient) {
@@ -100,13 +101,14 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
 
   /**
    * @param appointmentId refers the appointment identifier held in Activities and Appointments, not BVLS.
+   * @param deleteOnCancel true will hard delete the appointment whereas a soft delete will keep a history of the cancellation.
    */
-  fun cancelAppointment(appointmentId: Long) {
+  fun cancelAppointment(appointmentId: Long, deleteOnCancel: Boolean = false) {
     activitiesAppointmentsApiWebClient.put()
       .uri("/appointments/{appointmentId}/cancel", appointmentId)
       .bodyValue(
         AppointmentCancelRequest(
-          cancellationReasonId = CANCELLED_BY_EXTERNAL_SERVICE,
+          cancellationReasonId = if (deleteOnCancel) CANCELLED_BY_EXTERNAL_SERVICE else CANCELLED_BY_USER,
           applyTo = AppointmentCancelRequest.ApplyTo.THIS_APPOINTMENT,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsService.kt
@@ -114,9 +114,9 @@ class ManageExternalAppointmentsService(
             appointment.internalLocationId(),
           ).findMatchingAppointments(appointment)
             .forEach { matchingAppointment ->
-              log.info("EXTERNAL APPOINTMENTS: deleting video booking appointment $appointment from activities and appointments")
+              log.info("EXTERNAL APPOINTMENTS: soft deleting video booking appointment $appointment from activities and appointments")
               activitiesAppointmentsClient.cancelAppointment(matchingAppointment.appointmentId)
-              log.info("EXTERNAL APPOINTMENTS: deleted matching appointment ${matchingAppointment.appointmentId} from activities and appointments")
+              log.info("EXTERNAL APPOINTMENTS: soft deleted matching appointment ${matchingAppointment.appointmentId} from activities and appointments")
             }
         } else {
           prisonApiClient.getPrisonersAppointmentsAtLocations(
@@ -150,9 +150,9 @@ class ManageExternalAppointmentsService(
         onDate = bha.appointmentDate,
         bha.internalLocationId(),
       ).findMatchingAppointments(bha).forEach { matchingAppointment ->
-        log.info("EXTERNAL APPOINTMENTS: deleting video booking appointment $bha from activities and appointments")
-        activitiesAppointmentsClient.cancelAppointment(matchingAppointment.appointmentId)
-        log.info("EXTERNAL APPOINTMENTS: deleted matching appointment ${matchingAppointment.appointmentId} from activities and appointments")
+        log.info("EXTERNAL APPOINTMENTS: hard deleting video booking appointment $bha from activities and appointments")
+        activitiesAppointmentsClient.cancelAppointment(matchingAppointment.appointmentId, deleteOnCancel = true)
+        log.info("EXTERNAL APPOINTMENTS: hard deleted matching appointment ${matchingAppointment.appointmentId} from activities and appointments")
       }
     } else {
       prisonApiClient.getPrisonersAppointmentsAtLocations(
@@ -170,7 +170,7 @@ class ManageExternalAppointmentsService(
 
   private fun Collection<AppointmentSearchResult>.findMatchingAppointments(appointment: PrisonAppointment): List<AppointmentSearchResult> =
     filter {
-      appointment.startTime == LocalTime.parse(it.startTime) && appointment.endTime == LocalTime.parse(it.endTime)
+      appointment.startTime == LocalTime.parse(it.startTime) && appointment.endTime == LocalTime.parse(it.endTime) && !it.isCancelled
     }.ifEmpty {
       emptyList<AppointmentSearchResult>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in A&A for prison appointment ${appointment.prisonAppointmentId}") }
@@ -178,7 +178,7 @@ class ManageExternalAppointmentsService(
 
   private fun Collection<AppointmentSearchResult>.findMatchingAppointments(bha: BookingHistoryAppointment): List<AppointmentSearchResult> =
     filter {
-      bha.startTime == LocalTime.parse(it.startTime) && bha.endTime == LocalTime.parse(it.endTime)
+      bha.startTime == LocalTime.parse(it.startTime) && bha.endTime == LocalTime.parse(it.endTime) && !it.isCancelled
     }.ifEmpty {
       emptyList<AppointmentSearchResult>()
         .also { log.info("EXTERNAL APPOINTMENTS: no matching appointments found in A&A for booking history appointment ${bha.bookingHistoryAppointmentId}") }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClientTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesapp
 
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.mockito.Spy
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
@@ -16,6 +17,7 @@ import java.time.LocalTime
 
 class ActivitiesAppointmentsClientTest {
 
+  @Spy
   private val server = ActivitiesAppointmentsApiMockServer().also { it.start() }
   private val client = ActivitiesAppointmentsClient(WebClient.create("http://localhost:${server.port()}"))
 
@@ -114,6 +116,11 @@ class ActivitiesAppointmentsClientTest {
 
     server.stubGetRolledOutPrison(RISLEY, false)
     client.isAppointmentsRolledOutAt(RISLEY) isBool false
+  }
+
+  @Test
+  fun `should correct cancellation reason on cancel with delete`() {
+    client.cancelAppointment(1, true)
   }
 
   @AfterEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ManageExternalAppointmentsServiceTest.kt
@@ -438,7 +438,7 @@ class ManageExternalAppointmentsServiceTest {
 
     service.cancelCurrentAppointment(1)
 
-    verify(activitiesAppointmentsClient, never()).cancelAppointment(anyLong())
+    verify(activitiesAppointmentsClient, never()).cancelAppointment(anyLong(), any())
   }
 
   @Test
@@ -557,7 +557,7 @@ class ManageExternalAppointmentsServiceTest {
 
     service.cancelPreviousAppointment(bookingHistory.appointments().first())
 
-    verify(activitiesAppointmentsClient).cancelAppointment(99)
+    verify(activitiesAppointmentsClient).cancelAppointment(99, true)
     verify(prisonApiClient, times(0)).cancelAppointment(anyLong())
   }
 
@@ -591,7 +591,7 @@ class ManageExternalAppointmentsServiceTest {
 
     service.cancelPreviousAppointment(bookingHistory.appointments().first())
 
-    verify(activitiesAppointmentsClient, times(0)).cancelAppointment(anyLong())
+    verify(activitiesAppointmentsClient, times(0)).cancelAppointment(anyLong(), any())
     verify(prisonApiClient).cancelAppointment(99)
   }
 


### PR DESCRIPTION
When bookings are amended the existing correlating A&A appointments should be deleted on cancel.  New appointments will replace them.

When bookings are cancelled the existing correlating A&A appointments should not be deleted on cancel.  There are no new appointments to replace them.