### PR TITLE
BAVL-600: Add ids to responses and return INACTIVE locations in decorations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/Location.kt
@@ -29,6 +29,9 @@ data class Location(
 
 @Schema(description = "The additional attributes of a video location")
 data class RoomAttributes(
+  @Schema(description = "The internal ID for this room attribute", example = "123", required = true)
+  val attributeId: Long,
+
   @Schema(description = "The status of the room (ACTIVE or INACTIVE)", example = "ACTIVE", required = true)
   val locationStatus: LocationStatus,
 
@@ -38,11 +41,11 @@ data class RoomAttributes(
   @Schema(description = "The date the room is expected to be operational again", example = "2025-02-12")
   val expectedActiveDate: LocalDate?,
 
-  @Schema(description = "The preferred usage for this room (COURT, PROBATION, SHARED, SCHEDULE)", example = "SHARED", required = true)
+  @Schema(description = "The preferred usage for this room (COURT, PROBATION, SHARED, BLOCKED, SCHEDULE)", example = "SHARED", required = true)
   val locationUsage: LocationUsage,
 
-  @Schema(description = "Court or probation team codes allowed to use the room (comma-separated list)", example = "YRKMAG,DRBYJS")
-  val allowedParties: String?,
+  @Schema(description = "Court or probation team codes allowed to use the room (comma-separated list)", example = "[YRKMAG,DRBYJS")
+  val allowedParties: List<String> = emptyList(),
 
   @Schema(description = "The video URL to access the equipment in this room", example = "https://prison.video.link/123")
   val prisonVideoUrl: String?,
@@ -50,12 +53,14 @@ data class RoomAttributes(
   @Schema(description = "Notes for these additional attributes", example = "some notes")
   val notes: String?,
 
-  @Schema(description = "A schedule for this room. Only present if the locationUsage is SCHEDULE.")
   val schedule: List<RoomSchedule> = emptyList(),
 )
 
 @Schema(description = "The additional schedule of usage for a video room")
 data class RoomSchedule(
+  @Schema(description = "The internal ID for this room schedule", example = "345", required = true)
+  val scheduleId: Long,
+
   @Schema(description = "The day when this time-slot starts", example = "Monday", required = true)
   val startDayOfWeek: DayOfWeek,
 
@@ -68,10 +73,10 @@ data class RoomSchedule(
   @Schema(description = "End time of this slot (24 hr clock, HH:MI)", example = "16:00", required = true)
   val endTime: LocalTime,
 
-  @Schema(description = "The usage of this room within this slot (PROBATION, COURT, SHARED)", example = "SHARED", required = true)
+  @Schema(description = "The usage of this room within this slot (PROBATION, COURT, SHARED, BLOCKED)", example = "SHARED", required = true)
   @Enumerated(EnumType.STRING)
   val locationUsage: LocationUsage,
 
-  @Schema(description = "Court or probation codes (comma-separated) that can use the room within this slot", example = "YRKMAG,DRBYJS")
-  val allowedParties: String?,
+  @Schema(description = "Court or probation codes (comma-separated) that can use the room within this slot", example = "[YRKMAG,DRBYJS]")
+  val allowedParties: List<String> = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/LocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/LocationsService.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationsInsidePrisonClient
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.LocationStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.LocationAttributeRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
@@ -30,18 +29,13 @@ class LocationsService(
   @Transactional(readOnly = true)
   fun getDecoratedVideoLocations(prisonCode: String, enabledOnly: Boolean): List<Location> {
     val prisonLocations = getVideoLinkLocationsAtPrison(prisonCode, enabledOnly)
-
     val locationsById = prisonLocations.associateBy { it.dpsLocationId }
-
     val decoratedLocations = locationAttributeRepository.findByPrisonCode(prisonCode)
       .filter { locationsById[it.dpsLocationId] != null }
       .mapNotNull { attributes ->
         locationsById[attributes.dpsLocationId]?.toDecoratedLocation(attributes.toRoomAttributes())
       }
-
-    // Preserves the order of the original prison locations, but replaces where decorated locations exist
-    return (locationsById + decoratedLocations.associateBy { it.dpsLocationId }).values
-      .toList()
-      .filterNot { it.extraAttributes?.locationStatus == LocationStatus.INACTIVE }
+    // Preserves the order of the original prison locations
+    return (locationsById + decoratedLocations.associateBy { it.dpsLocationId }).values.toList()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/LocationMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/LocationMappers.kt
@@ -28,26 +28,26 @@ fun ModelLocation.toDecoratedLocation(attributes: RoomAttributes) = ModelLocatio
   extraAttributes = attributes,
 )
 
-// Additional location attributes
 fun LocationAttribute.toRoomAttributes() = RoomAttributes(
+  attributeId = this.locationAttributeId,
   locationStatus = this.locationStatus,
   statusMessage = this.statusMessage,
   expectedActiveDate = this.expectedActiveDate,
   locationUsage = this.locationUsage,
-  allowedParties = this.allowedParties,
+  allowedParties = this.allowedParties.let { this.allowedParties?.split(",") } ?: emptyList(),
   prisonVideoUrl = this.prisonVideoUrl,
   notes = this.notes,
   schedule = this.schedule().toRoomSchedule(),
 )
 
-// Additional location schedule
 fun List<LocationSchedule>.toRoomSchedule() = map {
   RoomSchedule(
+    scheduleId = it.locationScheduleId,
     startDayOfWeek = DayOfWeek.of(it.startDayOfWeek),
     endDayOfWeek = DayOfWeek.of(it.endDayOfWeek),
     startTime = it.startTime,
     endTime = it.endTime,
     locationUsage = it.locationUsage,
-    allowedParties = it.allowedParties,
+    allowedParties = it.allowedParties.let { parties -> parties?.split(",") } ?: emptyList(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/LocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/LocationsServiceTest.kt
@@ -184,10 +184,12 @@ class LocationsServiceTest {
       assertThat(enabled).isTrue()
       assertThat(extraAttributes).isNotNull
       with(extraAttributes!!) {
+        assertThat(attributeId).isEqualTo(1)
         assertThat(locationStatus).isEqualTo(LocationStatus.ACTIVE)
         assertThat(locationUsage).isEqualTo(LocationUsage.SCHEDULE)
         assertThat(schedule).hasSize(1)
         with(schedule[0]) {
+          assertThat(scheduleId).isEqualTo(1)
           assertThat(startDayOfWeek).isEqualTo(DayOfWeek.MONDAY)
           assertThat(endDayOfWeek).isEqualTo(DayOfWeek.SUNDAY)
           assertThat(startTime).isEqualTo(LocalTime.of(1, 0))
@@ -204,10 +206,12 @@ class LocationsServiceTest {
       assertThat(enabled).isFalse()
       assertThat(extraAttributes).isNotNull
       with(extraAttributes!!) {
+        assertThat(attributeId).isEqualTo(2)
         assertThat(locationStatus).isEqualTo(LocationStatus.ACTIVE)
         assertThat(locationUsage).isEqualTo(LocationUsage.SCHEDULE)
         assertThat(schedule).hasSize(1)
         with(schedule[0]) {
+          assertThat(scheduleId).isEqualTo(1)
           assertThat(startDayOfWeek).isEqualTo(DayOfWeek.MONDAY)
           assertThat(endDayOfWeek).isEqualTo(DayOfWeek.SUNDAY)
           assertThat(startTime).isEqualTo(LocalTime.of(1, 0))
@@ -243,15 +247,18 @@ class LocationsServiceTest {
       assertThat(enabled).isTrue()
       assertThat(extraAttributes).isNotNull
       with(extraAttributes!!) {
+        assertThat(attributeId).isEqualTo(1)
         assertThat(locationStatus).isEqualTo(LocationStatus.ACTIVE)
         assertThat(locationUsage).isEqualTo(LocationUsage.SCHEDULE)
         assertThat(schedule).hasSize(1)
         with(schedule[0]) {
+          assertThat(scheduleId).isEqualTo(1)
           assertThat(startDayOfWeek).isEqualTo(DayOfWeek.MONDAY)
           assertThat(endDayOfWeek).isEqualTo(DayOfWeek.SUNDAY)
           assertThat(startTime).isEqualTo(LocalTime.of(1, 0))
           assertThat(endTime).isEqualTo(LocalTime.of(23, 0))
           assertThat(locationUsage).isEqualTo(LocationUsage.SHARED)
+          assertThat(allowedParties).isEmpty()
         }
       }
     }
@@ -282,8 +289,10 @@ class LocationsServiceTest {
       assertThat(enabled).isTrue()
       assertThat(extraAttributes).isNotNull
       with(extraAttributes!!) {
+        assertThat(attributeId).isEqualTo(1)
         assertThat(locationStatus).isEqualTo(LocationStatus.ACTIVE)
         assertThat(locationUsage).isEqualTo(LocationUsage.SHARED)
+        assertThat(allowedParties).isEmpty()
         assertThat(schedule).isNullOrEmpty()
       }
     }
@@ -305,7 +314,7 @@ class LocationsServiceTest {
   }
 
   @Test
-  fun `should return a mixture of decorated and undecorated locations, and filter when decorated with INACTIVE`() {
+  fun `should return a mixture of decorated and undecorated locations even when decorated with INACTIVE`() {
     val locationA = location(WANDSWORTH, "A", active = true)
     val locationB = location(WANDSWORTH, "B", active = true)
     val locationC = location(WANDSWORTH, "C", active = true)
@@ -313,7 +322,7 @@ class LocationsServiceTest {
     whenever(prisonRepository.findByCode(WANDSWORTH)) doReturn prison(WANDSWORTH)
     whenever(locationsClient.getVideoLinkLocationsAtPrison(WANDSWORTH)) doReturn listOf(locationA, locationB, locationC)
 
-    // Location A is ACTIVE - in decorations
+    // Location A is ACTIVE - in decoration data
     val roomAttributesA = videoRoomAttributesWithoutSchedule(
       prisonCode = WANDSWORTH,
       attributeId = 1,
@@ -321,7 +330,7 @@ class LocationsServiceTest {
       locationStatus = LocationStatus.ACTIVE,
     )
 
-    // Location B is INACTIVE - in decoration
+    // Location B is INACTIVE - in decoration data
     val roomAttributesB = videoRoomAttributesWithoutSchedule(
       prisonCode = WANDSWORTH,
       attributeId = 2,
@@ -335,26 +344,29 @@ class LocationsServiceTest {
 
     val result = service.getDecoratedVideoLocations(WANDSWORTH, enabledOnly = false)
 
-    assertThat(result).hasSize(2)
+    assertThat(result).hasSize(3)
 
     with(result[0]) {
       assertThat(key).isEqualTo(locationA.key)
-      assertThat(dpsLocationId).isEqualTo(locationA.id)
-      assertThat(description).isEqualTo(locationA.localName)
       assertThat(enabled).isTrue()
-
       assertThat(extraAttributes).isNotNull
       with(extraAttributes!!) {
+        assertThat(attributeId).isEqualTo(1)
         assertThat(locationStatus).isEqualTo(LocationStatus.ACTIVE)
-        assertThat(locationUsage).isEqualTo(LocationUsage.SHARED)
-        assertThat(schedule).isNullOrEmpty()
       }
     }
 
     with(result[1]) {
+      assertThat(key).isEqualTo(locationB.key)
+      assertThat(enabled).isTrue()
+      with(extraAttributes!!) {
+        assertThat(attributeId).isEqualTo(2)
+        assertThat(locationStatus).isEqualTo(LocationStatus.INACTIVE)
+      }
+    }
+
+    with(result[2]) {
       assertThat(key).isEqualTo(locationC.key)
-      assertThat(dpsLocationId).isEqualTo(locationC.id)
-      assertThat(description).isEqualTo(locationC.localName)
       assertThat(enabled).isTrue()
       assertThat(extraAttributes).isNull()
     }


### PR DESCRIPTION
Minor changes only:
* Return the IDs for attributes and schedules on room decorations
* Return enabled locations (from locations api) even it the room decoration shows INACTIVE so they are visible on the admin forms.