### PR TITLE
BAVL-721 changes to include new probation values in the new prison probation booking email (isolated to dev only).

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
@@ -191,7 +191,7 @@ class BookingFacade(
       when (contact.contactType) {
         ContactType.USER -> ProbationEmailFactory.user(contact, prisoner, booking, prison, appointment, location, eventType, additionalBookingDetail).takeIf { user is PrisonUser || user is ExternalUser }
         ContactType.PROBATION -> ProbationEmailFactory.probation(contact, prisoner, booking, prison, appointment, location, eventType).takeIf { user is PrisonUser || user is ServiceUser }
-        ContactType.PRISON -> ProbationEmailFactory.prison(contact, prisoner, booking, prison, appointment, location, eventType, contacts)
+        ContactType.PRISON -> ProbationEmailFactory.prison(contact, prisoner, booking, prison, appointment, location, eventType, contacts, additionalBookingDetail)
         else -> null
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmailFactory.kt
@@ -46,6 +46,7 @@ object ProbationEmailFactory {
         prisonVideoUrl = location.extraAttributes?.prisonVideoUrl,
         probationOfficerName = additionalBookingDetail?.contactName,
         probationOfficerEmailAddress = additionalBookingDetail?.contactEmail,
+        probationOfficerContactNumber = additionalBookingDetail?.contactNumber,
       )
 
       BookingAction.AMEND -> AmendedProbationBookingUserEmail(
@@ -173,6 +174,7 @@ object ProbationEmailFactory {
     location: Location,
     action: BookingAction,
     contacts: Collection<BookingContact>,
+    additionalBookingDetail: AdditionalBookingDetail?,
   ): Email? {
     booking.requireIsProbationBooking()
 
@@ -196,6 +198,10 @@ object ProbationEmailFactory {
             prisonerLastName = prisoner.lastName,
             prison = prison.name,
             probationEmailAddress = primaryProbationContact.email!!,
+            prisonVideoUrl = location.extraAttributes?.prisonVideoUrl,
+            probationOfficerName = additionalBookingDetail?.contactName,
+            probationOfficerEmailAddress = additionalBookingDetail?.contactEmail,
+            probationOfficerContactNumber = additionalBookingDetail?.contactNumber,
           )
         } else {
           NewProbationBookingPrisonNoProbationEmail(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmails.kt
@@ -20,6 +20,7 @@ abstract class ProbationEmail(
   prisonVideoUrl: String? = null,
   probationOfficerName: String? = null,
   probationOfficerEmailAddress: String? = null,
+  probationOfficerContactNumber: String? = null,
 ) : Email(address, prisonerFirstName, prisonerLastName, appointmentDate, comments) {
 
   init {
@@ -33,6 +34,7 @@ abstract class ProbationEmail(
     prisonVideoUrl?.let { addPersonalisation("prisonVideoUrl", prisonVideoUrl) }
     probationOfficerName?.let { addPersonalisation("probationOfficerName", probationOfficerName) }
     probationOfficerEmailAddress?.let { addPersonalisation("probationOfficerEmailAddress", probationOfficerEmailAddress) }
+    probationOfficerContactNumber?.let { addPersonalisation("probationOfficerContactNumber", probationOfficerContactNumber) }
   }
 }
 
@@ -141,6 +143,7 @@ class NewProbationBookingUserEmail(
   prisonVideoUrl: String?,
   probationOfficerName: String?,
   probationOfficerEmailAddress: String?,
+  probationOfficerContactNumber: String?,
   comments: String?,
 ) : ProbationEmail(
   address = address,
@@ -156,6 +159,7 @@ class NewProbationBookingUserEmail(
   prisonVideoUrl = prisonVideoUrl ?: "Not yet known",
   probationOfficerName = probationOfficerName ?: "Not yet known",
   probationOfficerEmailAddress = probationOfficerEmailAddress ?: "Not yet known",
+  probationOfficerContactNumber = probationOfficerContactNumber ?: "Not yet known",
 )
 
 class NewProbationBookingPrisonProbationEmail(
@@ -168,6 +172,10 @@ class NewProbationBookingPrisonProbationEmail(
   probationEmailAddress: String,
   prison: String,
   appointmentInfo: String,
+  prisonVideoUrl: String?,
+  probationOfficerName: String?,
+  probationOfficerEmailAddress: String?,
+  probationOfficerContactNumber: String?,
   comments: String?,
 ) : ProbationEmail(
   address = address,
@@ -180,6 +188,10 @@ class NewProbationBookingPrisonProbationEmail(
   prison = prison,
   comments = comments,
   probationEmailAddress = probationEmailAddress,
+  prisonVideoUrl = prisonVideoUrl ?: "Not yet known",
+  probationOfficerName = probationOfficerName ?: "Not yet known",
+  probationOfficerEmailAddress = probationOfficerEmailAddress ?: "Not yet known",
+  probationOfficerContactNumber = probationOfficerContactNumber ?: "Not yet known",
 )
 
 class NewProbationBookingPrisonNoProbationEmail(

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,3 +7,4 @@ notify:
     probation:
       new-booking:
         user: "31d92a30-e67b-4bd8-856c-415b57ba0f7b"
+        prison-probation-email: "1d1e4265-7c58-4597-a0eb-1d77ec26ac5f"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
@@ -379,7 +379,7 @@ class BookingFacadeTest {
       whenever(videoBookingServiceDelegate.create(request, PROBATION_USER)) doReturn Pair(probationBookingAtBirminghamPrison, prisoner(prisonCode = prisoner.prisonId!!, prisonerNumber = prisoner.prisonerNumber, firstName = prisoner.firstName, lastName = prisoner.lastName))
       whenever(emailService.send(any<NewProbationBookingUserEmail>())) doReturn Result.success(emailNotificationId to "user template id")
       whenever(emailService.send(any<NewProbationBookingPrisonNoProbationEmail>())) doReturn Result.success(emailNotificationId to "probation template id")
-      whenever(additionalBookingDetailRepository.findByVideoBooking(probationBookingAtBirminghamPrison)) doReturn additionalDetails(probationBookingAtBirminghamPrison, "probation officer name", "probation.officer@email.com")
+      whenever(additionalBookingDetailRepository.findByVideoBooking(probationBookingAtBirminghamPrison)) doReturn additionalDetails(probationBookingAtBirminghamPrison, "probation officer name", "probation.officer@email.com", "0114 2345678")
 
       facade.create(request, PROBATION_USER)
 
@@ -410,6 +410,7 @@ class BookingFacadeTest {
           "prisonVideoUrl" to "birmingham-video-url",
           "probationOfficerName" to "probation officer name",
           "probationOfficerEmailAddress" to "probation.officer@email.com",
+          "probationOfficerContactNumber" to "0114 2345678",
         )
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/GovNotifyEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/GovNotifyEmailServiceTest.kt
@@ -858,6 +858,7 @@ class GovNotifyEmailServiceTest {
         prisonVideoUrl = "prison-video-url",
         probationOfficerName = "probation officer name",
         probationOfficerEmailAddress = "probation.officer@email.address",
+        probationOfficerContactNumber = "123456",
       ),
     )
 
@@ -879,6 +880,7 @@ class GovNotifyEmailServiceTest {
         "prisonVideoUrl" to "prison-video-url",
         "probationOfficerName" to "probation officer name",
         "probationOfficerEmailAddress" to "probation.officer@email.address",
+        "probationOfficerContactNumber" to "123456",
       ),
       null,
     )
@@ -897,7 +899,11 @@ class GovNotifyEmailServiceTest {
         appointmentInfo = "bobs appointment info",
         probationTeam = "the probation team",
         prison = "the prison",
+        prisonVideoUrl = "prison-video-url",
         probationEmailAddress = "jim@probation.com",
+        probationOfficerName = "probation officer name",
+        probationOfficerEmailAddress = "probation.officer@email.address",
+        probationOfficerContactNumber = "123456",
       ),
     )
 
@@ -916,6 +922,10 @@ class GovNotifyEmailServiceTest {
         "appointmentInfo" to "bobs appointment info",
         "probationEmailAddress" to "jim@probation.com",
         "frontendDomain" to "http://localhost:3000",
+        "prisonVideoUrl" to "prison-video-url",
+        "probationOfficerName" to "probation officer name",
+        "probationOfficerEmailAddress" to "probation.officer@email.address",
+        "probationOfficerContactNumber" to "123456",
       ),
       null,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmailFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmailFactoryTest.kt
@@ -200,6 +200,7 @@ class ProbationEmailFactoryTest {
         appointment = courtBooking.appointments().single(),
         location = birminghamLocation.toModel(),
         contacts = emptySet(),
+        additionalBookingDetail = null,
       )
     }
 
@@ -250,6 +251,7 @@ class ProbationEmailFactoryTest {
       appointment = probationBooking.appointments().single(),
       location = wandsworthLocation.toModel(),
       contacts = setOf(probationBookingContact),
+      additionalBookingDetail = null,
     )
 
     email isInstanceOf prisonEmails[action]!!
@@ -267,6 +269,7 @@ class ProbationEmailFactoryTest {
         appointment = probationBooking.appointments().single(),
         location = birminghamLocation.toModel(),
         contacts = emptySet(),
+        additionalBookingDetail = null,
       )
     }
 


### PR DESCRIPTION
Note for these changes you will only see the new email in DEV.

I have tested this locally, so fingers crossed will work in dev also.