### PR TITLE
BAVL-702: Remove the location from the booking request journey

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
@@ -7,6 +7,7 @@ import jakarta.validation.Constraint
 import jakarta.validation.ConstraintValidator
 import jakarta.validation.ConstraintValidatorContext
 import jakarta.validation.Payload
+import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import java.time.Duration
@@ -48,12 +49,14 @@ data class AvailabilityRequest(
   )
   val date: LocalDate?,
 
+  @field:Valid
   @Schema(
     description = "If present, the prison location and start/end time of the requested pre hearing, else null",
     requiredMode = RequiredMode.NOT_REQUIRED,
   )
   val preAppointment: LocationAndInterval? = null,
 
+  @field:Valid
   @field:NotNull(message = "The main appointment is mandatory")
   @Schema(
     description = "The main appointment which is always present",
@@ -61,6 +64,7 @@ data class AvailabilityRequest(
   )
   val mainAppointment: LocationAndInterval?,
 
+  @field:Valid
   @Schema(
     description = "If present, the prison location and start/end time of the post hearing, else null",
     requiredMode = RequiredMode.NOT_REQUIRED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
@@ -198,7 +198,7 @@ data class Appointment(
   private fun isInvalidStart() = (date == null || startTime == null) || date.atTime(startTime).isAfter(LocalDateTime.now())
 }
 
-private interface DateValidationExtension
+interface DateValidationExtension
 
 enum class AppointmentType(val isProbation: Boolean, val isCourt: Boolean) {
   // Probation types

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AppointmentsService.kt
@@ -50,8 +50,8 @@ class AppointmentsService(
     }
   }
 
-  fun checkCourtAppointments(appointments: List<Appointment>, prisonCode: String, user: User) {
-    val locations = locationValidator.validatePrisonLocations(prisonCode, appointments.mapNotNull { it.locationKey }.toSet())
+  private fun checkCourtAppointments(appointments: List<Appointment>, prisonCode: String, user: User) {
+    locationValidator.validatePrisonLocations(prisonCode, appointments.mapNotNull { it.locationKey }.toSet())
 
     appointments.checkCourtAppointmentTypesOnly()
     appointments.checkSuppliedCourtAppointmentDateAndTimesDoNotOverlap()
@@ -112,7 +112,7 @@ class AppointmentsService(
     if (user !is PrisonUser) require(enabled) { "Prison with code $code is not enabled for self service" }
   }
 
-  fun checkProbationAppointments(appointments: List<Appointment>, prisonCode: String, user: User) {
+  private fun checkProbationAppointments(appointments: List<Appointment>, prisonCode: String, user: User) {
     with(appointments.single()) {
       require(type!!.isProbation) {
         "Appointment type $type is not valid for probation appointments"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/AvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/AvailabilityService.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Availab
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Interval
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.LocationAndInterval
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.RequestVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AvailabilityResponse
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
@@ -75,21 +74,6 @@ class AvailabilityService(
   }
 
   private fun AmendVideoBookingRequest.appointment(type: AppointmentType) = prisoners.single().appointments.singleOrNull { it.type == type }?.let { LocationAndInterval(it.locationKey, Interval(it.startTime, it.endTime)) }
-
-  fun isAvailable(request: RequestVideoBookingRequest) = checkAvailability(
-    AvailabilityRequest(
-      bookingType = request.bookingType,
-      courtOrProbationCode = request.courtCode ?: request.probationTeamCode,
-      prisonCode = request.prisoners.first().prisonCode,
-      date = request.prisoners.first().appointments.first().date,
-      preAppointment = request.appointment(AppointmentType.VLB_COURT_PRE),
-      mainAppointment = request.appointment(AppointmentType.VLB_COURT_MAIN)
-        ?: request.appointment(AppointmentType.VLB_PROBATION),
-      postAppointment = request.appointment(AppointmentType.VLB_COURT_POST),
-    ),
-  ).availabilityOk
-
-  private fun RequestVideoBookingRequest.appointment(type: AppointmentType) = prisoners.single().appointments.singleOrNull { it.type == type }?.let { LocationAndInterval(it.locationKey, Interval(it.startTime, it.endTime)) }
 
   /**
    * Assumptions:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateV
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.PrisonerDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.RequestVideoBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.RequestedAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.UnknownPrisonerDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ExternalUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.PrisonUser
@@ -207,12 +208,10 @@ fun requestCourtVideoLinkRequest(
   firstName: String = "John",
   lastName: String = "Smith",
   dateOfBirth: LocalDate = LocalDate.of(1970, 1, 1),
-  locationSuffix: String = "A-1-001",
-  location: Location? = null,
   startTime: LocalTime = LocalTime.now(),
   endTime: LocalTime = LocalTime.now().plusHours(1),
   comments: String = "court booking comments",
-  appointments: List<Appointment> = emptyList(),
+  appointments: List<RequestedAppointment> = emptyList(),
 ): RequestVideoBookingRequest {
   val prisoner = UnknownPrisonerDetails(
     prisonCode = prisonCode,
@@ -221,9 +220,8 @@ fun requestCourtVideoLinkRequest(
     dateOfBirth = dateOfBirth,
     appointments = appointments.ifEmpty {
       listOf(
-        Appointment(
+        RequestedAppointment(
           type = AppointmentType.VLB_COURT_MAIN,
-          locationKey = location?.key ?: "$prisonCode-$locationSuffix",
           date = tomorrow(),
           startTime = startTime,
           endTime = endTime,
@@ -288,12 +286,10 @@ fun requestProbationVideoLinkRequest(
   firstName: String = "John",
   lastName: String = "Smith",
   dateOfBirth: LocalDate = LocalDate.of(1970, 1, 1),
-  locationSuffix: String = "A-1-001",
-  location: Location? = null,
   startTime: LocalTime = LocalTime.now(),
   endTime: LocalTime = LocalTime.now().plusHours(1),
   comments: String = "probation booking comments",
-  appointments: List<Appointment> = emptyList(),
+  appointments: List<RequestedAppointment> = emptyList(),
 ): RequestVideoBookingRequest {
   val prisoner = UnknownPrisonerDetails(
     prisonCode = prisonCode,
@@ -302,9 +298,8 @@ fun requestProbationVideoLinkRequest(
     dateOfBirth = dateOfBirth,
     appointments = appointments.ifEmpty {
       listOf(
-        Appointment(
+        RequestedAppointment(
           type = AppointmentType.VLB_PROBATION,
-          locationKey = location?.key ?: "$prisonCode-$locationSuffix",
           date = tomorrow(),
           startTime = startTime,
           endTime = endTime,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/RequestBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/RequestBookingServiceTest.kt
@@ -20,9 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.EmailService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ContactType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Notification
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BLACKPOOL_MC_PPOC
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_CENTRE
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.contact
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntriesExactlyInAnyOrder
@@ -39,7 +37,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.requestCourtVi
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.requestProbationVideoLinkRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.RequestVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.CourtRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.NotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
@@ -49,7 +46,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CourtBookingRequestUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationBookingRequestPrisonNoProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationBookingRequestUserEmail
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.availability.AvailabilityService
 import java.time.LocalTime
 import java.util.UUID
 
@@ -65,18 +61,14 @@ class RequestBookingServiceTest {
   private val referenceCodeRepository: ReferenceCodeRepository = mock()
   private val notificationRepository: NotificationRepository = mock()
   private val locationsInsidePrisonClient: LocationsInsidePrisonClient = mock()
-  private val availabilityService: AvailabilityService = mock()
   private val service = RequestBookingService(
     emailService,
     contactsService,
-    appointmentsService,
     courtRepository,
     probationTeamRepository,
     prisonRepository,
     referenceCodeRepository,
     notificationRepository,
-    locationsInsidePrisonClient,
-    availabilityService,
   )
 
   @BeforeEach
@@ -95,7 +87,6 @@ class RequestBookingServiceTest {
       contact(contactType = ContactType.USER, email = "jon@somewhere.com", name = "Jon"),
       contact(contactType = ContactType.PRISON, email = "jon@prison.com", name = "Jon"),
     )
-    whenever(availabilityService.isAvailable(any<RequestVideoBookingRequest>())) doReturn true
   }
 
   @Test
@@ -105,7 +96,6 @@ class RequestBookingServiceTest {
       prisonCode = WANDSWORTH,
       startTime = LocalTime.of(11, 0),
       endTime = LocalTime.of(11, 30),
-      location = wandsworthLocation,
     )
 
     val notificationId = UUID.randomUUID()
@@ -135,7 +125,7 @@ class RequestBookingServiceTest {
         "date" to tomorrow().toMediumFormatStyle(),
         "hearingType" to "Tribunal",
         "preAppointmentInfo" to "Not required",
-        "mainAppointmentInfo" to "${wandsworthLocation.localName} - 11:00 to 11:30",
+        "mainAppointmentInfo" to "11:00 to 11:30",
         "postAppointmentInfo" to "Not required",
         "comments" to "court booking comments",
         "courtHearingLink" to "https://video.link.com",
@@ -152,7 +142,7 @@ class RequestBookingServiceTest {
         "date" to tomorrow().toMediumFormatStyle(),
         "hearingType" to "Tribunal",
         "preAppointmentInfo" to "Not required",
-        "mainAppointmentInfo" to "${wandsworthLocation.localName} - 11:00 to 11:30",
+        "mainAppointmentInfo" to "11:00 to 11:30",
         "postAppointmentInfo" to "Not required",
         "comments" to "court booking comments",
         "courtHearingLink" to "https://video.link.com",
@@ -181,7 +171,6 @@ class RequestBookingServiceTest {
       prisonCode = WANDSWORTH,
       startTime = LocalTime.of(11, 0),
       endTime = LocalTime.of(11, 30),
-      location = wandsworthLocation,
     )
 
     val error = assertThrows<IllegalArgumentException> { service.request(bookingRequest, courtUser("court user")) }
@@ -200,7 +189,6 @@ class RequestBookingServiceTest {
       prisonCode = WANDSWORTH,
       startTime = LocalTime.of(11, 0),
       endTime = LocalTime.of(11, 30),
-      location = wandsworthLocation,
     )
 
     val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, courtUser("court user")) }
@@ -219,7 +207,6 @@ class RequestBookingServiceTest {
       prisonCode = WANDSWORTH,
       startTime = LocalTime.of(11, 0),
       endTime = LocalTime.of(11, 30),
-      location = wandsworthLocation,
     )
 
     val error = assertThrows<IllegalArgumentException> { service.request(bookingRequest, courtUser("court user")) }
@@ -238,7 +225,6 @@ class RequestBookingServiceTest {
       prisonCode = WANDSWORTH,
       startTime = LocalTime.of(11, 0),
       endTime = LocalTime.of(11, 30),
-      location = wandsworthLocation,
     )
 
     val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, courtUser("court user")) }
@@ -257,7 +243,6 @@ class RequestBookingServiceTest {
       prisonCode = WANDSWORTH,
       startTime = LocalTime.of(11, 0),
       endTime = LocalTime.of(11, 30),
-      location = wandsworthLocation,
     )
 
     val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, courtUser("court user")) }
@@ -274,7 +259,6 @@ class RequestBookingServiceTest {
       prisonCode = WANDSWORTH,
       startTime = LocalTime.of(11, 0),
       endTime = LocalTime.of(11, 30),
-      location = wandsworthLocation,
     )
 
     val notificationId = UUID.randomUUID()
@@ -303,7 +287,7 @@ class RequestBookingServiceTest {
         "dateOfBirth" to "1 Jan 1970",
         "date" to tomorrow().toMediumFormatStyle(),
         "meetingType" to "Pre-sentence report",
-        "appointmentInfo" to "${wandsworthLocation.localName} - 11:00 to 11:30",
+        "appointmentInfo" to "11:00 to 11:30",
         "comments" to "probation booking comments",
       )
     }
@@ -317,7 +301,7 @@ class RequestBookingServiceTest {
         "dateOfBirth" to "1 Jan 1970",
         "date" to tomorrow().toMediumFormatStyle(),
         "meetingType" to "Pre-sentence report",
-        "appointmentInfo" to "${wandsworthLocation.localName} - 11:00 to 11:30",
+        "appointmentInfo" to "11:00 to 11:30",
         "comments" to "probation booking comments",
       )
     }
@@ -344,7 +328,6 @@ class RequestBookingServiceTest {
       prisonCode = WANDSWORTH,
       startTime = LocalTime.of(11, 0),
       endTime = LocalTime.of(11, 30),
-      location = wandsworthLocation,
     )
 
     val error = assertThrows<IllegalArgumentException> { service.request(bookingRequest, probationUser("probation user")) }
@@ -363,7 +346,6 @@ class RequestBookingServiceTest {
       prisonCode = WANDSWORTH,
       startTime = LocalTime.of(11, 0),
       endTime = LocalTime.of(11, 30),
-      location = wandsworthLocation,
     )
 
     val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, probationUser("probation user")) }
@@ -382,7 +364,6 @@ class RequestBookingServiceTest {
       prisonCode = WANDSWORTH,
       startTime = LocalTime.of(11, 0),
       endTime = LocalTime.of(11, 30),
-      location = wandsworthLocation,
     )
 
     val error = assertThrows<IllegalArgumentException> { service.request(bookingRequest, probationUser("probation user")) }
@@ -401,7 +382,6 @@ class RequestBookingServiceTest {
       prisonCode = WANDSWORTH,
       startTime = LocalTime.of(11, 0),
       endTime = LocalTime.of(11, 30),
-      location = wandsworthLocation,
     )
 
     val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, probationUser("probation user")) }
@@ -420,39 +400,10 @@ class RequestBookingServiceTest {
       prisonCode = WANDSWORTH,
       startTime = LocalTime.of(11, 0),
       endTime = LocalTime.of(11, 30),
-      location = wandsworthLocation,
     )
 
     val error = assertThrows<EntityNotFoundException> { service.request(bookingRequest, probationUser("probation user")) }
     error.message isEqualTo "PROBATION_MEETING_TYPE with code PSR not found"
-
-    verify(emailService, never()).send(any())
-    verify(notificationRepository, never()).saveAndFlush(any())
-  }
-
-  @Test
-  fun `should fail if the requested court booking is not available`() {
-    val courtBookingRequest = requestCourtVideoLinkRequest()
-
-    whenever(availabilityService.isAvailable(courtBookingRequest)) doReturn false
-
-    val error = assertThrows<IllegalArgumentException> { service.request(courtBookingRequest, COURT_USER) }
-
-    error.message isEqualTo "Unable to request court booking, booking overlaps with an existing appointment."
-
-    verify(emailService, never()).send(any())
-    verify(notificationRepository, never()).saveAndFlush(any())
-  }
-
-  @Test
-  fun `should fail if the requested probation meeting is not available`() {
-    val probationBookingRequest = requestProbationVideoLinkRequest()
-
-    whenever(availabilityService.isAvailable(probationBookingRequest)) doReturn false
-
-    val error = assertThrows<IllegalArgumentException> { service.request(probationBookingRequest, PROBATION_USER) }
-
-    error.message isEqualTo "Unable to request probation booking, booking overlaps with an existing appointment."
 
     verify(emailService, never()).send(any())
     verify(notificationRepository, never()).saveAndFlush(any())


### PR DESCRIPTION
- Removes the location from the request a booking API endpoint, and resulting emails
- This is not behind a feature toggle, so the locations will be removed from the resulting emails when this is deployed to prod, however nothing should break.
- The location fields from the UI will be removed from the UI when we toggle ON the new court and probation journeys