### PR TITLE
BAVL-611 new entity to support the capture of additional booking details (for the updated probation journey).

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
 
   implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.12.0")
 
+  implementation("com.googlecode.libphonenumber:libphonenumber:8.13.54")
+
   // Test dependencies
   testImplementation("io.jsonwebtoken:jjwt-impl:0.12.6")
   testImplementation("io.jsonwebtoken:jjwt-jackson:0.12.6")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/StringExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/StringExt.kt
@@ -1,9 +1,18 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common
 
+import com.google.i18n.phonenumbers.PhoneNumberUtil
 import java.time.OffsetDateTime
+import java.util.Locale
+
+private val ukCountryCode: String = Locale.UK.country
+private val phoneNumberUtil: PhoneNumberUtil = PhoneNumberUtil.getInstance()
 
 fun String.isEmail() = this.matches(
   Regex("[a-zA-Z0-9\\+\\.\\_\\%\\-\\+]{1,256}\\@[a-zA-Z0-9][a-zA-Z0-9\\-]{0,64}(\\.[a-zA-Z0-9][a-zA-Z0-9\\-]{0,25})+"),
 )
 
 fun String.toOffsetDateTime(): OffsetDateTime = OffsetDateTime.parse(this)
+
+fun String.isUkPhoneNumber(): Boolean = runCatching {
+  phoneNumberUtil.parse(this, ukCountryCode).let { phoneNumberUtil.isValidNumber(it) }
+}.getOrElse { false }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/StringExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/StringExt.kt
@@ -14,5 +14,9 @@ fun String.isEmail() = this.matches(
 fun String.toOffsetDateTime(): OffsetDateTime = OffsetDateTime.parse(this)
 
 fun String.isUkPhoneNumber(): Boolean = runCatching {
-  phoneNumberUtil.parse(this, ukCountryCode).let { phoneNumberUtil.isValidNumber(it) }
+  phoneNumberUtil.parse(this, ukCountryCode).let {
+    // We don't want to allow alpha numbers e.g. 0800 800 ACME
+    !phoneNumberUtil.isAlphaNumber(this) &&
+      phoneNumberUtil.isValidNumber(it)
+  }
 }.getOrElse { false }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/AdditionalBookingDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/AdditionalBookingDetail.kt
@@ -1,0 +1,109 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import org.hibernate.Hibernate
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.isEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.isUkPhoneNumber
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.requireNot
+
+@Entity
+class AdditionalBookingDetail private constructor(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val additionalBookingDetailId: Long = 0,
+
+  @OneToOne
+  @JoinColumn(name = "video_booking_id")
+  val videoBooking: VideoBooking,
+
+  name: String,
+
+  email: String?,
+
+  phoneNumber: String?,
+
+  information: String?,
+) {
+  var contactName: String = ""
+    set(value) {
+      require(value.isNotBlank()) {
+        "Contact name cannot be blank"
+      }
+
+      field = value
+    }
+
+  var contactEmail: String? = ""
+    set(value) {
+      require(value == null || value.isNotBlank()) {
+        "Contact email cannot be blank"
+      }
+
+      require(value == null || value.isEmail()) {
+        "Contact email is not a valid email address"
+      }
+
+      field = value
+    }
+
+  var contactPhoneNumber: String? = null
+    set(value) {
+      require(value == null || value.isUkPhoneNumber()) {
+        "Contact number is not a valid UK phone number"
+      }
+
+      field = value
+    }
+
+  var extraInformation: String? = information
+    set(value) {
+      require(value == null || value.isNotBlank()) {
+        "Extra information cannot be blank"
+      }
+
+      field = value
+    }
+
+  init {
+    contactName = name
+    contactEmail = email
+    contactPhoneNumber = phoneNumber
+    extraInformation = information
+
+    requireNot(email == null && phoneNumber == null) {
+      "Must provide at least one, contact email or contact phone number"
+    }
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+
+    other as AdditionalBookingDetail
+
+    return additionalBookingDetailId == other.additionalBookingDetailId
+  }
+
+  override fun hashCode(): Int = additionalBookingDetailId.hashCode()
+
+  companion object {
+    fun newDetails(
+      videoBooking: VideoBooking,
+      contactName: String,
+      contactEmail: String?,
+      contactPhoneNumber: String?,
+      extraInformation: String?,
+    ) = AdditionalBookingDetail(
+      videoBooking = videoBooking,
+      name = contactName,
+      email = contactEmail,
+      phoneNumber = contactPhoneNumber,
+      information = extraInformation,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/AdditionalBookingDetailRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/AdditionalBookingDetailRepository.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.AdditionalBookingDetail
+
+interface AdditionalBookingDetailRepository : JpaRepository<AdditionalBookingDetail, Long>

--- a/src/main/resources/migrations/common/V2025.02.07__additional_booking_detail.sql
+++ b/src/main/resources/migrations/common/V2025.02.07__additional_booking_detail.sql
@@ -1,0 +1,11 @@
+CREATE TABLE additional_booking_detail
+(
+  additional_booking_detail_id  bigserial NOT NULL CONSTRAINT additional_booking_detail_pk PRIMARY KEY,
+  video_booking_id              bigint NOT NULL REFERENCES video_booking(video_booking_id),
+  contact_name                  varchar(100) NOT NULL,
+  contact_email                 varchar(100),
+  contact_number                varchar(30),
+  extra_information             varchar(100)
+);
+
+CREATE UNIQUE INDEX idx_video_booking_id ON additional_booking_detail(video_booking_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/StringExtensionUtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/StringExtensionUtilsTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 
 class StringExtensionUtilsTest {
   @Test
@@ -37,6 +38,17 @@ class StringExtensionUtilsTest {
 
     listOfEmailAddresses.forEach { address ->
       assertThat(address.isEmail()).isEqualTo(true)
+    }
+  }
+
+  @Test
+  fun `should recognise various UK phone numbers`() {
+    listOf(
+      "+44 123 456 7890",
+      "07928 660553",
+      "0344 561 6789",
+    ).forEach { phoneNumber ->
+      phoneNumber.isUkPhoneNumber() isBool true
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/StringExtensionUtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/StringExtensionUtilsTest.kt
@@ -42,6 +42,17 @@ class StringExtensionUtilsTest {
   }
 
   @Test
+  fun `should recognise invalid UK phone numbers`() {
+    listOf(
+      "+44 I11 456 7890",
+      "0800 800 ACME",
+    ).forEach { phoneNumber ->
+      println(phoneNumber)
+      phoneNumber.isUkPhoneNumber() isBool false
+    }
+  }
+
+  @Test
   fun `should recognise various UK phone numbers`() {
     listOf(
       "+44 123 456 7890",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/AdditionalBookingDetailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/AdditionalBookingDetailTest.kt
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+
+class AdditionalBookingDetailTest {
+
+  private val booking = courtBooking()
+
+  @Test
+  fun `should reject blank or empty contact name`() {
+    assertThrows<IllegalArgumentException> {
+      AdditionalBookingDetail.newDetails(booking, contactName = "", contactEmail = "email@somehwere.com", contactPhoneNumber = "124", extraInformation = null)
+    }.message isEqualTo "Contact name cannot be blank"
+
+    assertThrows<IllegalArgumentException> {
+      AdditionalBookingDetail.newDetails(booking, contactName = "   ", contactEmail = "email@somehwere.com", contactPhoneNumber = "124", extraInformation = null)
+    }.message isEqualTo "Contact name cannot be blank"
+  }
+
+  @Test
+  fun `should reject blank or empty contact email`() {
+    assertThrows<IllegalArgumentException> {
+      AdditionalBookingDetail.newDetails(booking, contactName = "contact", contactEmail = "", contactPhoneNumber = "124", extraInformation = null)
+    }.message isEqualTo "Contact email cannot be blank"
+
+    assertThrows<IllegalArgumentException> {
+      AdditionalBookingDetail.newDetails(booking, contactName = "contact", contactEmail = "   ", contactPhoneNumber = "124", extraInformation = null)
+    }.message isEqualTo "Contact email cannot be blank"
+  }
+
+  @Test
+  fun `should reject invalid contact email`() {
+    assertThrows<IllegalArgumentException> {
+      AdditionalBookingDetail.newDetails(booking, contactName = "contact", contactEmail = "invalid_email", contactPhoneNumber = "124", extraInformation = null)
+    }.message isEqualTo "Contact email is not a valid email address"
+
+    assertThrows<IllegalArgumentException> {
+      AdditionalBookingDetail.newDetails(booking, contactName = "contact", contactEmail = "invalid@@email.com", contactPhoneNumber = "124", extraInformation = null)
+    }.message isEqualTo "Contact email is not a valid email address"
+  }
+
+  @Test
+  fun `should reject invalid phone number`() {
+    assertThrows<IllegalArgumentException> {
+      AdditionalBookingDetail.newDetails(booking, contactName = "contact", contactEmail = "valid@email.address", contactPhoneNumber = "124", extraInformation = null)
+    }.message isEqualTo "Contact number is not a valid UK phone number"
+  }
+
+  @Test
+  fun `should reject when missing email and phone number`() {
+    assertThrows<IllegalArgumentException> {
+      AdditionalBookingDetail.newDetails(booking, contactName = "contact", contactEmail = null, contactPhoneNumber = null, extraInformation = null)
+    }.message isEqualTo "Must provide at least one, contact email or contact phone number"
+  }
+
+  @Test
+  fun `should be valid additional information`() {
+    AdditionalBookingDetail.newDetails(booking, contactName = "contact", contactEmail = "valid@email.address", contactPhoneNumber = null, extraInformation = "extra information")
+    AdditionalBookingDetail.newDetails(booking, contactName = "contact", contactEmail = null, contactPhoneNumber = "01234 567890", extraInformation = "extra information")
+
+    with(AdditionalBookingDetail.newDetails(booking, contactName = "contact", contactEmail = "valid@email.address", contactPhoneNumber = "01234 567890", extraInformation = "extra information")) {
+      videoBooking isEqualTo booking
+      contactName isEqualTo "contact"
+      contactEmail isEqualTo "valid@email.address"
+      contactPhoneNumber isEqualTo "01234 567890"
+      extraInformation isEqualTo "extra information"
+    }
+  }
+}


### PR DESCRIPTION
Initial attempt to provide an entity to capture additional booking details primarily for the new probation journey.

This is not tied to the probation journey specifically so can be used for other booking types should the need arise.

Needs wiring into the various endpoints e.g. create and backend services.

We will also need a means to record changes to booking details e.g. history.