### PR TITLE
BAVL-713 adding additional details and PVL to the probation cancellation emails.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmailFactory.kt
@@ -79,6 +79,10 @@ object ProbationEmailFactory {
           probationTeam = booking.probationTeam!!.description,
           appointmentDate = appointment.appointmentDate,
           appointmentInfo = appointment.appointmentInformation(location),
+          prisonVideoUrl = location.extraAttributes?.prisonVideoUrl,
+          probationOfficerName = additionalBookingDetail?.contactName,
+          probationOfficerEmailAddress = additionalBookingDetail?.contactEmail,
+          probationOfficerContactNumber = additionalBookingDetail?.contactNumber,
           comments = booking.comments,
         )
       }
@@ -148,6 +152,10 @@ object ProbationEmailFactory {
           probationTeam = booking.probationTeam!!.description,
           prison = prison.name,
           appointmentInfo = appointment.appointmentInformation(location),
+          prisonVideoUrl = location.extraAttributes?.prisonVideoUrl,
+          probationOfficerName = additionalBookingDetail?.contactName,
+          probationOfficerEmailAddress = additionalBookingDetail?.contactEmail,
+          probationOfficerContactNumber = additionalBookingDetail?.contactNumber,
           comments = booking.comments,
         )
       }
@@ -316,6 +324,10 @@ object ProbationEmailFactory {
             prisonerLastName = prisoner.lastName,
             prison = prison.name,
             probationEmailAddress = primaryProbationContact.email!!,
+            prisonVideoUrl = location.extraAttributes?.prisonVideoUrl,
+            probationOfficerName = additionalBookingDetail?.contactName,
+            probationOfficerEmailAddress = additionalBookingDetail?.contactEmail,
+            probationOfficerContactNumber = additionalBookingDetail?.contactNumber,
           )
         } else {
           CancelledProbationBookingPrisonNoProbationEmail(
@@ -328,6 +340,10 @@ object ProbationEmailFactory {
             prisonerFirstName = prisoner.firstName,
             prisonerLastName = prisoner.lastName,
             prison = prison.name,
+            prisonVideoUrl = location.extraAttributes?.prisonVideoUrl,
+            probationOfficerName = additionalBookingDetail?.contactName,
+            probationOfficerEmailAddress = additionalBookingDetail?.contactEmail,
+            probationOfficerContactNumber = additionalBookingDetail?.contactNumber,
           )
         }
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmails.kt
@@ -50,6 +50,10 @@ class CancelledProbationBookingUserEmail(
   probationTeam: String,
   prison: String,
   appointmentInfo: String,
+  prisonVideoUrl: String?,
+  probationOfficerName: String?,
+  probationOfficerEmailAddress: String?,
+  probationOfficerContactNumber: String?,
   comments: String?,
 ) : ProbationEmail(
   address = address,
@@ -61,6 +65,10 @@ class CancelledProbationBookingUserEmail(
   appointmentDate = appointmentDate,
   probationTeam = probationTeam,
   prison = prison,
+  prisonVideoUrl = prisonVideoUrl ?: "Not yet known",
+  probationOfficerName = probationOfficerName ?: "Not yet known",
+  probationOfficerEmailAddress = probationOfficerEmailAddress ?: "Not yet known",
+  probationOfficerContactNumber = probationOfficerContactNumber ?: "Not yet known",
   comments = comments,
 )
 
@@ -73,6 +81,10 @@ class CancelledProbationBookingProbationEmail(
   prison: String,
   appointmentDate: LocalDate,
   appointmentInfo: String,
+  prisonVideoUrl: String?,
+  probationOfficerName: String?,
+  probationOfficerEmailAddress: String?,
+  probationOfficerContactNumber: String?,
   comments: String?,
 ) : ProbationEmail(
   address = address,
@@ -83,6 +95,10 @@ class CancelledProbationBookingProbationEmail(
   appointmentDate = appointmentDate,
   probationTeam = probationTeam,
   prison = prison,
+  prisonVideoUrl = prisonVideoUrl ?: "Not yet known",
+  probationOfficerName = probationOfficerName ?: "Not yet known",
+  probationOfficerEmailAddress = probationOfficerEmailAddress ?: "Not yet known",
+  probationOfficerContactNumber = probationOfficerContactNumber ?: "Not yet known",
   comments = comments,
 )
 
@@ -96,6 +112,10 @@ class CancelledProbationBookingPrisonProbationEmail(
   prison: String,
   appointmentDate: LocalDate,
   appointmentInfo: String,
+  prisonVideoUrl: String?,
+  probationOfficerName: String?,
+  probationOfficerEmailAddress: String?,
+  probationOfficerContactNumber: String?,
   comments: String?,
 ) : ProbationEmail(
   address = address,
@@ -107,6 +127,10 @@ class CancelledProbationBookingPrisonProbationEmail(
   probationTeam = probationTeam,
   probationEmailAddress = probationEmailAddress,
   prison = prison,
+  prisonVideoUrl = prisonVideoUrl ?: "Not yet known",
+  probationOfficerName = probationOfficerName ?: "Not yet known",
+  probationOfficerEmailAddress = probationOfficerEmailAddress ?: "Not yet known",
+  probationOfficerContactNumber = probationOfficerContactNumber ?: "Not yet known",
   comments = comments,
 )
 
@@ -119,6 +143,10 @@ class CancelledProbationBookingPrisonNoProbationEmail(
   prison: String,
   appointmentDate: LocalDate,
   appointmentInfo: String,
+  prisonVideoUrl: String?,
+  probationOfficerName: String?,
+  probationOfficerEmailAddress: String?,
+  probationOfficerContactNumber: String?,
   comments: String?,
 ) : ProbationEmail(
   address = address,
@@ -129,6 +157,10 @@ class CancelledProbationBookingPrisonNoProbationEmail(
   appointmentDate = appointmentDate,
   probationTeam = probationTeam,
   prison = prison,
+  prisonVideoUrl = prisonVideoUrl ?: "Not yet known",
+  probationOfficerName = probationOfficerName ?: "Not yet known",
+  probationOfficerEmailAddress = probationOfficerEmailAddress ?: "Not yet known",
+  probationOfficerContactNumber = probationOfficerContactNumber ?: "Not yet known",
   comments = comments,
 )
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,3 +1,13 @@
 spring:
   flyway:
     locations: classpath:/migrations/common,classpath:/migrations/dev
+
+notify:
+  templates:
+    probation:
+      cancelled-booking:
+        user: "c0f0834d-7343-4af4-8df2-bfd3c970e836"
+        probation: "df97c314-cb5d-48ce-9241-7d94ea98e323"
+        prison-probation-email: "8bdf8c4e-c15c-4621-9469-035fa14c9daa"
+        prison-no-probation-email: "b090bedf-58da-495a-8d94-76e4f64aedf8"
+  

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacadeTest.kt
@@ -835,6 +835,10 @@ class BookingFacadeTest {
           "date" to tomorrow().toMediumFormatStyle(),
           "appointmentInfo" to "${birminghamLocation.localName} - 00:00 to 01:00",
           "comments" to "Probation meeting comments",
+          "prisonVideoUrl" to "birmingham-video-url",
+          "probationOfficerName" to "Not yet known",
+          "probationOfficerEmailAddress" to "Not yet known",
+          "probationOfficerContactNumber" to "Not yet known",
         )
       }
 
@@ -849,6 +853,10 @@ class BookingFacadeTest {
           "date" to tomorrow().toMediumFormatStyle(),
           "appointmentInfo" to "${birminghamLocation.localName} - 00:00 to 01:00",
           "comments" to "Probation meeting comments",
+          "prisonVideoUrl" to "birmingham-video-url",
+          "probationOfficerName" to "Not yet known",
+          "probationOfficerEmailAddress" to "Not yet known",
+          "probationOfficerContactNumber" to "Not yet known",
         )
       }
 
@@ -909,6 +917,10 @@ class BookingFacadeTest {
           "date" to tomorrow().toMediumFormatStyle(),
           "appointmentInfo" to "${birminghamLocation.localName} - 00:00 to 01:00",
           "comments" to "Probation meeting comments",
+          "prisonVideoUrl" to "birmingham-video-url",
+          "probationOfficerName" to "Not yet known",
+          "probationOfficerEmailAddress" to "Not yet known",
+          "probationOfficerContactNumber" to "Not yet known",
         )
       }
 
@@ -923,6 +935,10 @@ class BookingFacadeTest {
           "date" to tomorrow().toMediumFormatStyle(),
           "appointmentInfo" to "${birminghamLocation.localName} - 00:00 to 01:00",
           "comments" to "Probation meeting comments",
+          "prisonVideoUrl" to "birmingham-video-url",
+          "probationOfficerName" to "Not yet known",
+          "probationOfficerEmailAddress" to "Not yet known",
+          "probationOfficerContactNumber" to "Not yet known",
         )
       }
 
@@ -983,6 +999,10 @@ class BookingFacadeTest {
           "date" to tomorrow().toMediumFormatStyle(),
           "appointmentInfo" to "${birminghamLocation.localName} - 00:00 to 01:00",
           "comments" to "Probation meeting comments",
+          "prisonVideoUrl" to "birmingham-video-url",
+          "probationOfficerName" to "Not yet known",
+          "probationOfficerEmailAddress" to "Not yet known",
+          "probationOfficerContactNumber" to "Not yet known",
         )
       }
 


### PR DESCRIPTION
Adds the probation officers details and PVL to the probation cancellation emails (in DEV only).