### PR TITLE
BAVL-658 deriving the PCVL link using room attributes for probation bookings.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttribute.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttribute.kt
@@ -97,7 +97,7 @@ class LocationAttribute(
     return when (locationUsage) {
       LocationUsage.SHARED -> AvailabilityStatus.SHARED
       LocationUsage.PROBATION -> {
-        if (allowedParties == null) {
+        if (allowedParties.isNullOrBlank()) {
           AvailabilityStatus.PROBATION_ANY
         } else {
           if (isPartyAllowed(probationTeam.code)) {
@@ -141,7 +141,7 @@ class LocationAttribute(
     return when (locationUsage) {
       LocationUsage.SHARED -> AvailabilityStatus.SHARED
       LocationUsage.COURT -> {
-        if (allowedParties == null) {
+        if (allowedParties.isNullOrBlank()) {
           AvailabilityStatus.COURT_ANY
         } else {
           if (isPartyAllowed(court.code)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
@@ -167,7 +167,6 @@ class VideoBooking private constructor(
       probationTeam: ProbationTeam,
       probationMeetingType: String,
       comments: String?,
-      videoUrl: String?,
       createdBy: String,
       createdByPrison: Boolean,
     ): VideoBooking = VideoBooking(
@@ -177,7 +176,7 @@ class VideoBooking private constructor(
       probationTeam = probationTeam,
       probationMeetingType = probationMeetingType,
       comments = comments,
-      videoUrl = videoUrl,
+      videoUrl = null,
       createdBy = createdBy,
       createdByPrison = createdByPrison,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/LocationAttributeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/LocationAttributeRepository.kt
@@ -3,8 +3,12 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.LocationAttribute
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.LocationStatus
+import java.util.UUID
 
 @Repository
 interface LocationAttributeRepository : JpaRepository<LocationAttribute, Long> {
   fun findByPrisonCode(prisonCode: String): List<LocationAttribute>
+
+  fun findByDpsLocationIdAndLocationStatus(uuid: UUID, locationStatus: LocationStatus): LocationAttribute?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/LocationAttributeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/LocationAttributeRepository.kt
@@ -3,12 +3,11 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.LocationAttribute
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.LocationStatus
 import java.util.UUID
 
 @Repository
 interface LocationAttributeRepository : JpaRepository<LocationAttribute, Long> {
   fun findByPrisonCode(prisonCode: String): List<LocationAttribute>
 
-  fun findByDpsLocationIdAndLocationStatus(uuid: UUID, locationStatus: LocationStatus): LocationAttribute?
+  fun findByDpsLocationId(uuid: UUID): LocationAttribute?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendProbationBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendProbationBookingService.kt
@@ -55,7 +55,6 @@ class AmendProbationBookingService(
     return booking.apply {
       probationMeetingType = request.probationMeetingType!!.name
       comments = request.comments
-      videoUrl = request.videoLinkUrl
       this.amendedBy = amendedBy.username
       amendedTime = now()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingService.kt
@@ -70,7 +70,6 @@ class AmendVideoBookingService(
     return booking.apply {
       probationMeetingType = request.probationMeetingType!!.name
       comments = request.comments
-      videoUrl = request.videoLinkUrl
       this.amendedBy = amendedBy.username
       amendedTime = now()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingService.kt
@@ -54,7 +54,6 @@ class CreateProbationBookingService(
       probationTeam = probationTeam,
       probationMeetingType = request.probationMeetingType!!.name,
       comments = request.comments,
-      videoUrl = request.videoLinkUrl,
       createdBy = createdBy.username,
       createdByPrison = false,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
@@ -82,7 +82,6 @@ class CreateVideoBookingService(
       probationTeam = probationTeam,
       probationMeetingType = request.probationMeetingType!!.name,
       comments = request.comments,
-      videoUrl = request.videoLinkUrl,
       createdBy = createdBy.username,
       createdByPrison = false,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/LocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/LocationsService.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationsInsidePrisonClient
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.LocationStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.LocationAttributeRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
@@ -42,22 +41,22 @@ class LocationsService(
   }
 
   /**
-   * Will also include (active) room attributes if there are any.
+   * Will also include room attributes if there are any.
    */
   fun getLocationById(id: UUID) = locationsInsidePrisonClient.getLocationById(id)
     ?.let { location ->
-      locationAttributeRepository.findByDpsLocationIdAndLocationStatus(id, LocationStatus.ACTIVE)
+      locationAttributeRepository.findByDpsLocationId(id)
         ?.let { attributes ->
           location.toModel().toDecoratedLocation(attributes.toRoomAttributes())
         } ?: location.toModel()
     }
 
   /**
-   * Will also include (active) room attributes if there are any.
+   * Will also include room attributes if there are any.
    */
   fun getLocationByKey(key: String) = locationsInsidePrisonClient.getLocationByKey(key)
     ?.let { location ->
-      locationAttributeRepository.findByDpsLocationIdAndLocationStatus(location.id, LocationStatus.ACTIVE)
+      locationAttributeRepository.findByDpsLocationId(location.id)
         ?.let { attributes ->
           location.toModel().toDecoratedLocation(attributes.toRoomAttributes())
         } ?: location.toModel()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/LocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/LocationsService.kt
@@ -3,12 +3,14 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationsInsidePrisonClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.LocationStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.LocationAttributeRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toDecoratedLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toRoomAttributes
+import java.util.UUID
 
 @Service
 class LocationsService(
@@ -38,4 +40,26 @@ class LocationsService(
     // Preserves the order of the original prison locations
     return (locationsById + decoratedLocations.associateBy { it.dpsLocationId }).values.toList()
   }
+
+  /**
+   * Will also include (active) room attributes if there are any.
+   */
+  fun getLocationById(id: UUID) = locationsInsidePrisonClient.getLocationById(id)
+    ?.let { location ->
+      locationAttributeRepository.findByDpsLocationIdAndLocationStatus(id, LocationStatus.ACTIVE)
+        ?.let { attributes ->
+          location.toModel().toDecoratedLocation(attributes.toRoomAttributes())
+        } ?: location.toModel()
+    }
+
+  /**
+   * Will also include (active) room attributes if there are any.
+   */
+  fun getLocationByKey(key: String) = locationsInsidePrisonClient.getLocationByKey(key)
+    ?.let { location ->
+      locationAttributeRepository.findByDpsLocationIdAndLocationStatus(location.id, LocationStatus.ACTIVE)
+        ?.let { attributes ->
+          location.toModel().toDecoratedLocation(attributes.toRoomAttributes())
+        } ?: location.toModel()
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ScheduleService.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationsInsidePrisonClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.ScheduleItem
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ScheduleRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
@@ -11,7 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ScheduleItem a
 @Service
 class ScheduleService(
   private val scheduleRepository: ScheduleRepository,
-  private val locationsInsidePrisonClient: LocationsInsidePrisonClient,
+  private val locationsService: LocationsService,
 ) {
   fun getScheduleForPrison(prisonCode: String, date: LocalDate, includeCancelled: Boolean): List<ScheduleItem> = if (includeCancelled) {
     scheduleRepository.getScheduleForPrisonIncludingCancelled(prisonCode, date).mapScheduleToModel()
@@ -32,7 +31,7 @@ class ScheduleService(
   }
 
   private fun List<ScheduleItemEntity>.mapScheduleToModel(): List<ScheduleItem> {
-    val locations = mapNotNull { locationsInsidePrisonClient.getLocationById(it.prisonLocationId) }
+    val locations = mapNotNull { locationsService.getLocationById(it.prisonLocationId) }
     return toModel(locations)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/PrisonAppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/PrisonAppointmentMappers.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping
 
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment as PrisonAppointmentEntity
 
@@ -10,7 +10,7 @@ fun PrisonAppointmentEntity.toModel(locations: Set<Location>) = PrisonAppointmen
   prisonerNumber = prisonerNumber,
   appointmentType = appointmentType,
   comments = comments,
-  prisonLocKey = locations.find { it.id == prisonLocationId }?.key ?: throw IllegalArgumentException("Prison location with id $prisonLocationId not found in supplied set of locations"),
+  prisonLocKey = locations.find { it.dpsLocationId == prisonLocationId }?.key ?: throw IllegalArgumentException("Prison location with id $prisonLocationId not found in supplied set of locations"),
   appointmentDate = appointmentDate,
   startTime = startTime,
   endTime = endTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/ScheduleMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/ScheduleMappers.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping
 
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CourtHearingType
@@ -14,7 +14,7 @@ fun ScheduleItemEntity.toModel(locations: List<Location>) = ScheduleItem(
   prisonAppointmentId = prisonAppointmentId,
   bookingType = BookingType.valueOf(bookingType),
   statusCode = BookingStatus.valueOf(statusCode),
-  videoUrl = videoUrl,
+  videoUrl = videoUrl.takeIf { courtCode != null } ?: locations.find { it.dpsLocationId == prisonLocationId }?.extraAttributes?.prisonVideoUrl,
   bookingComments = bookingComments,
   createdByPrison = createdByPrison,
   courtId = courtId,
@@ -33,11 +33,11 @@ fun ScheduleItemEntity.toModel(locations: List<Location>) = ScheduleItem(
   appointmentType = AppointmentType.valueOf(appointmentType),
   appointmentTypeDescription = appointmentTypeDescription,
   appointmentComments = appointmentComments,
-  prisonLocKey = locations.find { it.id == prisonLocationId }?.key ?: throw IllegalArgumentException("Prison location with id $prisonLocationId not found in supplied set of locations"),
+  prisonLocKey = locations.find { it.dpsLocationId == prisonLocationId }?.key ?: throw IllegalArgumentException("Prison location with id $prisonLocationId not found in supplied set of locations"),
   appointmentDate = appointmentDate,
   startTime = startTime,
   endTime = endTime,
-  prisonLocDesc = locations.find { it.id == prisonLocationId }?.localName ?: throw IllegalArgumentException("Prison location with id $prisonLocationId not found in supplied set of locations"),
+  prisonLocDesc = locations.find { it.dpsLocationId == prisonLocationId }?.description ?: throw IllegalArgumentException("Prison location with id $prisonLocationId not found in supplied set of locations"),
   dpsLocationId = prisonLocationId,
   createdTime = createdTime,
   createdBy = createdBy,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/VideoLinkBookingMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/VideoLinkBookingMappers.kt
@@ -1,12 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping
 
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CourtHearingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AdditionalBookingDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.VideoLinkBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType as EntityBookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking as VideoBookingEntity
 
 fun VideoBookingEntity.toModel(
@@ -28,7 +29,7 @@ fun VideoBookingEntity.toModel(
   probationMeetingType = probationMeetingType?.let { ProbationMeetingType.valueOf(probationMeetingType!!) },
   probationMeetingTypeDescription = probationMeetingType?.let { probationMeetingTypeDescription },
   comments = comments,
-  videoLinkUrl = videoUrl,
+  videoLinkUrl = videoUrl.takeIf { this.isBookingType(EntityBookingType.COURT) } ?: locations.singleOrNull()?.extraAttributes?.prisonVideoUrl,
   createdByPrison = createdByPrison,
   createdBy = createdBy,
   createdAt = createdTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/TelemetryService.kt
@@ -54,7 +54,6 @@ sealed class TelemetryEvent(val eventType: String) {
       "location_id" to meeting().prisonLocationId.toString(),
       "start" to meeting().start().toIsoDateTime(),
       "end" to meeting().end().toIsoDateTime(),
-      "cvp_link" to (videoUrl != null).toString(),
     )
   }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,6 +8,11 @@ spring:
   jpa:
     show-sql: true
 
+  datasource:
+    url: 'jdbc:postgresql://localhost/book-a-video-link-db?sslmode=prefer'
+    username: book-a-video-link
+    password: book-a-video-link
+
   flyway:
     locations: classpath:/migrations/common,classpath:/migrations/dev
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -99,7 +99,6 @@ fun probationBooking(probationTeam: ProbationTeam = probationTeam(), meetingType
   probationTeam = probationTeam,
   probationMeetingType = meetingType.name,
   comments = "Probation meeting comments",
-  videoUrl = "https://probation.meeting.link",
   createdBy = "Probation team user",
   createdByPrison = false,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -220,7 +220,6 @@ fun requestCourtVideoLinkRequest(
 fun probationBookingRequest(
   probationTeamCode: String = "BLKPPP",
   probationMeetingType: ProbationMeetingType = ProbationMeetingType.PSR,
-  videoLinkUrl: String = "https://video.link.com",
   prisonCode: String = "WWI",
   prisonerNumber: String = "123456",
   locationSuffix: String = "A-1-001",
@@ -252,7 +251,7 @@ fun probationBookingRequest(
     probationMeetingType = probationMeetingType,
     prisoners = listOf(prisoner),
     comments = comments,
-    videoLinkUrl = videoLinkUrl,
+    videoLinkUrl = null,
     additionalBookingDetails = additionalBookingDetails,
   )
 }
@@ -338,7 +337,6 @@ fun amendCourtBookingRequest(
 
 fun amendProbationBookingRequest(
   probationMeetingType: ProbationMeetingType = ProbationMeetingType.PSR,
-  videoLinkUrl: String = "https://video.link.com",
   prisonCode: String = WANDSWORTH,
   prisonerNumber: String = "123456",
   locationSuffix: String = "A-1-001",
@@ -369,7 +367,7 @@ fun amendProbationBookingRequest(
     probationMeetingType = probationMeetingType,
     prisoners = listOf(prisoner),
     comments = comments,
-    videoLinkUrl = videoLinkUrl,
+    videoLinkUrl = null,
     additionalBookingDetails = additionalBookingDetails,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/AvailabilityResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/AvailabilityResourceIntegrationTest.kt
@@ -178,7 +178,6 @@ class AvailabilityResourceIntegrationTest : IntegrationTestBase() {
     val probationBookingRequest = probationBookingRequest(
       probationTeamCode = "BLKPPP",
       probationMeetingType = ProbationMeetingType.PSR,
-      videoLinkUrl = "https://probation.videolink.com",
       prisonCode = PENTONVILLE,
       prisonerNumber = "A1111AA",
       appointmentDate = tomorrow(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/BookingContactsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/BookingContactsResourceIntegrationTest.kt
@@ -68,7 +68,6 @@ class BookingContactsResourceIntegrationTest : IntegrationTestBase() {
     val probationBookingRequest = probationBookingRequest(
       probationTeamCode = "BLKPPP",
       probationMeetingType = ProbationMeetingType.PSR,
-      videoLinkUrl = "https://probation.videolink.com",
       prisonCode = PENTONVILLE,
       prisonerNumber = "A1111AA",
       startTime = LocalTime.of(9, 0),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/InboundEventsIntegrationTest.kt
@@ -403,7 +403,6 @@ class InboundEventsIntegrationTest : SqsIntegrationTestBase() {
     val probationBookingRequest = probationBookingRequest(
       probationTeamCode = BLACKPOOL_MC_PPOC,
       probationMeetingType = ProbationMeetingType.PSR,
-      videoLinkUrl = "https://probation.videolink.com",
       prisonCode = BIRMINGHAM,
       prisonerNumber = "123456",
       startTime = LocalTime.of(9, 0),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationBookingIntegrationTest.kt
@@ -38,7 +38,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasProbationMe
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasProbationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasStartTime
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasVideoUrl
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
@@ -78,7 +77,6 @@ class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
   private val psrProbationBookingRequest = probationBookingRequest(
     probationTeamCode = BLACKPOOL_MC_PPOC,
     probationMeetingType = ProbationMeetingType.PSR,
-    videoLinkUrl = "https://probation.videolink.com",
     prisonCode = BIRMINGHAM,
     prisonerNumber = "123456",
     startTime = LocalTime.of(9, 0),
@@ -96,7 +94,6 @@ class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
   private val rrProbationBookingRequest = probationBookingRequest(
     probationTeamCode = BLACKPOOL_MC_PPOC,
     probationMeetingType = ProbationMeetingType.RR,
-    videoLinkUrl = "https://probation.videolink.com",
     prisonCode = BIRMINGHAM,
     prisonerNumber = "123456",
     startTime = LocalTime.of(11, 0),
@@ -114,7 +111,6 @@ class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
   private val otherProbationBookingRequest = probationBookingRequest(
     probationTeamCode = BLACKPOOL_MC_PPOC,
     probationMeetingType = ProbationMeetingType.OTHER,
-    videoLinkUrl = "https://probation.videolink.com",
     prisonCode = BIRMINGHAM,
     prisonerNumber = "654321",
     startTime = LocalTime.of(14, 0),
@@ -160,7 +156,6 @@ class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
       .hasBookingType(BookingType.PROBATION)
       .hasMeetingType(ProbationMeetingType.PSR)
       .hasComments("psr integration test probation booking comments")
-      .hasVideoUrl("https://probation.videolink.com")
       .hasCreatedBy(PROBATION_USER)
       .hasCreatedTimeCloseTo(LocalDateTime.now())
       .hasCreatedByPrison(false)
@@ -224,7 +219,6 @@ class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
       .hasBookingType(BookingType.PROBATION)
       .hasMeetingType(ProbationMeetingType.RR)
       .hasComments("rr integration test probation booking comments")
-      .hasVideoUrl("https://probation.videolink.com")
       .hasCreatedBy(PROBATION_USER)
       .hasCreatedTimeCloseTo(LocalDateTime.now())
       .hasCreatedByPrison(false)
@@ -261,7 +255,6 @@ class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
         startTime = LocalTime.of(12, 0),
         endTime = LocalTime.of(13, 0),
         comments = "rr integration test probation booking comments",
-        videoLinkUrl = "https://probation.videolink.com",
         additionalBookingDetails = AdditionalBookingDetails(
           contactName = "rr probation contact",
           contactEmail = "rr_probation_contact@email.com",
@@ -290,7 +283,6 @@ class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
       .hasBookingType(BookingType.PROBATION)
       .hasMeetingType(ProbationMeetingType.RR)
       .hasComments("rr integration test probation booking comments")
-      .hasVideoUrl("https://probation.videolink.com")
       .hasCreatedBy(PROBATION_USER)
       .hasCreatedTimeCloseTo(LocalDateTime.now())
       .hasCreatedByPrison(false)
@@ -346,7 +338,6 @@ class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
       .hasBookingType(BookingType.PROBATION)
       .hasMeetingType(ProbationMeetingType.OTHER)
       .hasComments("other integration test probation booking comments")
-      .hasVideoUrl("https://probation.videolink.com")
       .hasCreatedBy(PROBATION_USER)
       .hasCreatedTimeCloseTo(LocalDateTime.now())
       .hasCreatedByPrison(false)
@@ -389,7 +380,6 @@ class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
         startTime = LocalTime.of(14, 30),
         endTime = LocalTime.of(15, 30),
         comments = "other integration test probation booking comments",
-        videoLinkUrl = "https://probation.videolink.com",
         additionalBookingDetails = null,
       ),
       PROBATION_USER,
@@ -414,7 +404,6 @@ class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
       .hasBookingType(BookingType.PROBATION)
       .hasMeetingType(ProbationMeetingType.OTHER)
       .hasComments("other integration test probation booking comments")
-      .hasVideoUrl("https://probation.videolink.com")
       .hasCreatedBy(PROBATION_USER)
       .hasCreatedTimeCloseTo(LocalDateTime.now())
       .hasCreatedByPrison(false)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingControllerTest.kt
@@ -28,7 +28,6 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationsInsidePrisonClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.BvlsRequestContext
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.HmppsBookAVideoLinkApiExceptionHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
@@ -55,8 +54,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBooki
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security.CaseloadAccessException
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security.VideoBookingAccessException
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingFacade
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.LocationsService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.RequestBookingService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.VideoLinkBookingsService
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
 import uk.gov.justice.hmpps.kotlin.auth.HmppsResourceServerConfiguration
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -88,7 +89,7 @@ class VideoLinkBookingControllerTest {
     fun videoAppointmentRepository() = mock<VideoAppointmentRepository>()
 
     @Bean
-    fun locationsInsidePrisonClient() = mock<LocationsInsidePrisonClient>()
+    fun locationService() = mock<LocationsService>()
 
     @Bean
     fun additionalBookingDetailRepository() = mock<AdditionalBookingDetailRepository>()
@@ -98,7 +99,7 @@ class VideoLinkBookingControllerTest {
       videoBookingRepository(),
       referenceCodeRepository(),
       videoAppointmentRepository(),
-      locationsInsidePrisonClient(),
+      locationService(),
       additionalBookingDetailRepository(),
     )
   }
@@ -116,7 +117,7 @@ class VideoLinkBookingControllerTest {
   private lateinit var referenceCodeRepository: ReferenceCodeRepository
 
   @Autowired
-  private lateinit var locationsInsidePrisonClient: LocationsInsidePrisonClient
+  private lateinit var locationService: LocationsService
 
   @Autowired
   private lateinit var context: WebApplicationContext
@@ -227,7 +228,7 @@ class VideoLinkBookingControllerTest {
   fun `should get Wandsworth prison court video booking for external user`() {
     whenever(videoBookingRepository.findById(1)) doReturn Optional.of(wandsworthPrisonCourtBooking)
     whenever(referenceCodeRepository.findByGroupCodeAndCode("COURT_HEARING_TYPE", wandsworthPrisonCourtBooking.hearingType!!)) doReturn courtAppealReferenceCode
-    whenever(locationsInsidePrisonClient.getLocationById(wandsworthLocation.id)) doReturn wandsworthLocation
+    whenever(locationService.getLocationById(wandsworthLocation.id)) doReturn wandsworthLocation.toModel()
 
     mockMvc.get("/video-link-booking/id/1") {
       contentType = MediaType.APPLICATION_JSON
@@ -243,7 +244,7 @@ class VideoLinkBookingControllerTest {
   fun `should get Wandsworth prison court video booking for Wandsworth prison user`() {
     whenever(videoBookingRepository.findById(1)) doReturn Optional.of(wandsworthPrisonCourtBooking)
     whenever(referenceCodeRepository.findByGroupCodeAndCode("COURT_HEARING_TYPE", wandsworthPrisonCourtBooking.hearingType!!)) doReturn courtAppealReferenceCode
-    whenever(locationsInsidePrisonClient.getLocationById(wandsworthLocation.id)) doReturn wandsworthLocation
+    whenever(locationService.getLocationById(wandsworthLocation.id)) doReturn wandsworthLocation.toModel()
 
     mockMvc.get("/video-link-booking/id/1") {
       contentType = MediaType.APPLICATION_JSON

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendProbationBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendProbationBookingServiceTest.kt
@@ -40,7 +40,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasPrisonCode
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasPrisonerNumber
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasProbationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasStartTime
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasVideoUrl
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonUser
@@ -126,7 +125,6 @@ class AmendProbationBookingServiceTest {
       .hasProbationTeam(probationBooking.probationTeam!!)
       .hasMeetingType(ProbationMeetingType.PSR)
       .hasComments("probation booking comments")
-      .hasVideoUrl(probationBookingRequest.videoLinkUrl!!)
       .hasAmendedBy(PROBATION_USER)
       .hasAmendedTimeCloseTo(LocalDateTime.now())
       .appointments()
@@ -199,7 +197,6 @@ class AmendProbationBookingServiceTest {
       .hasProbationTeam(probationBooking.probationTeam!!)
       .hasMeetingType(ProbationMeetingType.PSR)
       .hasComments("probation booking comments")
-      .hasVideoUrl(probationBookingRequest.videoLinkUrl!!)
       .hasAmendedBy(PROBATION_USER)
       .hasAmendedTimeCloseTo(LocalDateTime.now())
       .appointments()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendVideoBookingServiceTest.kt
@@ -524,7 +524,7 @@ class AmendVideoBookingServiceTest {
       probationTeam isEqualTo probationBooking.probationTeam!!
       probationMeetingType isEqualTo probationBookingRequest.probationMeetingType?.name
       comments isEqualTo "probation booking comments"
-      videoUrl isEqualTo probationBookingRequest.videoLinkUrl
+      videoUrl isEqualTo null
       amendedBy isEqualTo PROBATION_USER.username
       amendedTime isCloseTo LocalDateTime.now()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingServiceTest.kt
@@ -40,7 +40,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasPrisonCode
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasPrisonerNumber
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasProbationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasStartTime
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasVideoUrl
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisoner
@@ -126,7 +125,6 @@ class CreateProbationBookingServiceTest {
       .hasProbationTeam(requestedProbationTeam)
       .hasMeetingType(ProbationMeetingType.PSR)
       .hasComments("probation booking comments")
-      .hasVideoUrl("https://video.link.com")
       .hasCreatedBy(PROBATION_USER)
       .hasCreatedTimeCloseTo(LocalDateTime.now())
       .appointments()
@@ -187,7 +185,6 @@ class CreateProbationBookingServiceTest {
       .hasProbationTeam(requestedProbationTeam)
       .hasMeetingType(ProbationMeetingType.PSR)
       .hasComments("probation booking comments")
-      .hasVideoUrl("https://video.link.com")
       .hasCreatedBy(PRISON_USER_BIRMINGHAM)
       .hasCreatedTimeCloseTo(LocalDateTime.now())
       .appointments()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/LocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/LocationsServiceTest.kt
@@ -429,13 +429,13 @@ class LocationsServiceTest {
   @Test
   fun `should return undecorated location by id`() {
     whenever(locationsClient.getLocationById(wandsworthLocation.id)) doReturn wandsworthLocation
-    whenever(locationAttributeRepository.findByDpsLocationIdAndLocationStatus(wandsworthLocation.id, LocationStatus.ACTIVE)) doReturn null
+    whenever(locationAttributeRepository.findByDpsLocationId(wandsworthLocation.id)) doReturn null
 
     service.getLocationById(wandsworthLocation.id) isEqualTo wandsworthLocation.toModel()
 
     inOrder(locationsClient, locationAttributeRepository) {
       verify(locationsClient).getLocationById(wandsworthLocation.id)
-      verify(locationAttributeRepository).findByDpsLocationIdAndLocationStatus(wandsworthLocation.id, LocationStatus.ACTIVE)
+      verify(locationAttributeRepository).findByDpsLocationId(wandsworthLocation.id)
     }
   }
 
@@ -460,26 +460,26 @@ class LocationsServiceTest {
       prisonVideoUrl = "video-link",
     )
 
-    whenever(locationAttributeRepository.findByDpsLocationIdAndLocationStatus(wandsworthLocation.id, LocationStatus.ACTIVE)) doReturn roomAttributes
+    whenever(locationAttributeRepository.findByDpsLocationId(wandsworthLocation.id)) doReturn roomAttributes
 
     service.getLocationById(wandsworthLocation.id) isEqualTo wandsworthLocation.toModel().toDecoratedLocation(roomAttributes.toRoomAttributes())
 
     inOrder(locationsClient, locationAttributeRepository) {
       verify(locationsClient).getLocationById(wandsworthLocation.id)
-      verify(locationAttributeRepository).findByDpsLocationIdAndLocationStatus(wandsworthLocation.id, LocationStatus.ACTIVE)
+      verify(locationAttributeRepository).findByDpsLocationId(wandsworthLocation.id)
     }
   }
 
   @Test
   fun `should return undecorated location by key`() {
     whenever(locationsClient.getLocationByKey(wandsworthLocation.key)) doReturn wandsworthLocation
-    whenever(locationAttributeRepository.findByDpsLocationIdAndLocationStatus(wandsworthLocation.id, LocationStatus.ACTIVE)) doReturn null
+    whenever(locationAttributeRepository.findByDpsLocationId(wandsworthLocation.id)) doReturn null
 
     service.getLocationByKey(wandsworthLocation.key) isEqualTo wandsworthLocation.toModel()
 
     inOrder(locationsClient, locationAttributeRepository) {
       verify(locationsClient).getLocationByKey(wandsworthLocation.key)
-      verify(locationAttributeRepository).findByDpsLocationIdAndLocationStatus(wandsworthLocation.id, LocationStatus.ACTIVE)
+      verify(locationAttributeRepository).findByDpsLocationId(wandsworthLocation.id)
     }
   }
 
@@ -504,13 +504,13 @@ class LocationsServiceTest {
       prisonVideoUrl = "video-link",
     )
 
-    whenever(locationAttributeRepository.findByDpsLocationIdAndLocationStatus(wandsworthLocation.id, LocationStatus.ACTIVE)) doReturn roomAttributes
+    whenever(locationAttributeRepository.findByDpsLocationId(wandsworthLocation.id)) doReturn roomAttributes
 
     service.getLocationByKey(wandsworthLocation.key) isEqualTo wandsworthLocation.toModel().toDecoratedLocation(roomAttributes.toRoomAttributes())
 
     inOrder(locationsClient, locationAttributeRepository) {
       verify(locationsClient).getLocationByKey(wandsworthLocation.key)
-      verify(locationAttributeRepository).findByDpsLocationIdAndLocationStatus(wandsworthLocation.id, LocationStatus.ACTIVE)
+      verify(locationAttributeRepository).findByDpsLocationId(wandsworthLocation.id)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ScheduleServiceTest.kt
@@ -7,26 +7,30 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationsInsidePrisonClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.LocationStatus
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.LocationUsage
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ScheduleItem
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.pentonvilleLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.today
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.yesterday
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.RoomAttributes
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CourtHearingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ScheduleRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toDecoratedLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
 import java.time.LocalDate
 import java.time.LocalTime
 
 class ScheduleServiceTest {
   private val scheduleRepository: ScheduleRepository = mock()
-  private val locationsInsidePrisonClient: LocationsInsidePrisonClient = mock()
+  private val locationsService: LocationsService = mock()
 
-  private val service = ScheduleService(scheduleRepository, locationsInsidePrisonClient)
+  private val service = ScheduleService(scheduleRepository, locationsService)
 
   private val courtCode = "COURT"
   private val probationTeamCode = "PROBATION"
@@ -159,7 +163,17 @@ class ScheduleServiceTest {
     whenever(scheduleRepository.getScheduleForPrisonIncludingCancelled(PENTONVILLE, LocalDate.now()))
       .thenReturn(prisonItems)
 
-    whenever(locationsInsidePrisonClient.getLocationById(any())) doReturn pentonvilleLocation
+    whenever(locationsService.getLocationById(any())) doReturn pentonvilleLocation.toModel().toDecoratedLocation(
+      RoomAttributes(
+        1,
+        locationUsage = LocationUsage.SHARED,
+        locationStatus = LocationStatus.ACTIVE,
+        notes = null,
+        statusMessage = null,
+        expectedActiveDate = LocalDate.now(),
+        prisonVideoUrl = "prison-video-url",
+      ),
+    )
   }
 
   @Test
@@ -193,6 +207,7 @@ class ScheduleServiceTest {
       assertThat(item.courtCode).isNull()
       assertThat(item.dpsLocationId).isEqualTo(pentonvilleLocation.id)
       assertThat(item.prisonLocDesc).isEqualTo(pentonvilleLocation.localName)
+      assertThat(item.videoUrl).isEqualTo("prison-video-url")
       assertThat(item.createdTime).isEqualTo(yesterday().atStartOfDay())
       assertThat(item.createdBy).isEqualTo("CREATOR")
       assertThat(item.updatedTime).isEqualTo(today().atStartOfDay())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingAmendedTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingAmendedTelemetryEventTest.kt
@@ -32,7 +32,6 @@ class ProbationBookingAmendedTelemetryEventTest {
       createdBy = "probation_user",
       createdByPrison = false,
       comments = null,
-      videoUrl = "http://booking.created.url",
     ).addAppointment(
       prison = prison(BIRMINGHAM),
       prisonerNumber = "ABC123",
@@ -57,7 +56,6 @@ class ProbationBookingAmendedTelemetryEventTest {
         "location_id" to birminghamLocation.id.toString(),
         "start" to tomorrow().atTime(LocalTime.of(14, 0)).toIsoDateTime(),
         "end" to tomorrow().atTime(LocalTime.of(15, 0)).toIsoDateTime(),
-        "cvp_link" to "true",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(
@@ -77,7 +75,6 @@ class ProbationBookingAmendedTelemetryEventTest {
       createdBy = "probation_user",
       createdByPrison = false,
       comments = null,
-      videoUrl = "http://booking.created.url",
     ).addAppointment(
       prison = prison(BIRMINGHAM),
       prisonerNumber = "ABC123",
@@ -102,7 +99,6 @@ class ProbationBookingAmendedTelemetryEventTest {
         "location_id" to birminghamLocation.id.toString(),
         "start" to tomorrow().atTime(LocalTime.of(14, 0)).toIsoDateTime(),
         "end" to tomorrow().atTime(LocalTime.of(15, 0)).toIsoDateTime(),
-        "cvp_link" to "true",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCancelledTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCancelledTelemetryEventTest.kt
@@ -29,7 +29,6 @@ class ProbationBookingCancelledTelemetryEventTest {
     createdBy = "probation_user",
     createdByPrison = false,
     comments = null,
-    videoUrl = "http://booking.created.url",
   ).addAppointment(
     prison = prison(BIRMINGHAM),
     prisonerNumber = "ABC123",
@@ -56,7 +55,6 @@ class ProbationBookingCancelledTelemetryEventTest {
         "location_id" to birminghamLocation.id.toString(),
         "start" to tomorrow().atTime(LocalTime.of(14, 0)).toIsoDateTime(),
         "end" to tomorrow().atTime(LocalTime.of(15, 0)).toIsoDateTime(),
-        "cvp_link" to "true",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(
@@ -84,7 +82,6 @@ class ProbationBookingCancelledTelemetryEventTest {
         "location_id" to birminghamLocation.id.toString(),
         "start" to tomorrow().atTime(LocalTime.of(14, 0)).toIsoDateTime(),
         "end" to tomorrow().atTime(LocalTime.of(15, 0)).toIsoDateTime(),
-        "cvp_link" to "true",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(
@@ -112,7 +109,6 @@ class ProbationBookingCancelledTelemetryEventTest {
         "location_id" to birminghamLocation.id.toString(),
         "start" to tomorrow().atTime(LocalTime.of(14, 0)).toIsoDateTime(),
         "end" to tomorrow().atTime(LocalTime.of(15, 0)).toIsoDateTime(),
-        "cvp_link" to "true",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(
@@ -140,7 +136,6 @@ class ProbationBookingCancelledTelemetryEventTest {
         "location_id" to birminghamLocation.id.toString(),
         "start" to tomorrow().atTime(LocalTime.of(14, 0)).toIsoDateTime(),
         "end" to tomorrow().atTime(LocalTime.of(15, 0)).toIsoDateTime(),
-        "cvp_link" to "true",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(
@@ -168,7 +163,6 @@ class ProbationBookingCancelledTelemetryEventTest {
         "location_id" to birminghamLocation.id.toString(),
         "start" to tomorrow().atTime(LocalTime.of(14, 0)).toIsoDateTime(),
         "end" to tomorrow().atTime(LocalTime.of(15, 0)).toIsoDateTime(),
-        "cvp_link" to "true",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCreatedTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCreatedTelemetryEventTest.kt
@@ -28,7 +28,6 @@ class ProbationBookingCreatedTelemetryEventTest {
       createdBy = "probation_user",
       createdByPrison = false,
       comments = null,
-      videoUrl = "http://booking.created.url",
     ).addAppointment(
       prison = prison(BIRMINGHAM),
       prisonerNumber = "ABC123",
@@ -50,7 +49,6 @@ class ProbationBookingCreatedTelemetryEventTest {
         "location_id" to birminghamLocation.id.toString(),
         "start" to tomorrow().atTime(LocalTime.of(14, 0)).toIsoDateTime(),
         "end" to tomorrow().atTime(LocalTime.of(15, 0)).toIsoDateTime(),
-        "cvp_link" to "true",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(


### PR DESCRIPTION
This covers off most what I think is needed with regards to showing the video URL for probation bookings.

This is not behind any feature toggle, if a room is decorated then it will show the link in the existing service, I don't think this really matters to be honest.

@timharrison-moj I am unsure on this point on the Jira ticket `The probation appointment will have a room` so I have not done this yet. 