### PR TITLE
BAVL-696 adding support for 'Team not listed' for prison users when creating probation bookings.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
@@ -13,6 +13,7 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.requireNot
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -173,7 +174,7 @@ class VideoBooking private constructor(
       bookingType = BookingType.PROBATION,
       court = null,
       hearingType = null,
-      probationTeam = probationTeam,
+      probationTeam = probationTeam.also { requireNot(probationTeam.readOnly) { "Probation team with code ${it.code} is read only" } },
       probationMeetingType = probationMeetingType,
       comments = comments,
       videoUrl = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingService.kt
@@ -18,8 +18,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationT
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toPrisonerDetails
 
-private const val MEETING_TYPE_OTHER = "OTHER"
-
 @Service
 class CreateProbationBookingService(
   private val probationTeamRepository: ProbationTeamRepository,
@@ -45,7 +43,6 @@ class CreateProbationBookingService(
     }
 
     val probationTeam = probationTeamRepository.findByCode(request.probationTeamCode!!)
-      ?.also { require(it.enabled) { "Probation team with code ${it.code} is not enabled" } }
       ?: throw EntityNotFoundException("Probation team with code ${request.probationTeamCode} not found")
 
     val prisoner = request.prisoner().validate()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ProbationTeamsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ProbationTeamsService.kt
@@ -19,10 +19,10 @@ class ProbationTeamsService(
 ) {
   @Cacheable(CacheConfiguration.PROBATION_TEAMS_CACHE)
   fun getProbationTeams(enabledOnly: Boolean) = if (enabledOnly) {
-    probationTeamRepository.findAllByEnabledIsTrue().toModel()
+    probationTeamRepository.findAllByEnabledIsTrue()
   } else {
-    probationTeamRepository.findAll().filter(ProbationTeam::isReadable).toModel()
-  }
+    probationTeamRepository.findAll().filter(ProbationTeam::isReadable)
+  }.sortedWith(compareBy({ !it.enabled }, { it.description })).toModel()
 
   fun getUserProbationTeamPreferences(user: User) = probationTeamRepository.findProbationTeamsByUsername(user.username).toModel()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/ProbationTeamMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/ProbationTeamMappers.kt
@@ -11,4 +11,4 @@ fun ProbationTeamEntity.toModel() = ProbationTeam(
   notes = notes,
 )
 
-fun List<ProbationTeamEntity>.toModel() = map { it.toModel() }.sortedBy { it.description }
+fun List<ProbationTeamEntity>.toModel() = map { it.toModel() }

--- a/src/main/resources/migrations/common/V2025.03.19__insert_probation_team_not_listed.sql
+++ b/src/main/resources/migrations/common/V2025.03.19__insert_probation_team_not_listed.sql
@@ -1,0 +1,2 @@
+insert into probation_team (code, description, enabled, read_only, notes, created_by, created_time)
+  values ('TEAM_NOT_LISTED', 'Team not listed', false, false, 'Support for prison users where the team is not listed', 'MATT', current_timestamp);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
@@ -9,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.yesterday
 import java.time.LocalDateTime.now
@@ -87,5 +89,31 @@ class VideoBookingTest {
   @Test
   fun `should not be a migrated booking`() {
     booking.isMigrated() isBool false
+  }
+
+  @Test
+  fun `should reject new booking if probation team is read only`() {
+    assertThrows<IllegalArgumentException> {
+      VideoBooking.newProbationBooking(
+        probationTeam = probationTeam("READ_ONLY", readOnly = true),
+        probationMeetingType = "PSR",
+        comments = null,
+        createdBy = "TEST",
+        createdByPrison = false,
+      )
+    }.message isEqualTo "Probation team with code READ_ONLY is read only"
+  }
+
+  @Test
+  fun `should accept new booking if probation team is not read only`() {
+    assertDoesNotThrow {
+      VideoBooking.newProbationBooking(
+        probationTeam = probationTeam("NOT_READ_ONLY", readOnly = false),
+        probationMeetingType = "PSR",
+        comments = null,
+        createdBy = "TEST",
+        createdByPrison = false,
+      )
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -57,11 +57,12 @@ fun prison(prisonCode: String = BIRMINGHAM, enabled: Boolean = true) = Prison(
   createdBy = "Test",
 )
 
-fun probationTeam(code: String = "BLKPPP", enabled: Boolean = true) = ProbationTeam(
+fun probationTeam(code: String = "BLKPPP", enabled: Boolean = true, readOnly: Boolean = false) = ProbationTeam(
   probationTeamId = 0,
   code = code,
   description = "probation team description",
   enabled = enabled,
+  readOnly = readOnly,
   notes = null,
   createdBy = "Test",
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ProbationTeams.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ProbationTeams.kt
@@ -2,5 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper
 
 const val BLACKPOOL_MC_PPOC = "BLKPPP"
 const val HARROW = "HARROW"
+const val TEAM_NOT_LISTED = "TEAM_NOT_LISTED"
 
-val probationTeams = setOf(BLACKPOOL_MC_PPOC, HARROW)
+val probationTeams = setOf(BLACKPOOL_MC_PPOC, HARROW, TEAM_NOT_LISTED)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationTeamsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationTeamsResourceIntegrationTest.kt
@@ -34,16 +34,16 @@ class ProbationTeamsResourceIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:integration-test-data/seed-enabled-probation-team-data.sql")
   @Test
   fun `should return filtered and unfiltered probation teams`() {
-    probationTeamRepository.findAll() hasSize 31 // Including 1 read-only team
+    probationTeamRepository.findAll() hasSize 32 // Including 1 read-only team
 
     val enabledOnlyTeams = webTestClient.getProbationTeams(true)
     enabledOnlyTeams hasSize 29
     enabledOnlyTeams.all { it.enabled } isBool true
 
     val allTeams = webTestClient.getProbationTeams(false)
-    allTeams hasSize 30
+    allTeams hasSize 31
     allTeams.count { it.enabled } isEqualTo 29
-    allTeams.count { !it.enabled } isEqualTo 1
+    allTeams.count { !it.enabled } isEqualTo 2
   }
 
   @Sql("classpath:integration-test-data/seed-user-probation-team-data.sql")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingServiceTest.kt
@@ -277,20 +277,6 @@ class CreateProbationBookingServiceTest {
   }
 
   @Test
-  fun `should fail to create a probation video booking when team not enabled for probation user`() {
-    val probationBookingRequest = probationBookingRequest()
-    val disabledProbationTeam = probationTeam(probationBookingRequest.probationTeamCode!!, false)
-
-    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn disabledProbationTeam
-
-    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest, PROBATION_USER) }
-
-    error.message isEqualTo "Probation team with code ${probationBookingRequest.probationTeamCode} is not enabled"
-
-    verifyNoInteractions(videoBookingRepository)
-  }
-
-  @Test
   fun `should fail to create a probation video booking when appointment type not probation specific for probation user`() {
     val prisonCode = BIRMINGHAM
     val prisonerNumber = "123456"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ProbationTeamsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/ProbationTeamsServiceTest.kt
@@ -9,6 +9,7 @@ import org.mockito.MockitoAnnotations.openMocks
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.never
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsExactly
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
@@ -44,7 +45,7 @@ class ProbationTeamsServiceTest {
   }
 
   @Test
-  fun `Should return enabled teams only`() {
+  fun `Should return enabled teams only sorted`() {
     val enabledTeams = listOf(
       generateEntity(1L, "NORTH", "North"),
       generateEntity(2L, "SOUTH", "South"),
@@ -66,7 +67,7 @@ class ProbationTeamsServiceTest {
   }
 
   @Test
-  fun `Should return all teams`() {
+  fun `Should return all teams sorted with enabled having priority order`() {
     val enabledTeams = listOf(
       generateEntity(1L, "NORTH", "North"),
       generateEntity(2L, "SOUTH", "South"),
@@ -76,6 +77,7 @@ class ProbationTeamsServiceTest {
 
     val disabledTeams = listOf(
       generateEntity(5L, "NORTHWEST", "North West", enabled = false),
+      generateEntity(6L, "NORTHEAST", "North East", enabled = false),
     )
 
     val allTeams = enabledTeams.plus(disabledTeams)
@@ -83,7 +85,14 @@ class ProbationTeamsServiceTest {
     whenever(probationTeamRepository.findAllByEnabledIsTrue()) doReturn (enabledTeams)
     whenever(probationTeamRepository.findAll()) doReturn allTeams
 
-    service.getProbationTeams(false) containsExactlyInAnyOrder allTeams.toModel()
+    service.getProbationTeams(false) containsExactly listOf(
+      generateEntity(3L, "EAST", "East").toModel(),
+      generateEntity(1L, "NORTH", "North").toModel(),
+      generateEntity(2L, "SOUTH", "South").toModel(),
+      generateEntity(4L, "WEST", "West").toModel(),
+      generateEntity(6L, "NORTHEAST", "North East", enabled = false).toModel(),
+      generateEntity(5L, "NORTHWEST", "North West", enabled = false).toModel(),
+    )
     verify(probationTeamRepository, never()).findAllByEnabledIsTrue()
   }
 }


### PR DESCRIPTION
This change introduces a 'Team not listed' probation team to support creation of probation booking by prison users.

'Team not listed' will be available as a team option (at the bottom of the team choices) in A&A and DPS add appointment for probation booking creation.