### PR TITLE
BAVL-734 send email to probation team when a prison creates a probation booking.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probat
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.CancelledProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.NewProbationBookingPrisonNoProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.NewProbationBookingPrisonProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.NewProbationBookingProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.NewProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationBookingRequestPrisonNoProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationBookingRequestPrisonProbationTeamEmail
@@ -86,6 +87,7 @@ class EmailConfiguration(
   @Value("\${notify.templates.probation.booking-request.prison-probation-team-email:}") private val probationBookingRequestPrisonProbationTeamEmail: String,
   @Value("\${notify.templates.probation.booking-request.prison-no-probation-team-email:}") private val probationBookingRequestPrisonNoProbationTeamEmail: String,
   @Value("\${notify.templates.probation.new-booking.user:}") private val newProbationBookingUser: String,
+  @Value("\${notify.templates.probation.new-booking.probation:}") private val newProbationBookingProbation: String,
   @Value("\${notify.templates.probation.new-booking.prison-probation-email:}") private val newProbationBookingPrisonProbationEmail: String,
   @Value("\${notify.templates.probation.new-booking.prison-no-probation-email:}") private val newProbationBookingPrisonNoProbationEmail: String,
   @Value("\${notify.templates.probation.amended-booking.user:}") private val amendedProbationBookingUser: String,
@@ -141,6 +143,7 @@ class EmailConfiguration(
     releaseCourtBookingPrisonCourtEmail = releaseCourtBookingPrisonCourtEmail,
     releaseCourtBookingPrisonNoCourtEmail = releaseCourtBookingPrisonNoCourtEmail,
     newProbationBookingUser = newProbationBookingUser,
+    newProbationBookingProbation = newProbationBookingProbation,
     newProbationBookingPrisonProbationEmail = newProbationBookingPrisonProbationEmail,
     newProbationBookingPrisonNoProbationEmail = newProbationBookingPrisonNoProbationEmail,
     amendedProbationBookingUser = amendedProbationBookingUser,
@@ -218,6 +221,7 @@ data class EmailTemplates(
   val releaseCourtBookingPrisonCourtEmail: String,
   val releaseCourtBookingPrisonNoCourtEmail: String,
   val newProbationBookingUser: String,
+  val newProbationBookingProbation: String,
   val newProbationBookingPrisonProbationEmail: String,
   val newProbationBookingPrisonNoProbationEmail: String,
   val amendedProbationBookingUser: String,
@@ -263,6 +267,7 @@ data class EmailTemplates(
     ReleasedCourtBookingPrisonCourtEmail::class.java to releaseCourtBookingPrisonCourtEmail,
     ReleasedCourtBookingPrisonNoCourtEmail::class.java to releaseCourtBookingPrisonNoCourtEmail,
     NewProbationBookingUserEmail::class.java to newProbationBookingUser,
+    NewProbationBookingProbationEmail::class.java to newProbationBookingProbation,
     NewProbationBookingPrisonProbationEmail::class.java to newProbationBookingPrisonProbationEmail,
     NewProbationBookingPrisonNoProbationEmail::class.java to newProbationBookingPrisonNoProbationEmail,
     AmendedProbationBookingUserEmail::class.java to amendedProbationBookingUser,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmailFactory.kt
@@ -104,6 +104,22 @@ object ProbationEmailFactory {
     }
 
     return when (action) {
+      BookingAction.CREATE -> NewProbationBookingProbationEmail(
+        address = contact.email!!,
+        prisonerNumber = prisoner.prisonerNumber,
+        probationTeam = booking.probationTeam!!.description,
+        appointmentDate = appointment.appointmentDate,
+        appointmentInfo = appointment.appointmentInformation(location),
+        comments = booking.comments,
+        prisonerFirstName = prisoner.firstName,
+        prisonerLastName = prisoner.lastName,
+        prison = prison.name,
+        prisonVideoUrl = location.extraAttributes?.prisonVideoUrl,
+        probationOfficerName = additionalBookingDetail?.contactName,
+        probationOfficerEmailAddress = additionalBookingDetail?.contactEmail,
+        probationOfficerContactNumber = additionalBookingDetail?.contactNumber,
+      )
+
       BookingAction.AMEND -> AmendedProbationBookingProbationEmail(
         address = contact.email!!,
         prisonerNumber = prisoner.prisonerNumber,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmails.kt
@@ -164,6 +164,36 @@ class NewProbationBookingUserEmail(
   probationOfficerContactNumber = probationOfficerContactNumber ?: "Not yet known",
 )
 
+class NewProbationBookingProbationEmail(
+  address: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  prisonerNumber: String,
+  appointmentDate: LocalDate,
+  probationTeam: String,
+  prison: String,
+  appointmentInfo: String,
+  prisonVideoUrl: String?,
+  probationOfficerName: String?,
+  probationOfficerEmailAddress: String?,
+  probationOfficerContactNumber: String?,
+  comments: String?,
+) : ProbationEmail(
+  address = address,
+  prisonerNumber = prisonerNumber,
+  prisonerFirstName = prisonerFirstName,
+  prisonerLastName = prisonerLastName,
+  appointmentInfo = appointmentInfo,
+  appointmentDate = appointmentDate,
+  probationTeam = probationTeam,
+  prison = prison,
+  comments = comments,
+  prisonVideoUrl = prisonVideoUrl ?: "Not yet known",
+  probationOfficerName = probationOfficerName ?: "Not yet known",
+  probationOfficerEmailAddress = probationOfficerEmailAddress ?: "Not yet known",
+  probationOfficerContactNumber = probationOfficerContactNumber ?: "Not yet known",
+)
+
 class NewProbationBookingPrisonProbationEmail(
   address: String,
   prisonerFirstName: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCreatedTelemetryEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/ProbationBookingCreatedTelemetryEvent.kt
@@ -15,8 +15,7 @@ class ProbationBookingCreatedTelemetryEvent(private val booking: VideoBooking) :
     }
   }
 
-  // Probation bookings are only created by probation users
-  override fun properties() = booking.commonProperties().plus("created_by" to "probation")
+  override fun properties() = booking.commonProperties().plus("created_by" to if (booking.createdByPrison) "prison" else "probation")
 
   override fun metrics() = mapOf(booking.hoursBeforeStartTimeMetric())
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -158,6 +158,7 @@ notify:
         prison-no-probation-team-email: "2326fa9d-1627-4c04-8c8d-a6e1ae19a6cb"
       new-booking:
         user: "20fddb45-3907-4e10-a570-86377bbe9dd1"
+        probation: "8b5a06af-613e-436b-aef1-54fae1275723"
         prison-probation-email: "73a0e2b3-6b49-4a31-8960-973e3e833e81"
         prison-no-probation-email: "9701dd1e-ba93-49e9-94f4-2b335459d420"
       amended-booking:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailTemplatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailTemplatesTest.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probat
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.CancelledProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.NewProbationBookingPrisonNoProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.NewProbationBookingPrisonProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.NewProbationBookingProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.NewProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationBookingRequestPrisonNoProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationBookingRequestPrisonProbationTeamEmail
@@ -74,6 +75,7 @@ class EmailTemplatesTest {
     ReleasedCourtBookingPrisonCourtEmail::class.java to "releaseCourtBookingPrisonCourtEmail",
     ReleasedCourtBookingPrisonNoCourtEmail::class.java to "releaseCourtBookingPrisonNoCourtEmail",
     NewProbationBookingUserEmail::class.java to "newProbationBookingUser",
+    NewProbationBookingProbationEmail::class.java to "newProbationBookingProbation",
     NewProbationBookingPrisonProbationEmail::class.java to "newProbationBookingPrisonProbationEmail",
     NewProbationBookingPrisonNoProbationEmail::class.java to "newProbationBookingPrisonNoProbationEmail",
     AmendedProbationBookingUserEmail::class.java to "amendedProbationBookingUser",
@@ -119,6 +121,7 @@ class EmailTemplatesTest {
     releaseCourtBookingPrisonCourtEmail = "releaseCourtBookingPrisonCourtEmail",
     releaseCourtBookingPrisonNoCourtEmail = "releaseCourtBookingPrisonNoCourtEmail",
     newProbationBookingUser = "newProbationBookingUser",
+    newProbationBookingProbation = "newProbationBookingProbation",
     newProbationBookingPrisonProbationEmail = "newProbationBookingPrisonProbationEmail",
     newProbationBookingPrisonNoProbationEmail = "newProbationBookingPrisonNoProbationEmail",
     amendedProbationBookingUser = "amendedProbationBookingUser",
@@ -175,6 +178,7 @@ class EmailTemplatesTest {
       "w",
       "x",
       "y",
+      "y.y",
       "z",
       "1",
       "2",
@@ -221,6 +225,7 @@ class EmailTemplatesTest {
         "w",
         "x",
         "y",
+        "y.y",
         "z",
         "1",
         "2",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -95,11 +95,11 @@ fun VideoBooking.withMainCourtPrisonAppointment(
   endTime = endTime,
 )
 
-fun probationBooking(probationTeam: ProbationTeam = probationTeam(), meetingType: ProbationMeetingType = ProbationMeetingType.PSR) = VideoBooking.newProbationBooking(
+fun probationBooking(probationTeam: ProbationTeam = probationTeam(), meetingType: ProbationMeetingType = ProbationMeetingType.PSR, createdBy: User? = null) = VideoBooking.newProbationBooking(
   probationTeam = probationTeam,
   probationMeetingType = meetingType.name,
   comments = "Probation meeting comments",
-  createdBy = PROBATION_USER,
+  createdBy = createdBy ?: PROBATION_USER,
 )
 
 /**

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/GovNotifyEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/GovNotifyEmailServiceTest.kt
@@ -75,6 +75,7 @@ class GovNotifyEmailServiceTest {
     releaseCourtBookingPrisonCourtEmail = "releaseCourtBookingPrisonCourtEmail",
     releaseCourtBookingPrisonNoCourtEmail = "releaseCourtBookingPrisonNoCourtEmail",
     newProbationBookingUser = "newProbationBookingUser",
+    newProbationBookingProbation = "newProbationBookingProbation",
     newProbationBookingPrisonProbationEmail = "newProbationBookingPrisonProbationEmail",
     newProbationBookingPrisonNoProbationEmail = "newProbationBookingPrisonNoProbationEmail",
     amendedProbationBookingUser = "amendedProbationBookingUser",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactoryTest.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toMod
 import java.time.LocalDate
 import java.time.LocalTime
 
-class DeprecatedCourtEmailFactoryTest {
+class CourtEmailFactoryTest {
 
   private val userBookingContact = bookingContact(
     contactType = ContactType.USER,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmailFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmailFactoryTest.kt
@@ -87,6 +87,7 @@ class ProbationEmailFactoryTest {
   )
 
   private val probationEmails = mapOf(
+    BookingAction.CREATE to NewProbationBookingProbationEmail::class.java,
     BookingAction.AMEND to AmendedProbationBookingProbationEmail::class.java,
     BookingAction.CANCEL to CancelledProbationBookingProbationEmail::class.java,
     BookingAction.RELEASED to ReleasedProbationBookingProbationEmail::class.java,
@@ -112,10 +113,10 @@ class ProbationEmailFactoryTest {
     fun unsupportedUserBookingActions() = setOf(BookingAction.RELEASED, BookingAction.TRANSFERRED, BookingAction.COURT_HEARING_LINK_REMINDER)
 
     @JvmStatic
-    fun supportedPrisonBookingActions() = setOf(BookingAction.CREATE, BookingAction.AMEND, BookingAction.CANCEL, BookingAction.RELEASED, BookingAction.TRANSFERRED)
+    fun supportedPrisonBookingActions() = setOf(BookingAction.AMEND, BookingAction.CANCEL, BookingAction.RELEASED, BookingAction.TRANSFERRED)
 
     @JvmStatic
-    fun unsupportedProbationBookingActions() = setOf(BookingAction.CREATE, BookingAction.COURT_HEARING_LINK_REMINDER)
+    fun unsupportedProbationBookingActions() = setOf(BookingAction.COURT_HEARING_LINK_REMINDER)
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Spotted an email was missing from the new probation journey.

Prisons can now also create probation bookings, if they do then we need to send an email to the relevant probation contacts set up.

It is safe for this to change go live.  The current service does not allow probation teams to create probation bookings.