### PR TITLE
BAVL-691 fix issue where by a transfer event fails when attempting to send email due to using the wrong prison code 'TRN' looking up the prison.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
@@ -162,7 +162,7 @@ class BookingFacade(
 
   private fun sendCourtBookingEmails(eventType: BookingAction, booking: VideoBooking, prisoner: Prisoner, user: User) {
     val (pre, main, post) = booking.courtAppointments()
-    val prison = prisonRepository.findByCode(prisoner.prisonCode)!!
+    val prison = prisonRepository.findByCode(booking.prisonCode())!!
     val contacts = contactsService.getBookingContacts(booking.videoBookingId, user).withAnEmailAddress()
     val locations = setOfNotNull(pre?.prisonLocationId, main.prisonLocationId, post?.prisonLocationId).mapNotNull { locationsInsidePrisonClient.getLocationById(it) }.associateBy { it.id }
 
@@ -180,7 +180,7 @@ class BookingFacade(
 
   private fun sendProbationBookingEmails(eventType: BookingAction, booking: VideoBooking, prisoner: Prisoner, user: User) {
     val appointment = booking.appointments().single()
-    val prison = prisonRepository.findByCode(prisoner.prisonCode)!!
+    val prison = prisonRepository.findByCode(booking.prisonCode())!!
     val contacts = contactsService.getBookingContacts(booking.videoBookingId, user).withAnEmailAddress()
     val location = locationsInsidePrisonClient.getLocationById(appointment.prisonLocationId)!!
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
@@ -1331,7 +1331,7 @@ class BookingFacadeTest {
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
           "probationTeam" to "probation team description",
           "probationEmailAddress" to "probation.user@probation.com",
-          "prison" to "Wandsworth",
+          "prison" to "Birmingham",
           "offenderNo" to "654321",
           "prisonerName" to "Bob Builder",
           "dateOfBirth" to LocalDate.EPOCH.toMediumFormatStyle(),
@@ -1345,7 +1345,7 @@ class BookingFacadeTest {
         address isEqualTo PROBATION_USER.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
           "probationTeam" to "probation team description",
-          "prison" to "Wandsworth",
+          "prison" to "Birmingham",
           "offenderNo" to "654321",
           "prisonerName" to "Bob Builder",
           "dateOfBirth" to LocalDate.EPOCH.toMediumFormatStyle(),
@@ -1503,7 +1503,7 @@ class BookingFacadeTest {
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
           "probationTeam" to "probation team description",
           "probationEmailAddress" to "probation.user@probation.com",
-          "prison" to "Wandsworth",
+          "prison" to "Birmingham",
           "offenderNo" to "654321",
           "prisonerName" to "Bob Builder",
           "dateOfBirth" to LocalDate.EPOCH.toMediumFormatStyle(),
@@ -1517,7 +1517,7 @@ class BookingFacadeTest {
         address isEqualTo PROBATION_USER.email
         personalisation() containsEntriesExactlyInAnyOrder mapOf(
           "probationTeam" to "probation team description",
-          "prison" to "Wandsworth",
+          "prison" to "Birmingham",
           "offenderNo" to "654321",
           "prisonerName" to "Bob Builder",
           "dateOfBirth" to LocalDate.EPOCH.toMediumFormatStyle(),


### PR DESCRIPTION
Use the prison code off the booking and not the prisoner when prepping prison contacts for sending emails.  This is because the prison code may be something not recognised e.g. 'TRN' or 'OUT'.

We could use the last prison ID.  But if feels like we should be taking it off the booking as this should be where the email is sent.