### PR TITLE
BAVL-663 you can now add a schedule row to a location attribute even if the location attribute is not scheduled. It will have no effect.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttribute.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttribute.kt
@@ -87,6 +87,10 @@ class LocationAttribute private constructor(
 
   fun isLocationUsage(usage: LocationUsage) = locationUsage == usage
 
+  /**
+   * You can add a schedule row to a location attribute even when it is not a scheduled attribute, however it won't have
+   * any effect unless the location attribute itself is marked as scheduled.
+   */
   fun addSchedule(
     usage: LocationScheduleUsage,
     startDayOfWeek: Int,
@@ -97,10 +101,6 @@ class LocationAttribute private constructor(
     notes: String? = null,
     createdBy: ExternalUser,
   ) {
-    require(locationUsage == LocationUsage.SCHEDULE) {
-      "The location usage type must be SCHEDULE to add a schedule row to it."
-    }
-
     if (
       locationSchedule.any {
         it.locationUsage == usage &&

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationSchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationSchedule.kt
@@ -54,12 +54,6 @@ class LocationSchedule private constructor(
   var notes: String? = null
     private set
 
-  init {
-    require(locationAttribute.locationUsage == LocationUsage.SCHEDULE) {
-      "The location usage type must be SCHEDULE for a list of schedule rows to be associated with it."
-    }
-  }
-
   var amendedBy: String? = null
     private set
 


### PR DESCRIPTION
Relax adding a schedule row to a location attribute.  Can add even if the location attribute is not scheduled.  The schedule row(s) will have no effect on room selection.