### PR TITLE
BAVL-696 fixing bug with prison users in new probabtion journey, not setting created by prison correctly.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
@@ -14,6 +14,7 @@ import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.requireNot
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.PrisonUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -168,8 +169,7 @@ class VideoBooking private constructor(
       probationTeam: ProbationTeam,
       probationMeetingType: String,
       comments: String?,
-      createdBy: String,
-      createdByPrison: Boolean,
+      createdBy: User,
     ): VideoBooking = VideoBooking(
       bookingType = BookingType.PROBATION,
       court = null,
@@ -178,8 +178,8 @@ class VideoBooking private constructor(
       probationMeetingType = probationMeetingType,
       comments = comments,
       videoUrl = null,
-      createdBy = createdBy,
-      createdByPrison = createdByPrison,
+      createdBy = createdBy.username,
+      createdByPrison = createdBy is PrisonUser,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingService.kt
@@ -51,8 +51,7 @@ class CreateProbationBookingService(
       probationTeam = probationTeam,
       probationMeetingType = request.probationMeetingType!!.name,
       comments = request.comments,
-      createdBy = createdBy.username,
-      createdByPrison = false,
+      createdBy = createdBy,
     )
       .also { thisBooking -> appointmentsService.createAppointmentForProbation(thisBooking, request.prisoner(), createdBy) }
       .also { thisBooking -> videoBookingRepository.saveAndFlush(thisBooking) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateVideoBookingService.kt
@@ -82,8 +82,7 @@ class CreateVideoBookingService(
       probationTeam = probationTeam,
       probationMeetingType = request.probationMeetingType!!.name,
       comments = request.comments,
-      createdBy = createdBy.username,
-      createdByPrison = false,
+      createdBy = createdBy,
     )
       .also { thisBooking -> appointmentsService.createAppointmentForProbation(thisBooking, request.prisoner(), createdBy) }
       .also { thisBooking -> videoBookingRepository.saveAndFlush(thisBooking) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
@@ -98,8 +99,7 @@ class VideoBookingTest {
         probationTeam = probationTeam("READ_ONLY", readOnly = true),
         probationMeetingType = "PSR",
         comments = null,
-        createdBy = "TEST",
-        createdByPrison = false,
+        createdBy = PROBATION_USER,
       )
     }.message isEqualTo "Probation team with code READ_ONLY is read only"
   }
@@ -111,8 +111,7 @@ class VideoBookingTest {
         probationTeam = probationTeam("NOT_READ_ONLY", readOnly = false),
         probationMeetingType = "PSR",
         comments = null,
-        createdBy = "TEST",
-        createdByPrison = false,
+        createdBy = PROBATION_USER,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -100,8 +100,7 @@ fun probationBooking(probationTeam: ProbationTeam = probationTeam(), meetingType
   probationTeam = probationTeam,
   probationMeetingType = meetingType.name,
   comments = "Probation meeting comments",
-  createdBy = "Probation team user",
-  createdByPrison = false,
+  createdBy = PROBATION_USER,
 )
 
 /**

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationBookingIntegrationTest.kt
@@ -476,7 +476,7 @@ class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
       .hasComments("psr integration test probation booking comments")
       .hasCreatedBy(PRISON_USER_BIRMINGHAM)
       .hasCreatedTimeCloseTo(LocalDateTime.now())
-      .hasCreatedByPrison(false)
+      .hasCreatedByPrison(true)
       .also { it.probationTeam?.code isEqualTo TEAM_NOT_LISTED }
 
     prisonAppointmentRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingHistoryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingHistoryServiceTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
@@ -104,7 +105,7 @@ class BookingHistoryServiceTest {
       probationMeetingType isEqualTo probationBooking.probationMeetingType
       comments isEqualTo "Probation meeting comments"
       videoUrl isEqualTo probationBooking.videoUrl
-      createdBy isEqualTo "Probation team user"
+      createdBy isEqualTo PROBATION_USER.username
       createdTime isCloseTo LocalDateTime.now()
       appointments() hasSize 1
       with(appointments().first()) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingServiceTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasBookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasComments
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasContactName
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasCreatedBy
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasCreatedByPrison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasCreatedTimeCloseTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasEmailAddress
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasEndTime
@@ -186,6 +187,7 @@ class CreateProbationBookingServiceTest {
       .hasMeetingType(ProbationMeetingType.PSR)
       .hasComments("probation booking comments")
       .hasCreatedBy(PRISON_USER_BIRMINGHAM)
+      .hasCreatedByPrison(true)
       .hasCreatedTimeCloseTo(LocalDateTime.now())
       .appointments()
       .single()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/VideoLinkBookingMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/VideoLinkBookingMappersTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.CHESTERFIELD_JUSTICE_CENTRE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_CENTRE
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.locationAttributes
@@ -91,8 +92,7 @@ class VideoLinkBookingMappersTest {
       probationTeam(DERBY_JUSTICE_CENTRE),
       probationMeetingType = "PSR",
       comments = "some comments for the probation booking",
-      createdBy = "test",
-      createdByPrison = false,
+      createdBy = PROBATION_USER,
     )
 
     booking.toModel(locations = setOf(risleyLocation.toModel(locationAttributes().copy(prisonVideoUrl = "prob-video-url"))), probationMeetingTypeDescription = "meeting type description") isEqualTo VideoLinkBooking(
@@ -110,7 +110,7 @@ class VideoLinkBookingMappersTest {
       probationMeetingTypeDescription = "meeting type description",
       createdByPrison = false,
       videoLinkUrl = "prob-video-url",
-      createdBy = "test",
+      createdBy = PROBATION_USER.username,
       createdAt = booking.createdTime,
       comments = "some comments for the probation booking",
       amendedAt = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingAmendedTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingAmendedTelemetryEventTest.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BLACKPOOL_MC_PPOC
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntriesExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
@@ -29,8 +30,7 @@ class ProbationBookingAmendedTelemetryEventTest {
     val booking = VideoBooking.newProbationBooking(
       probationTeam = probationTeam(BLACKPOOL_MC_PPOC),
       probationMeetingType = "PSR",
-      createdBy = "probation_user",
-      createdByPrison = false,
+      createdBy = PROBATION_USER,
       comments = null,
     ).addAppointment(
       prison = prison(BIRMINGHAM),
@@ -72,8 +72,7 @@ class ProbationBookingAmendedTelemetryEventTest {
     val booking = VideoBooking.newProbationBooking(
       probationTeam = probationTeam(BLACKPOOL_MC_PPOC),
       probationMeetingType = "PSR",
-      createdBy = "probation_user",
-      createdByPrison = false,
+      createdBy = PROBATION_USER,
       comments = null,
     ).addAppointment(
       prison = prison(BIRMINGHAM),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCancelledTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCancelledTelemetryEventTest.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BLACKPOOL_MC_PPOC
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntriesExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
@@ -26,8 +27,7 @@ class ProbationBookingCancelledTelemetryEventTest {
   private val booking = VideoBooking.newProbationBooking(
     probationTeam = probationTeam(BLACKPOOL_MC_PPOC),
     probationMeetingType = "PSR",
-    createdBy = "probation_user",
-    createdByPrison = false,
+    createdBy = PROBATION_USER,
     comments = null,
   ).addAppointment(
     prison = prison(BIRMINGHAM),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCreatedTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCreatedTelemetryEventTest.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BLACKPOOL_MC_PPOC
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntriesExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
@@ -25,8 +26,7 @@ class ProbationBookingCreatedTelemetryEventTest {
     val booking = VideoBooking.newProbationBooking(
       probationTeam = probationTeam(BLACKPOOL_MC_PPOC),
       probationMeetingType = "PSR",
-      createdBy = "probation_user",
-      createdByPrison = false,
+      createdBy = PROBATION_USER,
       comments = null,
     ).addAppointment(
       prison = prison(BIRMINGHAM),


### PR DESCRIPTION
The CSV would have been wrong as a result of this bug.  Note: this does not affect the old journeys, only the new.