### PR TITLE
BAVL-723 add swagger docs test coverage.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,9 @@ dependencies {
   testImplementation("org.testcontainers:localstack:1.20.6")
   testImplementation("org.testcontainers:postgresql:1.20.6")
   testImplementation("org.wiremock:wiremock-standalone:3.12.1")
+  testImplementation("io.swagger.parser.v3:swagger-parser:2.1.25") {
+    exclude(group = "io.swagger.core.v3")
+  }
 }
 
 kotlin {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/OpenApiDocsTest.kt
@@ -1,0 +1,82 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration
+
+import io.swagger.v3.parser.OpenAPIV3Parser
+import net.minidev.json.JSONArray
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class OpenApiDocsTest : IntegrationTestBase() {
+  @LocalServerPort
+  private var port: Int = 0
+
+  @Test
+  fun `open api docs are available`() {
+    webTestClient.get()
+      .uri("/webjars/swagger-ui/index.html?configUrl=/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  fun `open api docs redirect to correct page`() {
+    webTestClient.get()
+      .uri("/swagger-ui.html")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().is3xxRedirection
+      .expectHeader().value("Location") { it.contains("/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config") }
+  }
+
+  @Test
+  fun `the open api json contains documentation`() {
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody().jsonPath("paths").isNotEmpty
+  }
+
+  @Test
+  fun `the open api json is valid and contains documentation`() {
+    val result = OpenAPIV3Parser().readLocation("http://localhost:$port/v3/api-docs", null, null)
+    assertThat(result.messages).isEmpty()
+    assertThat(result.openAPI.paths).isNotEmpty
+  }
+
+  @Test
+  fun `the swagger json contains the version number`() {
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody().jsonPath("info.version").isEqualTo(DateTimeFormatter.ISO_DATE.format(LocalDate.now()))
+  }
+
+  @Test
+  fun `the security scheme is setup for bearer tokens`() {
+    val bearerJwts = JSONArray()
+    bearerJwts.addAll(listOf("read", "write"))
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.components.securitySchemes.bearer-jwt.type").isEqualTo("http")
+      .jsonPath("$.components.securitySchemes.bearer-jwt.scheme").isEqualTo("bearer")
+      .jsonPath("$.components.securitySchemes.bearer-jwt.bearerFormat").isEqualTo("JWT")
+      .jsonPath("$.security[0].bearer-jwt")
+      .isEqualTo(bearerJwts)
+  }
+}


### PR DESCRIPTION
We have had swagger issues before when doing OWASP updates to 3rd party libs.

This should give us an early indication (i.e. test failure) if such changes would break the swagger docs.