### PR TITLE
BAVL-616 initial PR to support dedicated probation journey creation with new attributes.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/AdditionalBookingDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/AdditionalBookingDetail.kt
@@ -51,7 +51,7 @@ class AdditionalBookingDetail private constructor(
       field = value
     }
 
-  var contactPhoneNumber: String? = null
+  var contactNumber: String? = null
     set(value) {
       require(value == null || value.isUkPhoneNumber()) {
         "Contact number is not a valid UK phone number"
@@ -72,7 +72,7 @@ class AdditionalBookingDetail private constructor(
   init {
     contactName = name
     contactEmail = email
-    contactPhoneNumber = phoneNumber
+    contactNumber = phoneNumber
     extraInformation = information
 
     requireNot(email == null && phoneNumber == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AdditionalBookingDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AdditionalBookingDetails.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.AssertTrue
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+@Schema(
+  description =
+  """
+  Additional information for the booking. Must provide at least one form of contact email and/or phone number.
+  """,
+)
+data class AdditionalBookingDetails(
+  @field:NotBlank(message = "Name is mandatory")
+  @field:Size(max = 100, message = "Contact name should not exceed {max} characters")
+  val contactName: String?,
+
+  @field:Size(max = 100, message = "Contact email should not exceed {max} characters")
+  @Schema(description = "The email address for the contact, must be a valid email address")
+  val contactEmail: String?,
+
+  @field:Size(max = 30, message = "Contact phone number should not exceed {max} characters")
+  @Schema(description = "The contact phone number for the contact, must be a valid phone number")
+  val contactNumber: String?,
+
+  @field:Size(max = 100, message = "Extra information should not exceed {max} characters")
+  val extraInformation: String?,
+) {
+  @JsonIgnore
+  @AssertTrue(message = "Please provide an email address, contact number or both")
+  private fun isContactDetails() = contactEmail != null || contactNumber != null
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
@@ -68,6 +68,15 @@ data class CreateVideoBookingRequest(
   @field:Size(max = 120, message = "The video link should not exceed {max} characters")
   @Schema(description = "The video link for the appointment.", example = "https://video.here.com")
   val videoLinkUrl: String?,
+
+  @Schema(
+    description = """
+      The additional booking details for the booking. Additional details are only applicable to probation bookings. Will
+      be ignored if not a probation booking.
+      """,
+  )
+  @field:Valid
+  val additionalBookingDetails: AdditionalBookingDetails? = null,
 ) {
   @JsonIgnore
   @AssertTrue(message = "The court code and court hearing type are mandatory for court bookings")
@@ -117,6 +126,7 @@ enum class CourtHearingType {
 }
 
 enum class ProbationMeetingType {
+  OTHER,
   PSR,
   RR,
   UNKNOWN,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingService.kt
@@ -1,0 +1,98 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
+
+import jakarta.persistence.EntityNotFoundException
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerValidator
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.AdditionalBookingDetail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.PrisonerDetails
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.AdditionalBookingDetailRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toPrisonerDetails
+
+private const val MEETING_TYPE_OTHER = "OTHER"
+
+@Service
+class CreateProbationBookingService(
+  private val probationTeamRepository: ProbationTeamRepository,
+  private val videoBookingRepository: VideoBookingRepository,
+  private val appointmentsService: AppointmentsService,
+  private val bookingHistoryService: BookingHistoryService,
+  private val prisonRepository: PrisonRepository,
+  private val prisonerValidator: PrisonerValidator,
+  private val additionalBookingDetailRepository: AdditionalBookingDetailRepository,
+) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Transactional
+  fun create(request: CreateVideoBookingRequest, createdBy: User): Pair<VideoBooking, Prisoner> {
+    require(request.bookingType == BookingType.PROBATION) {
+      "PROBATION BOOKINGS: booking type is not probation"
+    }
+
+    require((createdBy is ExternalUser && createdBy.isProbationUser) || createdBy is PrisonUser) {
+      "Only probation users and prison users can create probation bookings."
+    }
+
+    val probationTeam = probationTeamRepository.findByCode(request.probationTeamCode!!)
+      ?.also { require(it.enabled) { "Probation team with code ${it.code} is not enabled" } }
+      ?: throw EntityNotFoundException("Probation team with code ${request.probationTeamCode} not found")
+
+    val prisoner = request.prisoner().validate()
+
+    return VideoBooking.newProbationBooking(
+      probationTeam = probationTeam,
+      probationMeetingType = request.probationMeetingType!!.name,
+      comments = request.comments,
+      videoUrl = request.videoLinkUrl,
+      createdBy = createdBy.username,
+      createdByPrison = false,
+    )
+      .also { thisBooking -> appointmentsService.createAppointmentForProbation(thisBooking, request.prisoner(), createdBy) }
+      .also { thisBooking -> videoBookingRepository.saveAndFlush(thisBooking) }
+      .also { thisBooking -> request.saveAdditionalDetailsFor(thisBooking) }
+      .also { thisBooking -> bookingHistoryService.createBookingHistory(HistoryType.CREATE, thisBooking) }
+      .also { thisBooking -> log.info("PROBATION BOOKING: booking ${thisBooking.videoBookingId} created") } to prisoner
+  }
+
+  private fun CreateVideoBookingRequest.saveAdditionalDetailsFor(booking: VideoBooking) {
+    additionalBookingDetails!!.let { details ->
+
+      if (booking.probationMeetingType!! == MEETING_TYPE_OTHER) {
+        requireNotNull(details.extraInformation) {
+          "Probation meeting extra information is required for meeting type Other"
+        }
+      }
+
+      additionalBookingDetailRepository.saveAndFlush(
+        AdditionalBookingDetail.newDetails(
+          videoBooking = booking,
+          contactName = details.contactName!!,
+          contactEmail = details.contactEmail,
+          contactPhoneNumber = details.contactNumber,
+          extraInformation = details.extraInformation,
+        ),
+      )
+    }
+  }
+
+  // We will only be creating appointments for one single prisoner as part of the initial rollout.
+  private fun CreateVideoBookingRequest.prisoner() = prisoners.first()
+
+  private fun PrisonerDetails.validate(): Prisoner {
+    // We are not checking if the prison is enabled here as we need to support prison users also.
+    // Our UI should not be sending disabled prisons though.
+    prisonRepository.findByCode(prisonCode!!) ?: throw EntityNotFoundException("Prison with code $prisonCode not found")
+    return prisonerValidator.validatePrisonerAtPrison(prisonerNumber!!, prisonCode).toPrisonerDetails()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegate.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Feature
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AmendVideoBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
+
+/**
+ * Responsible for delegating video booking specific operations to the appropriate video booking service.
+ */
+@Service
+class VideoBookingServiceDelegate(
+  private val createVideoBookingService: CreateVideoBookingService,
+  private val createProbationBookingService: CreateProbationBookingService,
+  private val amendVideoBookingService: AmendVideoBookingService,
+  private val cancelVideoBookingService: CancelVideoBookingService,
+  private val featureSwitches: FeatureSwitches,
+) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Transactional
+  fun create(booking: CreateVideoBookingRequest, createdBy: User) = when (featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) {
+    false -> {
+      log.info("CREATE BOOKING DELEGATE: VLPM feature toggle is off.")
+      createVideoBookingService.create(booking, createdBy)
+    }
+
+    true -> {
+      log.info("CREATE BOOKING DELEGATE: VLPM feature toggle is on.")
+      when (booking.bookingType!!) {
+        BookingType.COURT -> createVideoBookingService.create(booking, createdBy)
+        BookingType.PROBATION -> createProbationBookingService.create(booking, createdBy)
+      }
+    }
+  }
+
+  // TODO - this will need to check feature toggle to determine correct path for amendments.
+  @Transactional
+  fun amend(videoBookingId: Long, request: AmendVideoBookingRequest, amendedBy: User) = amendVideoBookingService.amend(videoBookingId, request, amendedBy)
+
+  @Transactional
+  fun cancel(videoBookingId: Long, cancelledBy: User): VideoBooking = cancelVideoBookingService.cancel(videoBookingId, cancelledBy)
+}

--- a/src/main/resources/migrations/dev/V2025.02.11__reference_data.sql
+++ b/src/main/resources/migrations/dev/V2025.02.11__reference_data.sql
@@ -1,0 +1,2 @@
+insert into reference_code (group_code, code, description,created_by, created_time, enabled)
+values ('PROBATION_MEETING_TYPE', 'OTHER', 'Other', 'TIM', current_timestamp, true);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/StringExtensionUtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/StringExtensionUtilsTest.kt
@@ -57,7 +57,8 @@ class StringExtensionUtilsTest {
     listOf(
       "+44 123 456 7890",
       "07928 660553",
-      "0344 561 6789",
+      "0115 6336363 ext 3",
+      "0115 6336363 ext. 3",
     ).forEach { phoneNumber ->
       phoneNumber.isUkPhoneNumber() isBool true
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/AdditionalBookingDetailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/AdditionalBookingDetailTest.kt
@@ -57,6 +57,13 @@ class AdditionalBookingDetailTest {
   }
 
   @Test
+  fun `should reject when details blank`() {
+    assertThrows<IllegalArgumentException> {
+      AdditionalBookingDetail.newDetails(booking, contactName = "contact", contactEmail = "valid@email.address", contactPhoneNumber = null, extraInformation = " ")
+    }.message isEqualTo "Extra information cannot be blank"
+  }
+
+  @Test
   fun `should be valid additional information`() {
     AdditionalBookingDetail.newDetails(booking, contactName = "contact", contactEmail = "valid@email.address", contactPhoneNumber = null, extraInformation = "extra information")
     AdditionalBookingDetail.newDetails(booking, contactName = "contact", contactEmail = null, contactPhoneNumber = "01234 567890", extraInformation = "extra information")
@@ -65,7 +72,7 @@ class AdditionalBookingDetailTest {
       videoBooking isEqualTo booking
       contactName isEqualTo "contact"
       contactEmail isEqualTo "valid@email.address"
-      contactPhoneNumber isEqualTo "01234 567890"
+      contactNumber isEqualTo "01234 567890"
       extraInformation isEqualTo "extra information"
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.manageusers.mo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.manageusers.model.UserDetailsDto.AuthSource
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AdditionalBookingDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AmendVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Appointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
@@ -228,6 +229,7 @@ fun probationBookingRequest(
   startTime: LocalTime = LocalTime.now(),
   endTime: LocalTime = LocalTime.now().plusHours(1),
   comments: String = "probation booking comments",
+  additionalBookingDetails: AdditionalBookingDetails? = null,
 ): CreateVideoBookingRequest {
   val appointment = Appointment(
     type = appointmentType,
@@ -250,6 +252,7 @@ fun probationBookingRequest(
     prisoners = listOf(prisoner),
     comments = comments,
     videoLinkUrl = videoLinkUrl,
+    additionalBookingDetails = additionalBookingDetails,
   )
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
@@ -89,7 +89,9 @@ abstract class IntegrationTestBase {
     nomisMappingApi().stubHealthPing(status)
   }
 
+  protected fun activitiesAppointmentsApi() = ActivitiesAppointmentsApiExtension.server
   protected fun prisonerApi() = PrisonApiExtension.server
+
   protected fun prisonSearchApi() = PrisonerSearchApiExtension.server
 
   protected fun locationsInsidePrisonApi() = LocationsInsidePrisonApiExtension.server

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationBookingIntegrationTest.kt
@@ -1,0 +1,137 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.resource
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.ActivitiesAppointmentsClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.TestEmailConfiguration
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingHistory
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BLACKPOOL_MC_PPOC
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.SqsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AdditionalBookingDetails
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.BookingHistoryRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
+import java.time.LocalTime
+
+@ContextConfiguration(classes = [TestEmailConfiguration::class])
+@TestPropertySource(properties = ["feature.master.vlpm.types=true"])
+class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
+
+  @MockitoBean
+  private lateinit var activitiesAppointmentsClient: ActivitiesAppointmentsClient
+
+  @Autowired
+  private lateinit var videoBookingRepository: VideoBookingRepository
+
+  @Autowired
+  private lateinit var prisonAppointmentRepository: PrisonAppointmentRepository
+
+  @Autowired
+  private lateinit var bookingHistoryRepository: BookingHistoryRepository
+
+  private val psrProbationBookingRequest = probationBookingRequest(
+    probationTeamCode = BLACKPOOL_MC_PPOC,
+    probationMeetingType = ProbationMeetingType.PSR,
+    videoLinkUrl = "https://probation.videolink.com",
+    prisonCode = BIRMINGHAM,
+    prisonerNumber = "123456",
+    startTime = LocalTime.of(9, 0),
+    endTime = LocalTime.of(9, 30),
+    appointmentType = AppointmentType.VLB_PROBATION,
+    location = birminghamLocation,
+    comments = "integration test probation booking comments",
+    additionalBookingDetails = AdditionalBookingDetails(
+      contactName = "probation contact",
+      contactEmail = "probation_contact@email.com",
+      contactNumber = null,
+      extraInformation = null,
+    ),
+  )
+
+  @Test
+  fun `should create a pre-sentence report probation booking using the VLPM appointment type`() {
+    videoBookingRepository.findAll().isEmpty() isBool true
+
+    prisonSearchApi().stubGetPrisoner("123456", BIRMINGHAM)
+    nomisMappingApi().stubGetNomisLocationMappingBy(birminghamLocation, 1)
+    locationsInsidePrisonApi().stubGetLocationById(birminghamLocation)
+    prisonerApi().stubGetScheduledAppointments(BIRMINGHAM, tomorrow(), 1)
+    activitiesAppointmentsClient.stub { on { isAppointmentsRolledOutAt(BIRMINGHAM) } doReturn true }
+
+    val bookingId = webTestClient.createBooking(psrProbationBookingRequest, PROBATION_USER)
+    val persistedBooking = videoBookingRepository.findById(bookingId).orElseThrow()
+
+    with(persistedBooking) {
+      videoBookingId isEqualTo bookingId
+      bookingType isEqualTo BookingType.PROBATION
+      probationTeam?.probationTeamId isEqualTo 1
+      probationMeetingType isEqualTo ProbationMeetingType.PSR.name
+      comments isEqualTo "integration test probation booking comments"
+      videoUrl isEqualTo "https://probation.videolink.com"
+      createdBy isEqualTo PROBATION_USER.username
+      createdByPrison isEqualTo false
+    }
+
+    getAppointmentAndCheckFor(persistedBooking) {
+      videoBooking isEqualTo persistedBooking
+      prisonCode() isEqualTo BIRMINGHAM
+      prisonerNumber isEqualTo "123456"
+      appointmentType isEqualTo AppointmentType.VLB_PROBATION.name
+      appointmentDate isEqualTo tomorrow()
+      prisonLocationId isEqualTo birminghamLocation.id
+      startTime isEqualTo LocalTime.of(9, 0)
+      endTime isEqualTo LocalTime.of(9, 30)
+      comments isEqualTo "integration test probation booking comments"
+    }
+
+    getHistoryAndCheckFor(persistedBooking) {
+      historyType isEqualTo HistoryType.CREATE
+      videoBookingId isEqualTo persistedBooking.videoBookingId
+      probationMeetingType isEqualTo persistedBooking.probationMeetingType
+      probationTeamId isEqualTo persistedBooking.probationTeam?.probationTeamId
+      appointments() hasSize 1
+    }
+
+    waitUntil {
+      verify(activitiesAppointmentsClient).createAppointment(
+        prisonCode = BIRMINGHAM,
+        prisonerNumber = "123456",
+        startDate = tomorrow(),
+        startTime = LocalTime.of(9, 0),
+        endTime = LocalTime.of(9, 30),
+        internalLocationId = 1,
+        comments = "integration test probation booking comments",
+        appointmentType = SupportedAppointmentTypes.Type.PROBATION,
+      )
+    }
+  }
+
+  private fun getAppointmentAndCheckFor(booking: VideoBooking, init: PrisonAppointment.() -> Unit) {
+    prisonAppointmentRepository.findByVideoBooking(booking).single().init()
+  }
+
+  private fun getHistoryAndCheckFor(booking: VideoBooking, init: BookingHistory.() -> Unit) {
+    bookingHistoryRepository.findAllByVideoBookingIdOrderByCreatedTime(booking.videoBookingId).first().init()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ReferenceCodesResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ReferenceCodesResourceIntegrationTest.kt
@@ -39,17 +39,17 @@ class ReferenceCodesResourceIntegrationTest : IntegrationTestBase() {
   @Test
   fun `should return a list of probation meeting type reference codes`() {
     val groupCode = "PROBATION_MEETING_TYPE"
-    referenceCodeRepository.findAllByGroupCodeEquals(groupCode) hasSize 3
+    referenceCodeRepository.findAllByGroupCodeEquals(groupCode) hasSize 4
 
     val enabledOnlyProbationMeetingTypes = webTestClient.getReferenceCodes(groupCode)
 
-    assertThat(enabledOnlyProbationMeetingTypes).extracting("code").containsExactlyInAnyOrder("PSR", "RR")
+    assertThat(enabledOnlyProbationMeetingTypes).extracting("code").containsExactlyInAnyOrder("PSR", "RR", "OTHER")
 
     val allProbationMeetingTypes = webTestClient.getReferenceCodes(groupCode, false)
 
     // Should be an extra one as UNKNOWN is disabled for probation teams
-    assertThat(allProbationMeetingTypes).extracting("code").containsExactlyInAnyOrder("PSR", "RR", "UNKNOWN")
-    allProbationMeetingTypes.count { it.enabled } isEqualTo 2
+    assertThat(allProbationMeetingTypes).extracting("code").containsExactlyInAnyOrder("PSR", "RR", "OTHER", "UNKNOWN")
+    allProbationMeetingTypes.count { it.enabled } isEqualTo 3
     allProbationMeetingTypes.single { it.enabled.not() && it.code == "UNKNOWN" }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/NomisMappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/NomisMappingApiMockServer.kt
@@ -1,11 +1,25 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.wiremock
 
+import com.github.tomakehurst.wiremock.client.WireMock
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping.NomisDpsLocationMapping
 
-class NomisMappingApiMockServer : MockServer(8096)
+class NomisMappingApiMockServer : MockServer(8096) {
+  fun stubGetNomisLocationMappingBy(location: Location, nomisLocationId: Long = 1) {
+    stubFor(
+      WireMock.get("/api/locations/dps/${location.id}").willReturn(
+        WireMock.aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody(mapper.writeValueAsString(NomisDpsLocationMapping(location.id, nomisLocationId)))
+          .withStatus(200),
+      ),
+    )
+  }
+}
 
 class NomisMappingApiExtension :
   BeforeAllCallback,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonerSchedule
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.ScheduledAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.ScheduledEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.NewAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
@@ -85,6 +86,22 @@ class PrisonApiMockServer : MockServer(8094) {
             .withBody(
               mapper.writeValueAsString(locations),
             )
+            .withStatus(200),
+        ),
+    )
+  }
+
+  fun stubGetScheduledAppointments(
+    prisonCode: String,
+    date: LocalDate,
+    locationId: Long,
+  ) {
+    stubFor(
+      WireMock.get("/api/schedules/$prisonCode/appointments?date=${date.toIsoDate()}&locationId=$locationId")
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(mapper.writeValueAsString(emptyList<ScheduledAppointment>()))
             .withStatus(200),
         ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AdditionalBookingDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AdditionalBookingDetailsTest.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request
+
+import org.junit.jupiter.api.Test
+
+class AdditionalBookingDetailsTest : ValidatorBase<AdditionalBookingDetails>() {
+
+  private val details = AdditionalBookingDetails(
+    contactName = "Fred",
+    contactEmail = "valid@email.address",
+    contactNumber = "0114 2345678",
+    extraInformation = "extra information",
+  )
+
+  @Test
+  fun `should be no errors for valid details`() {
+    assertNoErrors(details)
+    assertNoErrors(details.copy(contactEmail = null))
+    assertNoErrors(details.copy(contactNumber = null))
+    assertNoErrors(details.copy(extraInformation = null))
+  }
+
+  @Test
+  fun `should fail when no contact information`() {
+    details.copy(contactEmail = null, contactNumber = null) failsWithSingle ModelError("contactDetails", "Please provide an email address, contact number or both")
+  }
+
+  @Test
+  fun `should fail when extra details blank`() {
+    details.copy(contactEmail = null, contactNumber = null) failsWithSingle ModelError("contactDetails", "Please provide an email address, contact number or both")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingServiceTest.kt
@@ -1,0 +1,331 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
+
+import jakarta.persistence.EntityNotFoundException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationValidator
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationsInsidePrisonClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerValidator
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toMinutePrecision
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.AdditionalBookingDetail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.SERVICE_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isCloseTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisoner
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonerSearchPrisoner
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AdditionalBookingDetails
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.AdditionalBookingDetailRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class CreateProbationBookingServiceTest {
+  private val probationTeamRepository: ProbationTeamRepository = mock()
+  private val videoBookingRepository: VideoBookingRepository = mock()
+
+  private val bookingHistoryService: BookingHistoryService = mock()
+  private val prisonRepository: PrisonRepository = mock()
+  private val prisonerValidator: PrisonerValidator = mock()
+
+  private val persistedVideoBooking: VideoBooking = mock()
+  private val prisonAppointmentRepository: PrisonAppointmentRepository = mock()
+  private val locationsInsidePrisonClient: LocationsInsidePrisonClient = mock()
+  private val locationValidator: LocationValidator = mock()
+  private val additionalBookingDetailRepository: AdditionalBookingDetailRepository = mock()
+  private val persistedAdditionalBookingDetail: AdditionalBookingDetail = mock()
+
+  private val appointmentsService = AppointmentsService(prisonAppointmentRepository, prisonRepository, locationsInsidePrisonClient, locationValidator)
+
+  private val service = CreateProbationBookingService(
+    probationTeamRepository,
+    videoBookingRepository,
+    appointmentsService,
+    bookingHistoryService,
+    prisonRepository,
+    prisonerValidator,
+    additionalBookingDetailRepository,
+  )
+
+  private val newBookingCaptor = argumentCaptor<VideoBooking>()
+  private val additionalBookingDetailCaptor = argumentCaptor<AdditionalBookingDetail>()
+
+  @Test
+  fun `should create a probation video booking for probation user`() {
+    val prisonCode = BIRMINGHAM
+    val prisonerNumber = "123456"
+    val probationBookingRequest = probationBookingRequest(
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      location = birminghamLocation,
+    ).copy(additionalBookingDetails = AdditionalBookingDetails("Fred", "fred@email.com", "0173 361 6789", "some extra information for Fred"))
+
+    val requestedProbationTeam = probationTeam(probationBookingRequest.probationTeamCode!!)
+
+    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn requestedProbationTeam
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+    whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
+    whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, prisonCode)) doReturn prisonerSearchPrisoner(prisonerNumber, prisonCode)
+    whenever(locationValidator.validatePrisonLocation(BIRMINGHAM, birminghamLocation.key)) doReturn birminghamLocation
+    whenever(locationsInsidePrisonClient.getLocationByKey(birminghamLocation.key)) doReturn birminghamLocation
+    whenever(additionalBookingDetailRepository.saveAndFlush(any())) doReturn persistedAdditionalBookingDetail
+    val (booking, prisoner) = service.create(probationBookingRequest, PROBATION_USER)
+
+    booking isEqualTo persistedVideoBooking
+    prisoner isEqualTo prisoner(prisonerNumber, prisonCode)
+
+    verify(videoBookingRepository).saveAndFlush(newBookingCaptor.capture())
+    verify(additionalBookingDetailRepository).saveAndFlush(additionalBookingDetailCaptor.capture())
+
+    with(newBookingCaptor.firstValue) {
+      bookingType isEqualTo BookingType.PROBATION
+      probationTeam isEqualTo requestedProbationTeam
+      createdTime isCloseTo LocalDateTime.now()
+      probationMeetingType isEqualTo probationBookingRequest.probationMeetingType?.name
+      comments isEqualTo "probation booking comments"
+      videoUrl isEqualTo probationBookingRequest.videoLinkUrl
+      createdBy isEqualTo PROBATION_USER.username
+      createdTime isCloseTo LocalDateTime.now()
+
+      appointments() hasSize 1
+
+      with(appointments().single()) {
+        val onePrisoner = probationBookingRequest.prisoners.single()
+
+        prisonCode isEqualTo onePrisoner.prisonCode
+        prisonerNumber isEqualTo onePrisoner.prisonerNumber
+        appointmentType isEqualTo onePrisoner.appointments.single().type?.name
+        appointmentDate isEqualTo onePrisoner.appointments.single().date!!
+        startTime isEqualTo onePrisoner.appointments.single().startTime!!.toMinutePrecision()
+        endTime isEqualTo onePrisoner.appointments.single().endTime!!.toMinutePrecision()
+        prisonLocationId isEqualTo birminghamLocation.id
+      }
+    }
+
+    with(additionalBookingDetailCaptor.firstValue) {
+      contactName isEqualTo "Fred"
+      contactEmail isEqualTo "fred@email.com"
+      contactNumber isEqualTo "0173 361 6789"
+      extraInformation isEqualTo "some extra information for Fred"
+    }
+
+    verify(locationValidator).validatePrisonLocation(BIRMINGHAM, birminghamLocation.key)
+    verify(prisonerValidator).validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)
+    verify(bookingHistoryService).createBookingHistory(any(), any())
+  }
+
+  @Test
+  fun `should create a probation video booking for prison user`() {
+    val prisonCode = BIRMINGHAM
+    val prisonerNumber = "123456"
+    val probationBookingRequest = probationBookingRequest(
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      location = birminghamLocation,
+    ).copy(additionalBookingDetails = AdditionalBookingDetails("Jane", "jane@email.com", "0114 561 6789", "some extra information for Jane"))
+
+    val requestedProbationTeam = probationTeam(probationBookingRequest.probationTeamCode!!)
+
+    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn requestedProbationTeam
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+    whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
+    whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, prisonCode)) doReturn prisonerSearchPrisoner(prisonerNumber, prisonCode)
+    whenever(locationValidator.validatePrisonLocation(BIRMINGHAM, birminghamLocation.key)) doReturn birminghamLocation
+    whenever(locationsInsidePrisonClient.getLocationByKey(birminghamLocation.key)) doReturn birminghamLocation
+    whenever(additionalBookingDetailRepository.saveAndFlush(any())) doReturn persistedAdditionalBookingDetail
+    val (booking, prisoner) = service.create(probationBookingRequest, PRISON_USER_BIRMINGHAM)
+
+    booking isEqualTo persistedVideoBooking
+    prisoner isEqualTo prisoner(prisonerNumber, prisonCode)
+
+    verify(videoBookingRepository).saveAndFlush(newBookingCaptor.capture())
+    verify(additionalBookingDetailRepository).saveAndFlush(additionalBookingDetailCaptor.capture())
+
+    with(newBookingCaptor.firstValue) {
+      bookingType isEqualTo BookingType.PROBATION
+      probationTeam isEqualTo requestedProbationTeam
+      createdTime isCloseTo LocalDateTime.now()
+      probationMeetingType isEqualTo probationBookingRequest.probationMeetingType?.name
+      comments isEqualTo "probation booking comments"
+      videoUrl isEqualTo probationBookingRequest.videoLinkUrl
+      createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
+      createdTime isCloseTo LocalDateTime.now()
+
+      appointments() hasSize 1
+
+      with(appointments().single()) {
+        val onePrisoner = probationBookingRequest.prisoners.single()
+
+        prisonCode isEqualTo onePrisoner.prisonCode
+        prisonerNumber isEqualTo onePrisoner.prisonerNumber
+        appointmentType isEqualTo onePrisoner.appointments.single().type?.name
+        appointmentDate isEqualTo onePrisoner.appointments.single().date!!
+        startTime isEqualTo onePrisoner.appointments.single().startTime!!.toMinutePrecision()
+        endTime isEqualTo onePrisoner.appointments.single().endTime!!.toMinutePrecision()
+        prisonLocationId isEqualTo birminghamLocation.id
+      }
+    }
+
+    with(additionalBookingDetailCaptor.firstValue) {
+      contactName isEqualTo "Jane"
+      contactEmail isEqualTo "jane@email.com"
+      contactNumber isEqualTo "0114 561 6789"
+      extraInformation isEqualTo "some extra information for Jane"
+    }
+
+    verify(locationValidator).validatePrisonLocation(BIRMINGHAM, birminghamLocation.key)
+    verify(prisonerValidator).validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)
+    verify(bookingHistoryService).createBookingHistory(any(), any())
+  }
+
+  @Test
+  fun `should fail to create a probation video booking for with missing extra details for meeting type OTHER`() {
+    val prisonCode = BIRMINGHAM
+    val prisonerNumber = "123456"
+    val probationBookingRequest = probationBookingRequest(
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      location = birminghamLocation,
+      probationMeetingType = ProbationMeetingType.OTHER,
+    ).copy(additionalBookingDetails = AdditionalBookingDetails("Fred", "fred@email.com", "0173 361 6789", extraInformation = null))
+
+    val requestedProbationTeam = probationTeam(probationBookingRequest.probationTeamCode!!)
+
+    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn requestedProbationTeam
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+    whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
+    whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, prisonCode)) doReturn prisonerSearchPrisoner(prisonerNumber, prisonCode)
+    whenever(locationValidator.validatePrisonLocation(BIRMINGHAM, birminghamLocation.key)) doReturn birminghamLocation
+    whenever(locationsInsidePrisonClient.getLocationByKey(birminghamLocation.key)) doReturn birminghamLocation
+    whenever(additionalBookingDetailRepository.saveAndFlush(any())) doReturn persistedAdditionalBookingDetail
+
+    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest, PROBATION_USER) }
+    error.message isEqualTo "Probation meeting extra information is required for meeting type Other"
+  }
+
+  @Test
+  fun `should fail to create a probation video booking when new appointment overlaps existing for probation user`() {
+    val prisonCode = BIRMINGHAM
+    val prisonerNumber = "123456"
+    val probationBookingRequest = probationBookingRequest(
+      prisonCode = prisonCode,
+      prisonerNumber = prisonerNumber,
+      startTime = LocalTime.of(8, 30),
+      endTime = LocalTime.of(9, 30),
+      location = birminghamLocation,
+    )
+    val requestedProbationTeam = probationTeam(probationBookingRequest.probationTeamCode!!)
+
+    val overlappingAppointment: PrisonAppointment = mock {
+      on { startTime } doReturn LocalTime.of(9, 0)
+      on { endTime } doReturn LocalTime.of(10, 0)
+    }
+
+    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn requestedProbationTeam
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+    whenever(prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(BIRMINGHAM, birminghamLocation.id, tomorrow())) doReturn listOf(overlappingAppointment)
+    whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
+    whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
+    whenever(locationValidator.validatePrisonLocation(BIRMINGHAM, birminghamLocation.key)) doReturn birminghamLocation
+    whenever(locationsInsidePrisonClient.getLocationsByKeys(setOf(birminghamLocation.key))) doReturn listOf(birminghamLocation)
+
+    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest, PROBATION_USER) }
+
+    error.message isEqualTo "Requested probation appointment overlaps with an existing appointment at location ${birminghamLocation.key}"
+
+    verifyNoInteractions(bookingHistoryService)
+  }
+
+  @Test
+  fun `should fail to create a probation video booking when not probation user`() {
+    assertThrows<IllegalArgumentException> { service.create(probationBookingRequest(), COURT_USER) }.message isEqualTo "Only probation users and prison users can create probation bookings."
+    assertThrows<IllegalArgumentException> { service.create(probationBookingRequest(), SERVICE_USER) }.message isEqualTo "Only probation users and prison users can create probation bookings."
+
+    verify(videoBookingRepository, never()).saveAndFlush(any())
+  }
+
+  @Test
+  fun `should fail to create a probation video booking when team not found for probation user`() {
+    val probationBookingRequest = probationBookingRequest()
+
+    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn null
+
+    val error = assertThrows<EntityNotFoundException> { service.create(probationBookingRequest, PROBATION_USER) }
+
+    error.message isEqualTo "Probation team with code ${probationBookingRequest.probationTeamCode} not found"
+
+    verifyNoInteractions(videoBookingRepository)
+  }
+
+  @Test
+  fun `should fail to create a probation video booking when prison not found for probation user`() {
+    val probationBookingRequest = probationBookingRequest(prisonCode = BIRMINGHAM)
+
+    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn probationTeam()
+    whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn null
+
+    val error = assertThrows<EntityNotFoundException> { service.create(probationBookingRequest, PROBATION_USER) }
+
+    error.message isEqualTo "Prison with code $BIRMINGHAM not found"
+
+    verifyNoInteractions(videoBookingRepository)
+  }
+
+  @Test
+  fun `should fail to create a probation video booking when team not enabled for probation user`() {
+    val probationBookingRequest = probationBookingRequest()
+    val disabledProbationTeam = probationTeam(probationBookingRequest.probationTeamCode!!, false)
+
+    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn disabledProbationTeam
+
+    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest, PROBATION_USER) }
+
+    error.message isEqualTo "Probation team with code ${probationBookingRequest.probationTeamCode} is not enabled"
+
+    verifyNoInteractions(videoBookingRepository)
+  }
+
+  @Test
+  fun `should fail to create a probation video booking when appointment type not probation specific for probation user`() {
+    val prisonCode = BIRMINGHAM
+    val prisonerNumber = "123456"
+    val probationBookingRequest = probationBookingRequest(prisonCode = prisonCode, prisonerNumber = prisonerNumber, appointmentType = AppointmentType.VLB_COURT_MAIN)
+    val requestedProbationTeam = probationTeam(probationBookingRequest.probationTeamCode!!)
+
+    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn requestedProbationTeam
+    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
+    whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
+    whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
+    whenever(locationValidator.validatePrisonLocations(BIRMINGHAM, setOf(birminghamLocation.key))) doReturn listOf(birminghamLocation)
+    whenever(locationsInsidePrisonClient.getLocationByKey(birminghamLocation.key)) doReturn birminghamLocation
+
+    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest, PROBATION_USER) }
+
+    error.message isEqualTo "Appointment type VLB_COURT_MAIN is not valid for probation appointments"
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegateTest.kt
@@ -1,0 +1,80 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
+
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Feature
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.amendCourtBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.amendProbationBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
+
+class VideoBookingServiceDelegateTest {
+  private val createVideoBookingService: CreateVideoBookingService = mock()
+  private val createProbationBookingService: CreateProbationBookingService = mock()
+  private val amendVideoBookingService: AmendVideoBookingService = mock()
+  private val cancelVideoBookingService: CancelVideoBookingService = mock()
+  private val featureSwitches: FeatureSwitches = mock()
+  private val delegate =
+    VideoBookingServiceDelegate(createVideoBookingService, createProbationBookingService, amendVideoBookingService, cancelVideoBookingService, featureSwitches)
+
+  private val courtBookingRequest = courtBookingRequest()
+  private val probationBookingRequest = probationBookingRequest()
+  private val amendCourtBookingRequest = amendCourtBookingRequest()
+  private val amendProbationBookingRequest = amendProbationBookingRequest()
+
+  @Test
+  fun `should delegate to correct create booking service when FEATURE_MASTER_VLPM_TYPES toggle off`() {
+    whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn false
+
+    delegate.create(courtBookingRequest, COURT_USER)
+    verify(createVideoBookingService).create(courtBookingRequest, COURT_USER)
+
+    delegate.create(probationBookingRequest, PROBATION_USER)
+    verify(createVideoBookingService).create(probationBookingRequest, PROBATION_USER)
+
+    verifyNoInteractions(createProbationBookingService)
+  }
+
+  @Test
+  fun `should delegate to correct create booking service when FEATURE_MASTER_VLPM_TYPES toggle on`() {
+    whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn true
+
+    delegate.create(courtBookingRequest, COURT_USER)
+    verify(createVideoBookingService).create(courtBookingRequest, COURT_USER)
+
+    delegate.create(probationBookingRequest, PROBATION_USER)
+    verify(createProbationBookingService).create(probationBookingRequest, PROBATION_USER)
+
+    verifyNoMoreInteractions(createVideoBookingService)
+  }
+
+  @Test
+  fun `should delegate to amend booking service`() {
+    delegate.amend(1, amendCourtBookingRequest, COURT_USER)
+    verify(amendVideoBookingService).amend(1, amendCourtBookingRequest, COURT_USER)
+
+    delegate.amend(2, amendProbationBookingRequest, PROBATION_USER)
+    verify(amendVideoBookingService).amend(2, amendProbationBookingRequest, PROBATION_USER)
+
+    verifyNoInteractions(createVideoBookingService)
+    verifyNoInteractions(createProbationBookingService)
+  }
+
+  @Test
+  fun `should delegate to cancel booking service`() {
+    delegate.cancel(1, COURT_USER)
+    verify(cancelVideoBookingService).cancel(1, COURT_USER)
+
+    verifyNoInteractions(createVideoBookingService)
+    verifyNoInteractions(createProbationBookingService)
+    verifyNoInteractions(amendVideoBookingService)
+  }
+}


### PR DESCRIPTION
Changes to support the new probation journey attributes for the create journey.

Will be doing the amend journey next.

Note the feature toggle is still off so this is safe to merge.  I have not changed the existing creation process (bar the request object).