### PR TITLE
BAVL-717 including pre and post PVL's in new court booking user email.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactory.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingAction
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CourtEmailFactory.prisonVideoUrl
 import java.util.UUID
 
 object CourtEmailFactory {
@@ -42,9 +43,9 @@ object CourtEmailFactory {
         court = booking.court!!.description,
         prison = prison.name,
         appointmentDate = main.appointmentDate,
-        preAppointmentInfo = pre?.appointmentInformation(locations),
-        mainAppointmentInfo = main.appointmentInformation(locations),
-        postAppointmentInfo = post?.appointmentInformation(locations),
+        preAppointmentDetails = pre?.let { AppointmentDetails(locations.room(it), it.startTime, it.endTime, locations.prisonVideoUrl(it)) },
+        mainAppointmentDetails = AppointmentDetails(locations.room(main), main.startTime, main.endTime, locations.prisonVideoUrl(main)),
+        postAppointmentDetails = post?.let { AppointmentDetails(locations.room(it), it.startTime, it.endTime, locations.prisonVideoUrl(it)) },
         comments = booking.comments,
         courtHearingLink = booking.videoUrl,
       )
@@ -418,6 +419,10 @@ object CourtEmailFactory {
   private fun PrisonAppointment.appointmentInformation(locations: Map<UUID, Location>) = "${locations.room(prisonLocationId)} - ${startTime.toHourMinuteStyle()} to ${endTime.toHourMinuteStyle()}"
 
   private fun Map<UUID, Location>.room(id: UUID) = this[id]?.description ?: ""
+
+  private fun Map<UUID, Location>.room(pa: PrisonAppointment) = this[pa.prisonLocationId]?.description ?: ""
+
+  private fun Map<UUID, Location>.prisonVideoUrl(pa: PrisonAppointment) = this[pa.prisonLocationId]?.extraAttributes?.prisonVideoUrl
 
   private fun Collection<BookingContact>.primaryCourtContact() = singleOrNull { it.contactType == ContactType.COURT && it.primaryContact }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmails.kt
@@ -1,10 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court
 
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toHourMinuteStyle
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toMediumFormatStyle
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Email
 import java.time.LocalDate
+import java.time.LocalTime
 
-abstract class CourtEmail(
+@Deprecated(message = "Deprecated", replaceWith = ReplaceWith("CourtEmail"))
+abstract class DeprecatedCourtEmail(
   address: String,
   prisonerFirstName: String,
   prisonerLastName: String,
@@ -33,6 +36,41 @@ abstract class CourtEmail(
   }
 }
 
+abstract class CourtEmail(
+  address: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  prisonerNumber: String,
+  appointmentDate: LocalDate = LocalDate.now(),
+  court: String,
+  prison: String,
+  preAppointmentInfo: AppointmentDetails?,
+  mainAppointmentInfo: AppointmentDetails,
+  postAppointmentInfo: AppointmentDetails?,
+  comments: String?,
+  courtHearingLink: String?,
+  userName: String? = null,
+  courtEmailAddress: String? = null,
+) : Email(address, prisonerFirstName, prisonerLastName, appointmentDate, comments) {
+  init {
+    addPersonalisation("offenderNo", prisonerNumber)
+    addPersonalisation("court", court)
+    addPersonalisation("prison", prison)
+    addPersonalisation("preAppointmentInfo", preAppointmentInfo?.toString() ?: "Not required")
+    addPersonalisation("prePrisonVideoUrl", preAppointmentInfo?.prisonVideoUrl?.let { "Pre-court hearing link (PVL): $it" } ?: "")
+    addPersonalisation("mainAppointmentInfo", mainAppointmentInfo.toString())
+    addPersonalisation("postAppointmentInfo", postAppointmentInfo?.toString() ?: "Not required")
+    addPersonalisation("postPrisonVideoUrl", postAppointmentInfo?.prisonVideoUrl?.let { "Post-court hearing link (PVL): $it" } ?: "")
+    addPersonalisation("courtHearingLink", courtHearingLink ?: "Not yet known")
+    userName?.let { addPersonalisation("userName", userName) }
+    courtEmailAddress?.let { addPersonalisation("courtEmailAddress", courtEmailAddress) }
+  }
+}
+
+data class AppointmentDetails(val description: String, val startTime: LocalTime, val endTime: LocalTime, val prisonVideoUrl: String?) {
+  override fun toString() = "$description - ${startTime.toHourMinuteStyle()} to ${endTime.toHourMinuteStyle()}"
+}
+
 class NewCourtBookingUserEmail(
   address: String,
   prisonerFirstName: String,
@@ -42,9 +80,9 @@ class NewCourtBookingUserEmail(
   userName: String,
   court: String,
   prison: String,
-  preAppointmentInfo: String?,
-  mainAppointmentInfo: String,
-  postAppointmentInfo: String?,
+  preAppointmentDetails: AppointmentDetails?,
+  mainAppointmentDetails: AppointmentDetails,
+  postAppointmentDetails: AppointmentDetails?,
   comments: String?,
   courtHearingLink: String?,
 ) : CourtEmail(
@@ -56,9 +94,9 @@ class NewCourtBookingUserEmail(
   userName = userName,
   court = court,
   prison = prison,
-  preAppointmentInfo = preAppointmentInfo,
-  mainAppointmentInfo = mainAppointmentInfo,
-  postAppointmentInfo = postAppointmentInfo,
+  preAppointmentInfo = preAppointmentDetails,
+  mainAppointmentInfo = mainAppointmentDetails,
+  postAppointmentInfo = postAppointmentDetails,
   comments = comments,
   courtHearingLink = courtHearingLink,
 )
@@ -76,7 +114,7 @@ class NewCourtBookingCourtEmail(
   postAppointmentInfo: String?,
   comments: String?,
   courtHearingLink: String?,
-) : CourtEmail(
+) : DeprecatedCourtEmail(
   address = address,
   prisonerFirstName = prisonerFirstName,
   prisonerLastName = prisonerLastName,
@@ -105,7 +143,7 @@ class NewCourtBookingPrisonCourtEmail(
   postAppointmentInfo: String?,
   comments: String?,
   courtHearingLink: String?,
-) : CourtEmail(
+) : DeprecatedCourtEmail(
   address = address,
   prisonerFirstName = prisonerFirstName,
   prisonerLastName = prisonerLastName,
@@ -134,7 +172,7 @@ class NewCourtBookingPrisonNoCourtEmail(
   postAppointmentInfo: String?,
   comments: String?,
   courtHearingLink: String?,
-) : CourtEmail(
+) : DeprecatedCourtEmail(
   address = address,
   prisonerFirstName = prisonerFirstName,
   prisonerLastName = prisonerLastName,
@@ -163,7 +201,7 @@ class AmendedCourtBookingUserEmail(
   postAppointmentInfo: String?,
   comments: String?,
   courtHearingLink: String?,
-) : CourtEmail(
+) : DeprecatedCourtEmail(
   address = address,
   prisonerFirstName = prisonerFirstName,
   prisonerLastName = prisonerLastName,
@@ -192,7 +230,7 @@ class AmendedCourtBookingCourtEmail(
   postAppointmentInfo: String?,
   comments: String?,
   courtHearingLink: String?,
-) : CourtEmail(
+) : DeprecatedCourtEmail(
   address = address,
   prisonerFirstName = prisonerFirstName,
   prisonerLastName = prisonerLastName,
@@ -221,7 +259,7 @@ class AmendedCourtBookingPrisonCourtEmail(
   postAppointmentInfo: String?,
   comments: String?,
   courtHearingLink: String?,
-) : CourtEmail(
+) : DeprecatedCourtEmail(
   address = address,
   prisonerFirstName = prisonerFirstName,
   prisonerLastName = prisonerLastName,
@@ -250,7 +288,7 @@ class AmendedCourtBookingPrisonNoCourtEmail(
   postAppointmentInfo: String?,
   comments: String?,
   courtHearingLink: String?,
-) : CourtEmail(
+) : DeprecatedCourtEmail(
   address = address,
   prisonerFirstName = prisonerFirstName,
   prisonerLastName = prisonerLastName,
@@ -279,7 +317,7 @@ class CancelledCourtBookingUserEmail(
   postAppointmentInfo: String?,
   comments: String?,
   courtHearingLink: String?,
-) : CourtEmail(
+) : DeprecatedCourtEmail(
   address = address,
   prisonerFirstName = prisonerFirstName,
   prisonerLastName = prisonerLastName,
@@ -308,7 +346,7 @@ class CancelledCourtBookingCourtEmail(
   postAppointmentInfo: String?,
   comments: String?,
   courtHearingLink: String?,
-) : CourtEmail(
+) : DeprecatedCourtEmail(
   address = address,
   prisonerFirstName = prisonerFirstName,
   prisonerLastName = prisonerLastName,
@@ -337,7 +375,7 @@ class CancelledCourtBookingPrisonCourtEmail(
   postAppointmentInfo: String?,
   comments: String?,
   courtHearingLink: String?,
-) : CourtEmail(
+) : DeprecatedCourtEmail(
   address = address,
   prisonerFirstName = prisonerFirstName,
   prisonerLastName = prisonerLastName,
@@ -366,7 +404,7 @@ class CancelledCourtBookingPrisonNoCourtEmail(
   postAppointmentInfo: String?,
   comments: String?,
   courtHearingLink: String?,
-) : CourtEmail(
+) : DeprecatedCourtEmail(
   address = address,
   prisonerFirstName = prisonerFirstName,
   prisonerLastName = prisonerLastName,
@@ -629,7 +667,7 @@ class CourtHearingLinkReminderEmail(
   postAppointmentInfo: String?,
   comments: String?,
   bookingId: String,
-) : CourtEmail(
+) : DeprecatedCourtEmail(
   address = address,
   prisonerFirstName = prisonerFirstName,
   prisonerLastName = prisonerLastName,

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,9 @@ spring:
 
 notify:
   templates:
+    court:
+      new-booking:
+        user: "1405711e-1f30-4999-b336-27061d58fdb6"
     probation:
       new-booking:
         user: "31d92a30-e67b-4bd8-856c-415b57ba0f7b"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
@@ -232,6 +232,8 @@ class BookingFacadeTest {
           "postAppointmentInfo" to "Not required",
           "comments" to "Court hearing comments",
           "courtHearingLink" to "https://court.hearing.link",
+          "prePrisonVideoUrl" to "",
+          "postPrisonVideoUrl" to "",
         )
       }
       with(emailCaptor.secondValue) {
@@ -320,6 +322,8 @@ class BookingFacadeTest {
           "postAppointmentInfo" to "Not required",
           "comments" to "Court hearing comments",
           "courtHearingLink" to "https://court.hearing.link",
+          "prePrisonVideoUrl" to "",
+          "postPrisonVideoUrl" to "",
         )
       }
       with(emailCaptor.secondValue) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/GovNotifyEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/GovNotifyEmailServiceTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AppointmentDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.CancelledCourtBookingUserEmail
@@ -40,6 +41,7 @@ import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.NotificationClientException
 import uk.gov.service.notify.SendEmailResponse
 import java.time.LocalDate
+import java.time.LocalTime
 import java.util.UUID
 
 class GovNotifyEmailServiceTest {
@@ -105,9 +107,9 @@ class GovNotifyEmailServiceTest {
         appointmentDate = today,
         userName = "username",
         comments = "comments for bob",
-        preAppointmentInfo = "bobs pre-appointment info",
-        mainAppointmentInfo = "bobs main appointment info",
-        postAppointmentInfo = "bob post appointment info",
+        preAppointmentDetails = AppointmentDetails("pre", LocalTime.of(10, 0), LocalTime.of(10, 15), "pre-prison-video-url"),
+        mainAppointmentDetails = AppointmentDetails("main", LocalTime.of(10, 15), LocalTime.of(10, 30), "main-prison-video-url"),
+        postAppointmentDetails = AppointmentDetails("post", LocalTime.of(10, 30), LocalTime.of(10, 45), "post-prison-video-url"),
         court = "the court",
         prison = "the prison",
         courtHearingLink = "https://video.link.com",
@@ -127,11 +129,13 @@ class GovNotifyEmailServiceTest {
         "userName" to "username",
         "court" to "the court",
         "prison" to "the prison",
-        "preAppointmentInfo" to "bobs pre-appointment info",
-        "mainAppointmentInfo" to "bobs main appointment info",
-        "postAppointmentInfo" to "bob post appointment info",
+        "preAppointmentInfo" to "pre - 10:00 to 10:15",
+        "mainAppointmentInfo" to "main - 10:15 to 10:30",
+        "postAppointmentInfo" to "post - 10:30 to 10:45",
         "courtHearingLink" to "https://video.link.com",
         "frontendDomain" to "http://localhost:3000",
+        "prePrisonVideoUrl" to "Pre-court hearing link (PVL): pre-prison-video-url",
+        "postPrisonVideoUrl" to "Post-court hearing link (PVL): post-prison-video-url",
       ),
       null,
     )
@@ -148,9 +152,9 @@ class GovNotifyEmailServiceTest {
         appointmentDate = today,
         userName = "username",
         comments = null,
-        preAppointmentInfo = null,
-        mainAppointmentInfo = "bobs main appointment info",
-        postAppointmentInfo = null,
+        preAppointmentDetails = null,
+        mainAppointmentDetails = AppointmentDetails("main", LocalTime.of(10, 15), LocalTime.of(10, 30), null),
+        postAppointmentDetails = null,
         court = "the court",
         prison = "the prison",
         courtHearingLink = null,
@@ -171,10 +175,12 @@ class GovNotifyEmailServiceTest {
         "court" to "the court",
         "prison" to "the prison",
         "preAppointmentInfo" to "Not required",
-        "mainAppointmentInfo" to "bobs main appointment info",
+        "mainAppointmentInfo" to "main - 10:15 to 10:30",
         "postAppointmentInfo" to "Not required",
         "courtHearingLink" to "Not yet known",
         "frontendDomain" to "http://localhost:3000",
+        "prePrisonVideoUrl" to "",
+        "postPrisonVideoUrl" to "",
       ),
       null,
     )
@@ -850,9 +856,9 @@ class GovNotifyEmailServiceTest {
         appointmentDate = LocalDate.now(),
         userName = "username",
         comments = "comments for bob",
-        preAppointmentInfo = "bobs pre-appointment info",
-        mainAppointmentInfo = "bobs main appointment info",
-        postAppointmentInfo = "bob post appointment info",
+        preAppointmentDetails = AppointmentDetails("pre", LocalTime.of(10, 0), LocalTime.of(10, 15), null),
+        mainAppointmentDetails = AppointmentDetails("main", LocalTime.of(10, 15), LocalTime.of(10, 30), null),
+        postAppointmentDetails = AppointmentDetails("post", LocalTime.of(10, 30), LocalTime.of(10, 45), null),
         court = "the court",
         prison = "the prison",
         courtHearingLink = "https://video.link.com",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/DeprecatedCourtEmailFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/DeprecatedCourtEmailFactoryTest.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toMod
 import java.time.LocalDate
 import java.time.LocalTime
 
-class CourtEmailFactoryTest {
+class DeprecatedCourtEmailFactoryTest {
 
   private val userBookingContact = bookingContact(
     contactType = ContactType.USER,


### PR DESCRIPTION
If no PVL link then nothing is shown in the email template.  The label text is provided by the API.  A bit on the fence with this idea (it was my idea).