### PR TITLE
BAVL-687 changes to support both old and new probation bookings when the support for VLPM goes live.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAndAppointmentsExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAndAppointmentsExt.kt
@@ -8,6 +8,8 @@ import java.time.LocalTime
 
 fun AppointmentSearchResult.isTheSameAppointmentType(appointmentType: SupportedAppointmentTypes.Type) = category.code == appointmentType.code
 
-fun AppointmentSearchResult.isTheSameTime(appointment: PrisonAppointment) = appointment.startTime == LocalTime.parse(startTime) && appointment.endTime == LocalTime.parse(endTime)
+fun AppointmentSearchResult.isTheSameTime(appointment: PrisonAppointment) = appointment.startTime == LocalTime.parse(startTime) && appointment.endTime == LocalTime.parse(endTime!!)
 
-fun AppointmentSearchResult.isTheSameTime(bha: BookingHistoryAppointment) = bha.startTime == LocalTime.parse(startTime) && bha.endTime == LocalTime.parse(endTime)
+fun AppointmentSearchResult.isTheSameTime(bha: BookingHistoryAppointment) = bha.startTime == LocalTime.parse(startTime) && bha.endTime == LocalTime.parse(endTime!!)
+
+fun AppointmentSearchResult.appointmentCode() = category.code

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
@@ -140,6 +140,8 @@ data class PrisonerSchedule(
 ) {
   fun isTheSameAppointmentType(appointmentType: SupportedAppointmentTypes.Type) = event == appointmentType.code
 
+  fun appointmentCode() = event
+
   fun isTheSameTime(appointment: PrisonAppointment) = startTime == appointment.appointmentDate.atTime(appointment.startTime) &&
     appointment.appointmentDate.atTime(appointment.endTime) == endTime
 


### PR DESCRIPTION
The changes in this PR will mean we do not need to make any changes to existing probation bookings with an appointment code of 'VLB'.

If changes are made to future meetings with the old VLB code then the service can now recognise them as well as the new VLPM types.