### PR TITLE
BAVL-756 update SQS listener on back of recommended changes in the shared SQS library.

### DIFF
--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -28,6 +28,17 @@
             }
           ],
           "percentage": 10
+        },
+        {
+          "telemetryType": "exception",
+          "attributes": [
+            {
+              "key": "exception.type",
+              "value": "java.util.concurrent.CompletionException",
+              "matchType": "strict"
+            }
+          ],
+          "percentage": 10
         }
       ]
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsListener.kt
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.awspring.cloud.sqs.annotation.SqsListener
-import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.instrumentation.annotations.WithSpan
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
@@ -24,7 +22,6 @@ class InboundEventsListener(
   }
 
   @SqsListener("bvls", factory = "hmppsQueueContainerFactoryProxy")
-  @WithSpan(value = "hmpps-book-a-video-link-hmpps_book_a_video_link_queue", kind = SpanKind.SERVER)
   fun onMessage(rawMessage: String) {
     val message: Message = mapper.readValue(rawMessage)
 


### PR DESCRIPTION
`WithSpan` is no longer needed as this is now managed automatically by the SQS library.

The insights config has been updated on the back of a recommendation in the release note readme [here](https://github.com/ministryofjustice/hmpps-spring-boot-sqs/blob/b282d3e5db11f23948537bce0488f68710b6f4ea/release-notes/5.x.md#510)