### PR TITLE
BAVL-628 change to factor in existing booking. If one is supplied then results will still show the existing bookings time as available in the results.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
@@ -155,4 +155,9 @@ data class ScheduledAppointment(
   val firstName: String,
   val lastName: String,
   val createUserId: String,
-)
+) {
+  fun isTheSameAppointmentType(appointmentType: SupportedAppointmentTypes.Type) = appointmentTypeCode == appointmentType.code
+
+  fun isTheSameTime(appointment: PrisonAppointment) = startTime == appointment.appointmentDate.atTime(appointment.startTime) &&
+    appointment.appointmentDate.atTime(appointment.endTime) == endTime
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailableLocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailableLocationsService.kt
@@ -35,7 +35,7 @@ class AvailableLocationsService(
     val startOfDay = prisonRegime.startOfDay(request.prisonCode!!)
     val endOfDay = prisonRegime.endOfDay(request.prisonCode)
     val prisonVideoLinkLocations = getDecoratedLocationsAt(request.prisonCode)
-    val bookedLocations = bookedLocationsService.findBooked(request.prisonCode, request.date!!, prisonVideoLinkLocations)
+    val bookedLocations = bookedLocationsService.findBooked(BookedLookup(request.prisonCode, request.date!!, prisonVideoLinkLocations, request.vlbIdToExclude))
     val meetingDuration = request.bookingDuration!!.toLong()
 
     val availableLocations = buildList {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookedLocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookedLocationsService.kt
@@ -1,12 +1,21 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
+import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.ActivitiesAppointmentsClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.isTheSameAppointmentType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.isTheSameTime
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSearchResult
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping.NomisMappingClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonApiClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.ScheduledAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.isTimesOverlap
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.StatusCode
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -16,40 +25,87 @@ class BookedLocationsService(
   private val activitiesAppointmentsClient: ActivitiesAppointmentsClient,
   private val prisonApiClient: PrisonApiClient,
   private val nomisMappingClient: NomisMappingClient,
+  private val videoBookingRepository: VideoBookingRepository,
+  private val supportedAppointmentTypes: SupportedAppointmentTypes,
 ) {
-  fun findBooked(prisonCode: String, date: LocalDate, locations: Collection<Location>): BookedLocations {
+  fun findBooked(lookup: BookedLookup): BookedLocations = findBooked(
+    lookup.prisonCode,
+    lookup.date,
+    lookup.locations,
+    lookup.videoBookingIdToExclude?.let {
+      videoBookingRepository.findById(it).orElseThrow {
+        EntityNotFoundException("Video booking with ID $it not found.")
+      }?.also { exitingBooking ->
+        require(exitingBooking.isStatus(StatusCode.ACTIVE)) {
+          "Video booking ${exitingBooking.videoBookingId} is not active"
+        }
+      }?.appointments()
+    } ?: emptyList(),
+  )
+
+  private fun findBooked(
+    prisonCode: String,
+    date: LocalDate,
+    locations: Collection<Location>,
+    existingAppointments: List<PrisonAppointment>,
+  ): BookedLocations {
     val nomisToDpsLocations = nomisMappingClient.getNomisLocationMappingsBy(locations.map(Location::dpsLocationId))
       .associate { it.nomisLocationId to it.dpsLocationId }
 
     return when (activitiesAppointmentsClient.isAppointmentsRolledOutAt(prisonCode)) {
       true -> activitiesAppointmentsClient.getScheduledAppointments(prisonCode, date, nomisToDpsLocations.keys)
-        .map { result ->
-          BookedLocation(
-            locations.single { l -> l.dpsLocationId == nomisToDpsLocations[result.internalLocation!!.id] },
-            startTime = LocalTime.parse(result.startTime),
-            endTime = LocalTime.parse(result.endTime),
-          )
+        .mapNotNull { result ->
+          // Only include if result does not match existing BVLS appointment
+          if (existingAppointments.none { existing -> result.matches(existing) }) {
+            BookedLocation(
+              locations.single { l -> l.dpsLocationId == nomisToDpsLocations[result.internalLocation!!.id] },
+              startTime = LocalTime.parse(result.startTime),
+              endTime = LocalTime.parse(result.endTime),
+            )
+          } else {
+            null
+          }
         }
         .let { BookedLocations(it) }
 
       false -> prisonApiClient.getScheduledAppointments(prisonCode, date, nomisToDpsLocations.keys)
-        .map { result ->
-          BookedLocation(
-            locations.single { l -> l.dpsLocationId == nomisToDpsLocations[result.locationId] },
-            startTime = result.startTime.toLocalTime(),
-            endTime = result.endTime!!.toLocalTime(),
-          )
+        .mapNotNull { result ->
+          // Only include if result does not match existing BVLS appointment
+          if (existingAppointments.none { existing -> result.matches(existing) }) {
+            BookedLocation(
+              locations.single { l -> l.dpsLocationId == nomisToDpsLocations[result.locationId] },
+              startTime = result.startTime.toLocalTime(),
+              endTime = result.endTime!!.toLocalTime(),
+            )
+          } else {
+            null
+          }
         }
         .let { BookedLocations(it) }
     }
   }
+
+  private fun AppointmentSearchResult.matches(prisonAppointment: PrisonAppointment) = isTheSameTime(prisonAppointment) &&
+    isTheSameAppointmentType(supportedAppointmentTypes.typeOf(prisonAppointment.bookingType())) &&
+    attendees.any { it.prisonerNumber == prisonAppointment.prisonerNumber }
+
+  private fun ScheduledAppointment.matches(prisonAppointment: PrisonAppointment) = isTheSameTime(prisonAppointment) &&
+    isTheSameAppointmentType(supportedAppointmentTypes.typeOf(prisonAppointment.bookingType())) &&
+    offenderNo == prisonAppointment.prisonerNumber
 }
+
+data class BookedLookup(
+  val prisonCode: String,
+  val date: LocalDate,
+  val locations: Collection<Location>,
+  val videoBookingIdToExclude: Long? = null,
+)
 
 data class BookedLocation(val location: Location, val startTime: LocalTime, val endTime: LocalTime)
 
 class BookedLocations(booked: Collection<BookedLocation>) {
 
-  private val locations = booked.groupBy { it.location.key }
+  private val locations = booked.groupBy { it.location.dpsLocationId }
 
-  fun isBooked(location: Location, startTime: LocalTime, endTime: LocalTime) = locations[location.key]?.any { isTimesOverlap(it.startTime, it.endTime, startTime, endTime) } ?: false
+  fun isBooked(location: Location, startTime: LocalTime, endTime: LocalTime) = locations[location.dpsLocationId]?.any { isTimesOverlap(it.startTime, it.endTime, startTime, endTime) } ?: false
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -36,6 +36,7 @@ val wandsworthLocation3 =
 val pentonvilleLocation = location(prisonCode = PENTONVILLE, locationKeySuffix = "ABCDEFG", localName = "Pentonville room 3")
 val norwichLocation = location(prisonCode = NORWICH, locationKeySuffix = "ABCDEFG")
 val risleyLocation = location(prisonCode = RISLEY, locationKeySuffix = "ABCDEFG", localName = "Risley room")
+val risleyLocation2 = location(prisonCode = RISLEY, locationKeySuffix = "ABCDEFG", localName = "Risley room 2")
 
 fun location(prisonCode: String, locationKeySuffix: String, active: Boolean = true, localName: String? = null, id: UUID = UUID.randomUUID()) = Location(
   id = id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailableLocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AvailableLocationsServiceTest.kt
@@ -57,7 +57,7 @@ class AvailableLocationsServiceTest {
     @Test
     fun `should return 5 available morning times for location 1 with one blocked out booking`() {
       whenever(locationsService.getDecoratedVideoLocations(WANDSWORTH, true)) doReturn listOf(location1)
-      whenever(bookedLocationsService.findBooked(WANDSWORTH, tomorrow(), listOf(location1))) doReturn BookedLocations(
+      whenever(bookedLocationsService.findBooked(BookedLookup(WANDSWORTH, tomorrow(), listOf(location1)))) doReturn BookedLocations(
         listOf(BookedLocation(location1, LocalTime.of(10, 0), LocalTime.of(11, 0))),
       )
 
@@ -88,9 +88,11 @@ class AvailableLocationsServiceTest {
       whenever(locationsService.getDecoratedVideoLocations(WANDSWORTH, true)) doReturn listOf(location1, location2)
       whenever(
         bookedLocationsService.findBooked(
-          WANDSWORTH,
-          tomorrow(),
-          listOf(location1, location2),
+          BookedLookup(
+            WANDSWORTH,
+            tomorrow(),
+            listOf(location1, location2),
+          ),
         ),
       ) doReturn BookedLocations(
         listOf(
@@ -134,7 +136,7 @@ class AvailableLocationsServiceTest {
     @Test
     fun `should return 20 available afternoon times for location 1 when on blocked out booking`() {
       whenever(locationsService.getDecoratedVideoLocations(WANDSWORTH, true)) doReturn listOf(location1)
-      whenever(bookedLocationsService.findBooked(WANDSWORTH, tomorrow(), listOf(location1))) doReturn BookedLocations(
+      whenever(bookedLocationsService.findBooked(BookedLookup(WANDSWORTH, tomorrow(), listOf(location1)))) doReturn BookedLocations(
         listOf(BookedLocation(location1, LocalTime.of(10, 0), LocalTime.of(11, 0))),
       )
 
@@ -179,7 +181,7 @@ class AvailableLocationsServiceTest {
     @Test
     fun `should cap to 10 available afternoon times for location 1 when on blocked out booking`() {
       whenever(locationsService.getDecoratedVideoLocations(WANDSWORTH, true)) doReturn listOf(location1)
-      whenever(bookedLocationsService.findBooked(WANDSWORTH, tomorrow(), listOf(location1))) doReturn BookedLocations(
+      whenever(bookedLocationsService.findBooked(BookedLookup(WANDSWORTH, tomorrow(), listOf(location1)))) doReturn BookedLocations(
         listOf(BookedLocation(location1, LocalTime.of(10, 0), LocalTime.of(11, 0))),
       )
 
@@ -214,7 +216,7 @@ class AvailableLocationsServiceTest {
     @Test
     fun `should return 18 available morning and afternoon times for location 1 when two block out bookings`() {
       whenever(locationsService.getDecoratedVideoLocations(WANDSWORTH, true)) doReturn listOf(location1)
-      whenever(bookedLocationsService.findBooked(WANDSWORTH, tomorrow(), listOf(location1))) doReturn BookedLocations(
+      whenever(bookedLocationsService.findBooked(BookedLookup(WANDSWORTH, tomorrow(), listOf(location1)))) doReturn BookedLocations(
         listOf(
           BookedLocation(location1, LocalTime.of(10, 0), LocalTime.of(11, 0)),
           BookedLocation(location1, LocalTime.of(13, 0), LocalTime.of(14, 0)),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookedLocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookedLocationsServiceTest.kt
@@ -1,0 +1,367 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.ActivitiesAppointmentsClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentAttendeeSearchResult
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentCategorySummary
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentLocationSummary
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSearchResult
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping.NomisDpsLocationMapping
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping.NomisMappingClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonApiClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.ScheduledAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toHourMinuteStyle
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.risleyLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.risleyLocation2
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation2
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withMainCourtPrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.Optional
+
+class BookedLocationsServiceTest {
+
+  private val activitiesAppointmentsClient: ActivitiesAppointmentsClient = mock()
+  private val prisonApiClient: PrisonApiClient = mock()
+  private val nomisMappingClient: NomisMappingClient = mock()
+  private val videoBookingRepository: VideoBookingRepository = mock()
+  private val featureSwitches: FeatureSwitches = mock()
+  private val supportedAppointmentTypes = SupportedAppointmentTypes(featureSwitches)
+
+  private val service = BookedLocationsService(
+    activitiesAppointmentsClient,
+    prisonApiClient,
+    nomisMappingClient,
+    videoBookingRepository,
+    supportedAppointmentTypes,
+  )
+
+  @Nested
+  inner class ActivitiesAndAppointmentsRolledOut {
+
+    @BeforeEach
+    fun before() {
+      whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(WANDSWORTH)) doReturn true
+
+      nomisMappingClient.stub {
+        on { getNomisLocationMappingsBy(listOf(wandsworthLocation.id, wandsworthLocation2.id)) } doReturn listOf(
+          NomisDpsLocationMapping(wandsworthLocation.id, 1),
+          NomisDpsLocationMapping(wandsworthLocation2.id, 2),
+        )
+      }
+    }
+
+    @Test
+    fun `should check if Wandsworth locations are booked or not`() {
+      activitiesAppointmentsClient.stub {
+        on {
+          getScheduledAppointments(
+            prisonCode = WANDSWORTH,
+            onDate = tomorrow(),
+            locationIds = setOf(1, 2),
+          )
+        } doReturn listOf(
+          searchResult(
+            prisonCode = WANDSWORTH,
+            date = tomorrow(),
+            startTime = LocalTime.of(10, 0),
+            endTime = LocalTime.of(11, 0),
+            prisonerNumber = "123456",
+            locationId = 1,
+          ),
+          searchResult(
+            prisonCode = WANDSWORTH,
+            date = tomorrow(),
+            startTime = LocalTime.of(11, 0),
+            endTime = LocalTime.of(12, 0),
+            prisonerNumber = "123456",
+            locationId = 2,
+          ),
+        )
+      }
+
+      val booked = service.findBooked(
+        BookedLookup(
+          prisonCode = WANDSWORTH,
+          date = tomorrow(),
+          locations = listOf(wandsworthLocation.toModel(), wandsworthLocation2.toModel()),
+        ),
+      )
+
+      // location 1
+      booked.isBooked(wandsworthLocation.toModel(), LocalTime.of(9, 0), LocalTime.of(10, 0)) isBool false
+      booked.isBooked(wandsworthLocation.toModel(), LocalTime.of(9, 15), LocalTime.of(10, 15)) isBool true
+      booked.isBooked(wandsworthLocation.toModel(), LocalTime.of(10, 0), LocalTime.of(11, 0)) isBool true
+      booked.isBooked(wandsworthLocation.toModel(), LocalTime.of(10, 15), LocalTime.of(11, 15)) isBool true
+      booked.isBooked(wandsworthLocation.toModel(), LocalTime.of(11, 0), LocalTime.of(12, 0)) isBool false
+
+      // location 2
+      booked.isBooked(wandsworthLocation2.toModel(), LocalTime.of(10, 0), LocalTime.of(11, 0)) isBool false
+      booked.isBooked(wandsworthLocation2.toModel(), LocalTime.of(10, 15), LocalTime.of(11, 15)) isBool true
+      booked.isBooked(wandsworthLocation2.toModel(), LocalTime.of(11, 0), LocalTime.of(12, 0)) isBool true
+      booked.isBooked(wandsworthLocation2.toModel(), LocalTime.of(11, 45), LocalTime.of(12, 45)) isBool true
+      booked.isBooked(wandsworthLocation2.toModel(), LocalTime.of(12, 0), LocalTime.of(13, 0)) isBool false
+    }
+
+    @Test
+    fun `should check if Wandsworth locations are booked or not with matching BVLS booking appointment`() {
+      whenever(videoBookingRepository.findById(1)) doReturn Optional.of(
+        courtBooking().withMainCourtPrisonAppointment(
+          date = tomorrow(),
+          prisonCode = WANDSWORTH,
+          prisonerNumber = "123456",
+          startTime = LocalTime.of(10, 0),
+          endTime = LocalTime.of(11, 0),
+        ),
+      )
+
+      activitiesAppointmentsClient.stub {
+        on {
+          getScheduledAppointments(
+            prisonCode = WANDSWORTH,
+            onDate = tomorrow(),
+            locationIds = setOf(1, 2),
+          )
+        } doReturn listOf(
+          searchResult(
+            prisonCode = WANDSWORTH,
+            date = tomorrow(),
+            startTime = LocalTime.of(10, 0),
+            endTime = LocalTime.of(11, 0),
+            prisonerNumber = "123456",
+            locationId = 1,
+          ),
+          searchResult(
+            prisonCode = WANDSWORTH,
+            date = tomorrow(),
+            startTime = LocalTime.of(11, 0),
+            endTime = LocalTime.of(12, 0),
+            prisonerNumber = "123456",
+            locationId = 2,
+          ),
+        )
+      }
+
+      val booked = service.findBooked(
+        BookedLookup(
+          prisonCode = WANDSWORTH,
+          date = tomorrow(),
+          locations = listOf(wandsworthLocation.toModel(), wandsworthLocation2.toModel()),
+          videoBookingIdToExclude = 1,
+        ),
+      )
+
+      // location 1 times are all available when we have an existing matching BVLS appointment
+      booked.isBooked(wandsworthLocation.toModel(), LocalTime.of(9, 0), LocalTime.of(10, 0)) isBool false
+      booked.isBooked(wandsworthLocation.toModel(), LocalTime.of(9, 15), LocalTime.of(10, 15)) isBool false
+      booked.isBooked(wandsworthLocation.toModel(), LocalTime.of(10, 0), LocalTime.of(11, 0)) isBool false
+      booked.isBooked(wandsworthLocation.toModel(), LocalTime.of(10, 15), LocalTime.of(11, 15)) isBool false
+      booked.isBooked(wandsworthLocation.toModel(), LocalTime.of(11, 0), LocalTime.of(12, 0)) isBool false
+
+      // location 2
+      booked.isBooked(wandsworthLocation2.toModel(), LocalTime.of(10, 0), LocalTime.of(11, 0)) isBool false
+      booked.isBooked(wandsworthLocation2.toModel(), LocalTime.of(10, 15), LocalTime.of(11, 15)) isBool true
+      booked.isBooked(wandsworthLocation2.toModel(), LocalTime.of(11, 0), LocalTime.of(12, 0)) isBool true
+      booked.isBooked(wandsworthLocation2.toModel(), LocalTime.of(11, 45), LocalTime.of(12, 45)) isBool true
+      booked.isBooked(wandsworthLocation2.toModel(), LocalTime.of(12, 0), LocalTime.of(13, 0)) isBool false
+    }
+
+    private fun searchResult(
+      prisonCode: String,
+      date: LocalDate,
+      startTime: LocalTime,
+      endTime: LocalTime,
+      prisonerNumber: String,
+      locationId: Long,
+    ) = AppointmentSearchResult(
+      appointmentType = AppointmentSearchResult.AppointmentType.INDIVIDUAL,
+      startDate = date,
+      startTime = startTime.toHourMinuteStyle(),
+      endTime = endTime.toHourMinuteStyle(),
+      isCancelled = false,
+      isExpired = false,
+      isEdited = false,
+      appointmentId = 99,
+      appointmentSeriesId = 1,
+      appointmentName = "appointment name",
+      attendees = listOf(AppointmentAttendeeSearchResult(1, prisonerNumber, 1)),
+      category = AppointmentCategorySummary("VLB", "video link booking"),
+      inCell = false,
+      isRepeat = false,
+      maxSequenceNumber = 1,
+      prisonCode = prisonCode,
+      sequenceNumber = 1,
+      internalLocation = AppointmentLocationSummary(locationId, prisonCode, "VIDEO LINK"),
+      timeSlot = AppointmentSearchResult.TimeSlot.AM,
+    )
+  }
+
+  @Nested
+  inner class ActivitiesAndAppointmentsNotRolledOut {
+
+    @BeforeEach
+    fun before() {
+      whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(RISLEY)) doReturn false
+
+      nomisMappingClient.stub {
+        on { getNomisLocationMappingsBy(listOf(risleyLocation.id, risleyLocation2.id)) } doReturn listOf(
+          NomisDpsLocationMapping(risleyLocation.id, 1),
+          NomisDpsLocationMapping(risleyLocation2.id, 2),
+        )
+      }
+    }
+
+    @Test
+    fun `should check if Risley locations are booked or not`() {
+      prisonApiClient.stub {
+        on {
+          getScheduledAppointments(
+            prisonCode = RISLEY,
+            date = tomorrow(),
+            locationId = setOf(1, 2),
+          )
+        } doReturn listOf(
+          scheduledAppointment(
+            prisonCode = RISLEY,
+            date = tomorrow(),
+            startTime = LocalTime.of(10, 0),
+            endTime = LocalTime.of(11, 0),
+            prisonerNumber = "123456",
+            locationId = 1,
+          ),
+          scheduledAppointment(
+            prisonCode = RISLEY,
+            date = tomorrow(),
+            startTime = LocalTime.of(11, 0),
+            endTime = LocalTime.of(12, 0),
+            prisonerNumber = "123456",
+            locationId = 2,
+          ),
+        )
+      }
+
+      val booked = service.findBooked(
+        BookedLookup(
+          prisonCode = RISLEY,
+          date = tomorrow(),
+          locations = listOf(risleyLocation.toModel(), risleyLocation2.toModel()),
+        ),
+      )
+
+      // location 1
+      booked.isBooked(risleyLocation.toModel(), LocalTime.of(9, 0), LocalTime.of(10, 0)) isBool false
+      booked.isBooked(risleyLocation.toModel(), LocalTime.of(9, 15), LocalTime.of(10, 15)) isBool true
+      booked.isBooked(risleyLocation.toModel(), LocalTime.of(10, 0), LocalTime.of(11, 0)) isBool true
+      booked.isBooked(risleyLocation.toModel(), LocalTime.of(10, 15), LocalTime.of(11, 15)) isBool true
+      booked.isBooked(risleyLocation.toModel(), LocalTime.of(11, 0), LocalTime.of(12, 0)) isBool false
+
+      // location 2
+      booked.isBooked(risleyLocation2.toModel(), LocalTime.of(10, 0), LocalTime.of(11, 0)) isBool false
+      booked.isBooked(risleyLocation2.toModel(), LocalTime.of(10, 15), LocalTime.of(11, 15)) isBool true
+      booked.isBooked(risleyLocation2.toModel(), LocalTime.of(11, 0), LocalTime.of(12, 0)) isBool true
+      booked.isBooked(risleyLocation2.toModel(), LocalTime.of(11, 45), LocalTime.of(12, 45)) isBool true
+      booked.isBooked(risleyLocation2.toModel(), LocalTime.of(12, 0), LocalTime.of(13, 0)) isBool false
+    }
+
+    @Test
+    fun `should check if Risley locations are booked or not with matching BVLS booking appointment`() {
+      whenever(videoBookingRepository.findById(1)) doReturn Optional.of(
+        courtBooking().withMainCourtPrisonAppointment(
+          date = tomorrow(),
+          prisonCode = RISLEY,
+          prisonerNumber = "123456",
+          startTime = LocalTime.of(10, 0),
+          endTime = LocalTime.of(11, 0),
+        ),
+      )
+
+      prisonApiClient.stub {
+        on {
+          getScheduledAppointments(
+            prisonCode = RISLEY,
+            date = tomorrow(),
+            locationId = setOf(1, 2),
+          )
+        } doReturn listOf(
+          scheduledAppointment(
+            prisonCode = RISLEY,
+            date = tomorrow(),
+            startTime = LocalTime.of(10, 0),
+            endTime = LocalTime.of(11, 0),
+            prisonerNumber = "123456",
+            locationId = 1,
+          ),
+          scheduledAppointment(
+            prisonCode = RISLEY,
+            date = tomorrow(),
+            startTime = LocalTime.of(11, 0),
+            endTime = LocalTime.of(12, 0),
+            prisonerNumber = "123456",
+            locationId = 2,
+          ),
+        )
+      }
+
+      val booked = service.findBooked(
+        BookedLookup(
+          prisonCode = RISLEY,
+          date = tomorrow(),
+          locations = listOf(risleyLocation.toModel(), risleyLocation2.toModel()),
+          videoBookingIdToExclude = 1,
+        ),
+      )
+
+      // location 1 times are all available when we have an existing matching BVLS appointment
+      booked.isBooked(risleyLocation.toModel(), LocalTime.of(9, 0), LocalTime.of(10, 0)) isBool false
+      booked.isBooked(risleyLocation.toModel(), LocalTime.of(9, 15), LocalTime.of(10, 15)) isBool false
+      booked.isBooked(risleyLocation.toModel(), LocalTime.of(10, 0), LocalTime.of(11, 0)) isBool false
+      booked.isBooked(risleyLocation.toModel(), LocalTime.of(10, 15), LocalTime.of(11, 15)) isBool false
+      booked.isBooked(risleyLocation.toModel(), LocalTime.of(11, 0), LocalTime.of(12, 0)) isBool false
+
+      // location 2
+      booked.isBooked(risleyLocation2.toModel(), LocalTime.of(10, 0), LocalTime.of(11, 0)) isBool false
+      booked.isBooked(risleyLocation2.toModel(), LocalTime.of(10, 15), LocalTime.of(11, 15)) isBool true
+      booked.isBooked(risleyLocation2.toModel(), LocalTime.of(11, 0), LocalTime.of(12, 0)) isBool true
+      booked.isBooked(risleyLocation2.toModel(), LocalTime.of(11, 45), LocalTime.of(12, 45)) isBool true
+      booked.isBooked(risleyLocation2.toModel(), LocalTime.of(12, 0), LocalTime.of(13, 0)) isBool false
+    }
+
+    private fun scheduledAppointment(
+      prisonCode: String,
+      date: LocalDate,
+      startTime: LocalTime,
+      endTime: LocalTime,
+      prisonerNumber: String,
+      locationId: Long,
+    ): ScheduledAppointment = ScheduledAppointment(
+      id = locationId,
+      agencyId = prisonerNumber,
+      locationId = locationId,
+      locationDescription = "location description $locationId",
+      appointmentTypeCode = "VLB",
+      appointmentTypeDescription = "appointment type description $locationId",
+      startTime = date.atTime(startTime),
+      endTime = date.atTime(endTime),
+      offenderNo = prisonerNumber,
+      firstName = "first name $locationId",
+      lastName = "last name $locationId",
+      createUserId = "user id",
+    )
+  }
+}


### PR DESCRIPTION
This change allows for the amend journey where we still want to see the times in the allowable slots for the existing journeys appointments prior to changing it.