### PR TITLE
Revert "BAVL-743 temporary workaround for migrating future VLB probation bookings to future VLPM bookings."

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/VideoBookingAmendedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/VideoBookingAmendedEventHandler.kt
@@ -33,8 +33,7 @@ class VideoBookingAmendedEventHandler(
           val history = bookingHistoryService.getByVideoBookingId(booking.videoBookingId)
             .sortedByDescending { history -> history.createdTime }
             .let {
-              // Temporary workaround to migrate existing bookings without an amend history
-              if (it.size == 1) it[0] else it[1]
+              it[1]
             }
 
           // Cancel the appointments related to the previous state from history rows

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/VideoBookingAmendedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/VideoBookingAmendedEventHandlerTest.kt
@@ -108,20 +108,6 @@ class VideoBookingAmendedEventHandlerTest {
   }
 
   @Test
-  fun `should remove and recreate external appointments when missing amend on receipt of a BOOKING_AMENDED event`() {
-    whenever(videoBookingRepository.findById(anyLong())) doReturn Optional.of(booking)
-    whenever(bookingHistoryService.getByVideoBookingId(anyLong())) doReturn listOf(createHistory)
-
-    handler.handle(VideoBookingAmendedEvent(1))
-
-    verify(manageExternalAppointmentsService, times(2)).cancelPreviousAppointment(any())
-
-    verify(outboundEventsService, times(2)).send(DomainEventType.APPOINTMENT_CREATED, 0)
-
-    verifyNoMoreInteractions(manageExternalAppointmentsService)
-  }
-
-  @Test
   fun `should no-op an unknown booking`() {
     whenever(videoBookingRepository.findById(anyLong())) doReturn Optional.empty()
 


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-book-a-video-link-api#446