### PR TITLE
BAVL-635 include additional details on GET video booking if there are any for a booking.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/AdditionalBookingDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/AdditionalBookingDetails.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class AdditionalBookingDetails(
+  @Schema(description = "The name of the contact")
+  val contactName: String,
+
+  @Schema(description = "The email address for the contact, must be a valid email address")
+  val contactEmail: String,
+
+  @Schema(description = "The contact phone number for the contact, must be a valid phone number")
+  val contactNumber: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/VideoLinkBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/VideoLinkBooking.kt
@@ -64,6 +64,9 @@ data class VideoLinkBooking(
 
   @Schema(description = "Date and time of the last amendment to this booking.", example = "2024-03-14 14:45")
   val amendedAt: LocalDateTime?,
+
+  @Schema(description = "Additional details for the booking if there are any.")
+  val additionalBookingDetails: AdditionalBookingDetails? = null,
 )
 
 enum class BookingStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsService.kt
@@ -7,8 +7,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsid
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType.COURT
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType.PROBATION
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.VideoBookingSearchRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AdditionalBookingDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.VideoLinkBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.AdditionalBookingDetailRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ReferenceCodeRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
@@ -25,6 +27,7 @@ class VideoLinkBookingsService(
   private val referenceCodeRepository: ReferenceCodeRepository,
   private val videoAppointmentRepository: VideoAppointmentRepository,
   private val locationsInsidePrisonClient: LocationsInsidePrisonClient,
+  private val additionalBookingDetailRepository: AdditionalBookingDetailRepository,
 ) {
   fun getVideoLinkBookingById(videoBookingId: Long, user: User): VideoLinkBooking {
     val booking = videoBookingRepository.findById(videoBookingId)
@@ -46,6 +49,13 @@ class VideoLinkBookingsService(
       locations = locations,
       courtHearingTypeDescription = hearingType?.description,
       probationMeetingTypeDescription = meetingType?.description,
+      additionalBookingDetails = additionalBookingDetailRepository.findByVideoBooking(booking)?.let {
+        AdditionalBookingDetails(
+          contactName = it.contactName,
+          contactEmail = it.contactEmail,
+          contactNumber = it.contactNumber,
+        )
+      },
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/VideoLinkBookingMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/VideoLinkBookingMappers.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsid
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CourtHearingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AdditionalBookingDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.VideoLinkBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking as VideoBookingEntity
@@ -12,6 +13,7 @@ fun VideoBookingEntity.toModel(
   locations: Set<Location>,
   courtHearingTypeDescription: String? = null,
   probationMeetingTypeDescription: String? = null,
+  additionalBookingDetails: AdditionalBookingDetails? = null,
 ) = VideoLinkBooking(
   videoLinkBookingId = videoBookingId,
   bookingType = BookingType.valueOf(bookingType.name),
@@ -32,4 +34,5 @@ fun VideoBookingEntity.toModel(
   createdAt = createdTime,
   amendedBy = amendedBy,
   amendedAt = amendedTime,
+  additionalBookingDetails = additionalBookingDetails,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -270,6 +270,18 @@ fun videoRoomAttributesWithoutSchedule(
   return mutableListOf(roomAttributes)
 }
 
+fun additionalDetails(
+  booking: VideoBooking,
+  contactName: String = "contact name",
+  contactEmail: String = "contact@email.com",
+  contactNumber: String = "0114 2345678",
+) = AdditionalBookingDetail.newDetails(
+  videoBooking = booking,
+  contactName = contactName,
+  contactEmail = contactEmail,
+  contactPhoneNumber = contactNumber,
+)
+
 fun VideoBooking.hasBookingType(that: BookingType): VideoBooking = also { it.bookingType isEqualTo that }
 fun VideoBooking.hasProbationTeam(that: ProbationTeam): VideoBooking = also { it.probationTeam isEqualTo that }
 fun VideoBooking.hasMeetingType(that: ProbationMeetingType): VideoBooking = also { it.probationMeetingType isEqualTo that.name }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
@@ -48,6 +48,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.AdditionalBookingDetailRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ReferenceCodeRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
@@ -90,11 +91,15 @@ class VideoLinkBookingControllerTest {
     fun locationsInsidePrisonClient() = mock<LocationsInsidePrisonClient>()
 
     @Bean
+    fun additionalBookingDetailRepository() = mock<AdditionalBookingDetailRepository>()
+
+    @Bean
     fun videoLinkBookingsService() = VideoLinkBookingsService(
       videoBookingRepository(),
       referenceCodeRepository(),
       videoAppointmentRepository(),
       locationsInsidePrisonClient(),
+      additionalBookingDetailRepository(),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsServiceTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_BI
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.additionalDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
@@ -32,7 +33,9 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Appoint
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CourtHearingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.VideoBookingSearchRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AdditionalBookingDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingStatus
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.AdditionalBookingDetailRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ReferenceCodeRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
@@ -48,12 +51,14 @@ class VideoLinkBookingsServiceTest {
   private val referenceCodeRepository: ReferenceCodeRepository = mock()
   private val videoAppointmentRepository: VideoAppointmentRepository = mock()
   private val locationsInsidePrisonClient: LocationsInsidePrisonClient = mock()
+  private val additionalBookingDetailRepository: AdditionalBookingDetailRepository = mock()
 
   private val service = VideoLinkBookingsService(
     videoBookingRepository,
     referenceCodeRepository,
     videoAppointmentRepository,
     locationsInsidePrisonClient,
+    additionalBookingDetailRepository = additionalBookingDetailRepository,
   )
 
   @BeforeEach
@@ -117,6 +122,7 @@ class VideoLinkBookingsServiceTest {
         )
 
       whenever(videoBookingRepository.findById(1L)) doReturn Optional.of(courtBooking)
+      whenever(additionalBookingDetailRepository.findByVideoBooking(courtBooking())) doReturn additionalDetails(courtBooking(), "court contact", "court@email.com", "0114 2345678")
 
       with(service.getVideoLinkBookingById(1L, COURT_USER)) {
         prisonAppointments hasSize 3
@@ -131,6 +137,7 @@ class VideoLinkBookingsServiceTest {
         courtHearingTypeDescription isEqualTo "Tribunal"
         comments isEqualTo "Court hearing comments"
         videoLinkUrl isEqualTo "https://court.hearing.link"
+        additionalBookingDetails isEqualTo AdditionalBookingDetails("court contact", "court@email.com", "0114 2345678")
 
         // Should be null for a court booking
         assertThat(probationTeamCode).isNull()


### PR DESCRIPTION
This is support the new probation journey where we can capture optional additional details.

We need to be able to pull them back as well e.g. for amend journeys.