### PR TITLE
BAVL-736: Update court descriptions to expected values where hyphens exists.

### DIFF
--- a/src/main/resources/migrations/common/V2025.03.31__correct_court_hypens.sql
+++ b/src/main/resources/migrations/common/V2025.03.31__correct_court_hypens.sql
@@ -1,0 +1,14 @@
+-- FRC courts to add spaces around the hyphens
+update court set description = 'FRC - Bristol' where code = 'FRCBLC';
+update court set description = 'FRC - Bournemouth' where code = 'FRCBRC';
+update court set description = 'FRC - East Midlands' where code = 'FRCEMC';
+update court set description = 'FRC - Peterborough' where code = 'FRCPRC';
+update court set description = 'FRC - Plymouth' where code = 'FRCPHC';
+update court set description = 'FRC - Thames Valley' where code = 'FRCTVC';
+update court set description = 'FRC - West Midlands' where code = 'FRCWMC';
+
+-- RCJ court to correct an odd hyphen character
+update court set description = 'RCJ - Court of Appeal Criminal' where code = 'RCJCCC';
+
+-- RCU - nothing obviously wrong with this but updating to ensure no ctrl characters in there
+update court set description = 'RCU - Wales and South West' where code = 'RCUWSW';


### PR DESCRIPTION
This PR makes some of the court descriptions better match the user's expectations.

FRC-xxxx - had no spaces around hyphens.
RCJ -xxxx - one court had an elongated hyphen (odd character).
RCU-xxx - no discernable problem, but updated in case there was a ctrl character copied from Emma spreadsheet.