### PR TITLE
BAVL-676 using bulk nomis mapping location lookup endpoint now that it is available in favour of multiple single calls.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/nomismapping/NomisMappingClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/nomismapping/NomisMappingClient.kt
@@ -1,11 +1,16 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping
 
 import org.slf4j.LoggerFactory
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.CacheConfiguration
 import java.util.UUID
+
+inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>() {}
 
 @Component
 class NomisMappingClient(private val nomisMappingApiWebClient: WebClient) {
@@ -13,7 +18,15 @@ class NomisMappingClient(private val nomisMappingApiWebClient: WebClient) {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun getNomisLocationMappingsBy(dpsLocationIds: Collection<UUID>): Collection<NomisDpsLocationMapping> = dpsLocationIds.mapNotNull { getNomisLocationMappingBy(it) }
+  @Cacheable(CacheConfiguration.NOMIS_MAPPING_CACHE_NAME)
+  fun getNomisLocationMappingsBy(dpsLocationIds: DpsLocationsIds) = nomisMappingApiWebClient
+    .post()
+    .uri("/api/locations/dps")
+    .bodyValue(dpsLocationIds)
+    .retrieve()
+    .bodyToMono(typeReference<Collection<NomisDpsLocationMapping>>())
+    .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
+    .block() ?: emptyList()
 
   fun getNomisLocationMappingBy(dpsLocationId: UUID): NomisDpsLocationMapping? = nomisMappingApiWebClient
     .get()
@@ -23,6 +36,20 @@ class NomisMappingClient(private val nomisMappingApiWebClient: WebClient) {
     .doOnError { error -> log.info("Error looking up internal location mapping by dps location id $dpsLocationId in mapping service", error) }
     .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
     .block()
+}
+
+class DpsLocationsIds(locationIds: Collection<UUID>) {
+  val locationIds = locationIds.sorted()
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as DpsLocationsIds
+
+    return locationIds == other.locationIds
+  }
+
+  override fun hashCode() = locationIds.hashCode()
 }
 
 data class NomisDpsLocationMapping(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/CacheConfiguration.kt
@@ -22,6 +22,9 @@ class CacheConfiguration {
     const val VIDEO_LINK_LOCATIONS_CACHE_NAME: String = "video_link_locations"
     const val NON_RESIDENTIAL_LOCATIONS_CACHE_NAME: String = "non_residential_locations"
     const val ROLLED_OUT_PRISONS_CACHE_NAME = "rolled_out_prisons"
+    const val NOMIS_MAPPING_CACHE_NAME = "nomis_mapping"
+    const val TWO = 2L
+    const val FIVE = 5L
   }
 
   @Bean
@@ -29,23 +32,30 @@ class CacheConfiguration {
     VIDEO_LINK_LOCATIONS_CACHE_NAME,
     NON_RESIDENTIAL_LOCATIONS_CACHE_NAME,
     ROLLED_OUT_PRISONS_CACHE_NAME,
+    NOMIS_MAPPING_CACHE_NAME,
   )
 
   @CacheEvict(value = [VIDEO_LINK_LOCATIONS_CACHE_NAME], allEntries = true)
-  @Scheduled(fixedDelay = 5, timeUnit = TimeUnit.MINUTES)
+  @Scheduled(fixedDelay = FIVE, timeUnit = TimeUnit.MINUTES)
   fun cacheEvictVideoLinkLocations() {
-    log.info("Evicting cache: $VIDEO_LINK_LOCATIONS_CACHE_NAME after 5 mins")
+    log.info("Evicting cache: $VIDEO_LINK_LOCATIONS_CACHE_NAME after $FIVE mins")
   }
 
   @CacheEvict(value = [NON_RESIDENTIAL_LOCATIONS_CACHE_NAME], allEntries = true)
-  @Scheduled(fixedDelay = 5, timeUnit = TimeUnit.MINUTES)
+  @Scheduled(fixedDelay = FIVE, timeUnit = TimeUnit.MINUTES)
   fun cacheEvictNonResidentialLocations() {
-    log.info("Evicting cache: $NON_RESIDENTIAL_LOCATIONS_CACHE_NAME after 5 mins")
+    log.info("Evicting cache: $NON_RESIDENTIAL_LOCATIONS_CACHE_NAME after $FIVE mins")
   }
 
   @CacheEvict(value = [ROLLED_OUT_PRISONS_CACHE_NAME], allEntries = true)
-  @Scheduled(fixedDelay = 5, timeUnit = TimeUnit.MINUTES)
+  @Scheduled(fixedDelay = FIVE, timeUnit = TimeUnit.MINUTES)
   fun cacheEvictRolledOutPrisons() {
-    log.info("Evicting cache: $ROLLED_OUT_PRISONS_CACHE_NAME after 5 mins")
+    log.info("Evicting cache: $ROLLED_OUT_PRISONS_CACHE_NAME after $FIVE mins")
+  }
+
+  @CacheEvict(value = [NOMIS_MAPPING_CACHE_NAME], allEntries = true)
+  @Scheduled(fixedDelay = TWO, timeUnit = TimeUnit.HOURS)
+  fun cacheEvictNomisMapping() {
+    log.info("Evicting cache: $NOMIS_MAPPING_CACHE_NAME after $TWO hours")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/AvailableLocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/AvailableLocationsService.kt
@@ -16,8 +16,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.slot
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.CourtRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.LocationAttributeRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookedLocationsService
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookedLookup
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.LocationsService
 import java.time.LocalDateTime
 import java.time.LocalTime

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/BookedLocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/BookedLocationsService.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.availability
 
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.isTheSameAppointmentType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.isTheSameTime
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSearchResult
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping.DpsLocationsIds
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping.NomisMappingClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonApiClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.ScheduledAppointment
@@ -49,7 +50,7 @@ class BookedLocationsService(
     locations: Collection<Location>,
     existingAppointments: List<PrisonAppointment>,
   ): BookedLocations {
-    val nomisToDpsLocations = nomisMappingClient.getNomisLocationMappingsBy(locations.map(Location::dpsLocationId))
+    val nomisToDpsLocations = nomisMappingClient.getNomisLocationMappingsBy(DpsLocationsIds(locations.map(Location::dpsLocationId)))
       .associate { it.nomisLocationId to it.dpsLocationId }
 
     return when (activitiesAppointmentsClient.isAppointmentsRolledOutAt(prisonCode)) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/AvailableLocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/AvailableLocationsServiceTest.kt
@@ -30,10 +30,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Availab
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AvailableLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.slot
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookedLocation
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookedLocations
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookedLocationsService
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookedLookup
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.LocationsService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
 import java.time.LocalDateTime

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/BookedLocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/BookedLocationsServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.availability
 
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentCategorySummary
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentLocationSummary
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.model.AppointmentSearchResult
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping.DpsLocationsIds
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping.NomisDpsLocationMapping
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping.NomisMappingClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.PrisonApiClient
@@ -60,7 +61,7 @@ class BookedLocationsServiceTest {
       whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(WANDSWORTH)) doReturn true
 
       nomisMappingClient.stub {
-        on { getNomisLocationMappingsBy(listOf(wandsworthLocation.id, wandsworthLocation2.id)) } doReturn listOf(
+        on { getNomisLocationMappingsBy(DpsLocationsIds(listOf(wandsworthLocation.id, wandsworthLocation2.id))) } doReturn listOf(
           NomisDpsLocationMapping(wandsworthLocation.id, 1),
           NomisDpsLocationMapping(wandsworthLocation2.id, 2),
         )
@@ -220,7 +221,7 @@ class BookedLocationsServiceTest {
       whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(RISLEY)) doReturn false
 
       nomisMappingClient.stub {
-        on { getNomisLocationMappingsBy(listOf(risleyLocation.id, risleyLocation2.id)) } doReturn listOf(
+        on { getNomisLocationMappingsBy(DpsLocationsIds(listOf(risleyLocation.id, risleyLocation2.id))) } doReturn listOf(
           NomisDpsLocationMapping(risleyLocation.id, 1),
           NomisDpsLocationMapping(risleyLocation2.id, 2),
         )


### PR DESCRIPTION
This replaces multiple single GET requests to the NOMIS mapping service with a single POST call now that a bulk lookup endpoint is available on the NOMIS mapping service.