### PR TITLE
BAVL-742: Relaxes BLOCKED schedules so bookings can overlap at the exact time of the schedule boundary 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/LocalTimeExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/LocalTimeExt.kt
@@ -6,6 +6,10 @@ import java.time.temporal.ChronoUnit
 
 fun LocalTime.isBetween(from: LocalTime, to: LocalTime) = this.isOnOrAfter(from) && this.isOnOrBefore(to)
 
+fun LocalTime.isBetweenExclusiveEnd(from: LocalTime, to: LocalTime) = this.isOnOrAfter(from) && this.isBefore(to)
+
+fun LocalTime.isBetweenExclusiveStart(from: LocalTime, to: LocalTime) = this.isAfter(from) && this.isOnOrBefore(to)
+
 fun LocalTime.toMinutePrecision(): LocalTime = this.truncatedTo(ChronoUnit.MINUTES)
 
 fun LocalTime.isOnOrBefore(other: LocalTime) = this <= other

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/LocalTimeExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/LocalTimeExt.kt
@@ -4,12 +4,6 @@ import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
-fun LocalTime.isBetween(from: LocalTime, to: LocalTime) = this.isOnOrAfter(from) && this.isOnOrBefore(to)
-
-fun LocalTime.isBetweenExclusiveEnd(from: LocalTime, to: LocalTime) = this.isOnOrAfter(from) && this.isBefore(to)
-
-fun LocalTime.isBetweenExclusiveStart(from: LocalTime, to: LocalTime) = this.isAfter(from) && this.isOnOrBefore(to)
-
 fun LocalTime.toMinutePrecision(): LocalTime = this.truncatedTo(ChronoUnit.MINUTES)
 
 fun LocalTime.isOnOrBefore(other: LocalTime) = this <= other

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttribute.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttribute.kt
@@ -171,10 +171,18 @@ class LocationAttribute private constructor(
     return when {
       // If there aren't any schedules which fall on the requested date and time then default to SHARED
       schedules.isEmpty() -> AvailabilityStatus.SHARED
-      // If there are schedules fall on the date and time look and see if any match the following
-      schedules.any { schedule -> schedule.isUsage(LocationScheduleUsage.BLOCKED) } -> AvailabilityStatus.NONE
+
+      // If there are schedules falling on the date and time look and see if any match the following
+
+      // Block appointments within BLOCKED periods except those whose start time is the same as BLOCKED end-time - lenient at the time borders
+      schedules.any { schedule -> schedule.isUsage(LocationScheduleUsage.BLOCKED) && schedule.endTime != dateAndTime.toLocalTime() } -> AvailabilityStatus.NONE
+
+      // Determine if this schedule is specifically allowed for this team
       schedules.any { schedule -> schedule.isForProbationTeam(probationTeam) } -> AvailabilityStatus.PROBATION_ROOM
+
+      // Determine if this schedule allows any probation team
       schedules.any { schedule -> schedule.isForAnyProbationTeam() } -> AvailabilityStatus.PROBATION_ANY
+
       // If there are no matches above then it is not available
       else -> AvailabilityStatus.NONE
     }
@@ -207,10 +215,18 @@ class LocationAttribute private constructor(
     return when {
       // If there aren't any schedules which fall on the requested date and time then default to SHARED
       schedules.isEmpty() -> AvailabilityStatus.SHARED
-      // If there are schedules fall on the date and time look and see if any match the following
-      schedules.any { schedule -> schedule.isUsage(LocationScheduleUsage.BLOCKED) } -> AvailabilityStatus.NONE
+
+      // If there are schedules falling on the date and time look and see if any match the following
+
+      // Block appointments within BLOCKED periods except those whose start time is the same as BLOCKED end-time - lenient at the time borders
+      schedules.any { schedule -> schedule.isUsage(LocationScheduleUsage.BLOCKED) && schedule.endTime != dateAndTime.toLocalTime() } -> AvailabilityStatus.NONE
+
+      // Determine if this schedule is specifically allowed for this court
       schedules.any { schedule -> schedule.isForCourt(court) } -> AvailabilityStatus.COURT_ROOM
+
+      // Determine if this schedule is allowed for any court
       schedules.any { schedule -> schedule.isForAnyCourt() } -> AvailabilityStatus.COURT_ANY
+
       // If there are no matches above then it is not available
       else -> AvailabilityStatus.NONE
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/DateTimeAvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/DateTimeAvailabilityService.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.Availa
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.slot
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.LocationsService
-import java.time.LocalTime
 
 /**
  * This provides a snapshot (date and time) of available rooms at time of calling. Note this does not guarantee the
@@ -68,7 +67,7 @@ class DateTimeAvailabilityService(
         } else {
           if (!bookedLocations.isBooked(location, meetingStartTime, meetingEndTime)) {
             add(
-              availabilityStatus = location.allowsByAnyRuleOrSchedule(request, meetingStartTime),
+              availabilityStatus = location.allowsByAnyRuleOrSchedule(request),
               availableLocation = AvailableLocation(
                 name = location.description ?: location.key,
                 startTime = meetingStartTime,
@@ -96,21 +95,25 @@ class DateTimeAvailabilityService(
     location.dpsLocationId == prisonAppointment.prisonLocationId && prisonAppointment.appointmentDate == request.date && prisonAppointment.startTime == request.startTime && prisonAppointment.endTime == request.endTime
   }
 
-  protected fun Location.allowsByAnyRuleOrSchedule(request: DateTimeAvailabilityRequest, time: LocalTime): AvailabilityStatus {
+  protected fun Location.allowsByAnyRuleOrSchedule(request: DateTimeAvailabilityRequest): AvailabilityStatus {
     if (extraAttributes != null) {
       return when (request.bookingType!!) {
         BookingType.COURT -> locationAttributesService.isLocationAvailableFor(
           LocationAvailableRequest.court(
             extraAttributes.attributeId,
             request.courtCode!!,
-            request.date!!.atTime(time),
+            request.date!!,
+            request.startTime!!,
+            request.endTime!!,
           ),
         )
         BookingType.PROBATION -> locationAttributesService.isLocationAvailableFor(
           LocationAvailableRequest.probation(
             extraAttributes.attributeId,
             request.probationTeamCode!!,
-            request.date!!.atTime(time),
+            request.date!!,
+            request.startTime!!,
+            request.endTime!!,
           ),
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/LocationAttributesAvailableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/LocationAttributesAvailableService.kt
@@ -7,7 +7,8 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.AvailabilitySt
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.CourtRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.LocationAttributeRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
-import java.time.LocalDateTime
+import java.time.LocalDate
+import java.time.LocalTime
 
 @Service
 @Transactional(readOnly = true)
@@ -24,13 +25,17 @@ class LocationAttributesAvailableService(
       LocationAvailableRequest.Type.COURT -> {
         attribute.isAvailableFor(
           courtRepository.findByCode(request.code) ?: throw EntityNotFoundException("Court code ${request.code} not found"),
-          request.onDateTime,
+          request.onDate,
+          request.startTime,
+          request.endTime,
         )
       }
       LocationAvailableRequest.Type.PROBATION -> {
         attribute.isAvailableFor(
           probationTeamRepository.findByCode(request.code) ?: throw EntityNotFoundException("Probation team ${request.code} not found"),
-          request.onDateTime,
+          request.onDate,
+          request.startTime,
+          request.endTime,
         )
       }
     }
@@ -41,7 +46,9 @@ class LocationAvailableRequest private constructor(
   val attributeId: Long,
   val type: Type,
   val code: String,
-  val onDateTime: LocalDateTime,
+  val onDate: LocalDate,
+  val startTime: LocalTime,
+  val endTime: LocalTime,
 ) {
   enum class Type {
     COURT,
@@ -49,9 +56,9 @@ class LocationAvailableRequest private constructor(
   }
 
   companion object {
-    fun court(attributeId: Long, courtCode: String, onDateTime: LocalDateTime) = LocationAvailableRequest(attributeId, Type.COURT, courtCode, onDateTime)
+    fun court(attributeId: Long, courtCode: String, onDate: LocalDate, startTime: LocalTime, endTime: LocalTime) = LocationAvailableRequest(attributeId, Type.COURT, courtCode, onDate, startTime, endTime)
 
-    fun probation(attributeId: Long, probationTeamCode: String, onDateTime: LocalDateTime) = LocationAvailableRequest(attributeId, Type.PROBATION, probationTeamCode, onDateTime)
+    fun probation(attributeId: Long, probationTeamCode: String, onDate: LocalDate, startTime: LocalTime, endTime: LocalTime) = LocationAvailableRequest(attributeId, Type.PROBATION, probationTeamCode, onDate, startTime, endTime)
   }
 
   override fun equals(other: Any?): Boolean {
@@ -63,7 +70,9 @@ class LocationAvailableRequest private constructor(
     if (attributeId != other.attributeId) return false
     if (type != other.type) return false
     if (code != other.code) return false
-    if (onDateTime != other.onDateTime) return false
+    if (onDate != other.onDate) return false
+    if (startTime != other.startTime) return false
+    if (endTime != other.endTime) return false
 
     return true
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/TimeSlotAvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/TimeSlotAvailabilityService.kt
@@ -108,14 +108,18 @@ class TimeSlotAvailabilityService(
           LocationAvailableRequest.court(
             extraAttributes.attributeId,
             request.courtCode!!,
-            request.date!!.atTime(time),
+            request.date!!,
+            time,
+            time.plusMinutes(request.bookingDuration!!.toLong()),
           ),
         )
         BookingType.PROBATION -> locationAttributesService.isLocationAvailableFor(
           LocationAvailableRequest.probation(
             extraAttributes.attributeId,
             request.probationTeamCode!!,
-            request.date!!.atTime(time),
+            request.date!!,
+            time,
+            time.plusMinutes(request.bookingDuration!!.toLong()),
           ),
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttributesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttributesTest.kt
@@ -373,6 +373,25 @@ class LocationAttributesTest {
 
       roomAttributes.isAvailableFor(probationTeam(), today().atTime(12, 0)) isEqualTo AvailabilityStatus.NONE
     }
+
+    @Test
+    fun `should be PROBATION ANY when schedule is blocked and probation but start time is on the boundary`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = PROBATION_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(9, 0), endTime = LocalTime.of(10, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.PROBATION)
+      }
+
+      roomAttributes.isAvailableFor(probationTeam(), today().atTime(10, 0)) isEqualTo AvailabilityStatus.PROBATION_ANY
+    }
   }
 
   @Nested
@@ -583,6 +602,25 @@ class LocationAttributesTest {
       ).apply { schedule(this, locationUsage = LocationScheduleUsage.PROBATION) }
 
       roomAttributes.isAvailableFor(court(), today().atTime(12, 0)) isEqualTo AvailabilityStatus.NONE
+    }
+
+    @Test
+    fun `should be COURT ANY when schedule is blocked and court but start time in on the boundary`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(9, 0), endTime = LocalTime.of(10, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.COURT)
+      }
+
+      roomAttributes.isAvailableFor(court(), today().atTime(10, 0)) isEqualTo AvailabilityStatus.COURT_ANY
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttributesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttributesTest.kt
@@ -530,7 +530,7 @@ class LocationAttributesTest {
     }
 
     @Test
-    fun `should be NONE for any probation schedule when the end time is out of bounds`() {
+    fun `should be SHARED for any probation schedule when the end time is out of bounds`() {
       val roomAttributes = LocationAttribute.decoratedRoom(
         dpsLocationId = UUID.randomUUID(),
         prison = pentonvillePrison,
@@ -549,7 +549,7 @@ class LocationAttributesTest {
         today(),
         LocalTime.of(10, 30),
         LocalTime.of(11, 30),
-      ) isEqualTo AvailabilityStatus.NONE
+      ) isEqualTo AvailabilityStatus.SHARED
     }
 
     @Test
@@ -987,7 +987,7 @@ class LocationAttributesTest {
     }
 
     @Test
-    fun `should be NONE for any court schedule when the end time is out bounds`() {
+    fun `should be SHARED for any court schedule when the end time is out bounds`() {
       val roomAttributes = LocationAttribute.decoratedRoom(
         dpsLocationId = UUID.randomUUID(),
         prison = pentonvillePrison,
@@ -1006,7 +1006,7 @@ class LocationAttributesTest {
         today(),
         LocalTime.of(10, 30),
         LocalTime.of(11, 30),
-      ) isEqualTo AvailabilityStatus.NONE
+      ) isEqualTo AvailabilityStatus.SHARED
     }
 
     @Test
@@ -1128,6 +1128,29 @@ class LocationAttributesTest {
         LocalTime.of(16, 30),
         LocalTime.of(17, 0),
       ) isEqualTo AvailabilityStatus.SHARED
+    }
+
+    @Test
+    fun `should be NONE when start and end time overlaps blocked schedule`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(12, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+      }
+
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(9, 0),
+        LocalTime.of(13, 0),
+      ) isEqualTo AvailabilityStatus.NONE
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttributesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttributesTest.kt
@@ -605,7 +605,7 @@ class LocationAttributesTest {
     }
 
     @Test
-    fun `should be COURT ANY when schedule is blocked and court but start time in on the boundary`() {
+    fun `should be COURT ANY when schedule is blocked and court but start time is on the boundary`() {
       val roomAttributes = LocationAttribute.decoratedRoom(
         dpsLocationId = UUID.randomUUID(),
         prison = pentonvillePrison,
@@ -618,6 +618,25 @@ class LocationAttributesTest {
       ).apply {
         schedule(this, startTime = LocalTime.of(9, 0), endTime = LocalTime.of(10, 0), locationUsage = LocationScheduleUsage.BLOCKED)
         schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.COURT)
+      }
+
+      roomAttributes.isAvailableFor(court(), today().atTime(10, 0)) isEqualTo AvailabilityStatus.COURT_ANY
+    }
+
+    @Test
+    fun `should be COURT ANY when schedule is blocked and court but end time is on the boundary`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(9, 0), endTime = LocalTime.of(10, 0), locationUsage = LocationScheduleUsage.COURT)
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.BLOCKED)
       }
 
       roomAttributes.isAvailableFor(court(), today().atTime(10, 0)) isEqualTo AvailabilityStatus.COURT_ANY

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttributesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttributesTest.kt
@@ -622,25 +622,6 @@ class LocationAttributesTest {
 
       roomAttributes.isAvailableFor(court(), today().atTime(10, 0)) isEqualTo AvailabilityStatus.COURT_ANY
     }
-
-    @Test
-    fun `should be COURT ANY when schedule is blocked and court but end time is on the boundary`() {
-      val roomAttributes = LocationAttribute.decoratedRoom(
-        dpsLocationId = UUID.randomUUID(),
-        prison = pentonvillePrison,
-        locationStatus = LocationStatus.ACTIVE,
-        locationUsage = LocationUsage.SCHEDULE,
-        allowedParties = emptySet(),
-        prisonVideoUrl = null,
-        notes = null,
-        createdBy = COURT_USER,
-      ).apply {
-        schedule(this, startTime = LocalTime.of(9, 0), endTime = LocalTime.of(10, 0), locationUsage = LocationScheduleUsage.COURT)
-        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.BLOCKED)
-      }
-
-      roomAttributes.isAvailableFor(court(), today().atTime(10, 0)) isEqualTo AvailabilityStatus.COURT_ANY
-    }
   }
 
   private fun schedule(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttributesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttributesTest.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.today
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthPrison
 import java.time.DayOfWeek
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.util.UUID
@@ -200,7 +199,7 @@ class LocationAttributesTest {
         createdBy = PROBATION_USER,
       )
 
-      roomAttributes.isAvailableFor(probationTeam(), today().atTime(12, 0)) isEqualTo AvailabilityStatus.PROBATION_ANY
+      roomAttributes.isAvailableFor(probationTeam(), today(), LocalTime.of(12, 0), LocalTime.of(12, 30)) isEqualTo AvailabilityStatus.PROBATION_ANY
     }
 
     @Test
@@ -216,7 +215,7 @@ class LocationAttributesTest {
         createdBy = PROBATION_USER,
       )
 
-      roomAttributes.isAvailableFor(probationTeam(), today().atTime(12, 0)) isEqualTo AvailabilityStatus.NONE
+      roomAttributes.isAvailableFor(probationTeam(), today(), LocalTime.of(12, 0), LocalTime.of(12, 30)) isEqualTo AvailabilityStatus.NONE
     }
 
     @Test
@@ -234,7 +233,9 @@ class LocationAttributesTest {
 
       roomAttributes.isAvailableFor(
         probationTeam(code = "TEAM_CODE"),
-        LocalDateTime.now(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
       ) isEqualTo AvailabilityStatus.PROBATION_ROOM
     }
 
@@ -253,7 +254,9 @@ class LocationAttributesTest {
 
       roomAttributes.isAvailableFor(
         probationTeam(code = "DIFFERENT_TEAM_CODE"),
-        today().atTime(12, 0),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
       ) isEqualTo AvailabilityStatus.NONE
     }
 
@@ -270,7 +273,12 @@ class LocationAttributesTest {
         createdBy = COURT_USER,
       )
 
-      roomAttributes.isAvailableFor(probationTeam(), today().atTime(12, 0)) isEqualTo AvailabilityStatus.NONE
+      roomAttributes.isAvailableFor(
+        probationTeam(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.NONE
     }
 
     @Test
@@ -289,7 +297,12 @@ class LocationAttributesTest {
         schedule(this, locationUsage = LocationScheduleUsage.BLOCKED)
       }
 
-      roomAttributes.isAvailableFor(probationTeam(), today().atTime(12, 0)) isEqualTo AvailabilityStatus.NONE
+      roomAttributes.isAvailableFor(
+        probationTeam(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.NONE
     }
 
     @Test
@@ -305,7 +318,12 @@ class LocationAttributesTest {
         createdBy = PROBATION_USER,
       )
 
-      roomAttributes.isAvailableFor(probationTeam(), today().atTime(12, 0)) isEqualTo AvailabilityStatus.SHARED
+      roomAttributes.isAvailableFor(
+        probationTeam(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.SHARED
     }
 
     @Test
@@ -321,7 +339,12 @@ class LocationAttributesTest {
         createdBy = PROBATION_USER,
       )
 
-      roomAttributes.isAvailableFor(probationTeam(), today().atTime(12, 0)) isEqualTo AvailabilityStatus.SHARED
+      roomAttributes.isAvailableFor(
+        probationTeam(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.SHARED
     }
 
     @Test
@@ -337,7 +360,12 @@ class LocationAttributesTest {
         createdBy = PROBATION_USER,
       ).apply { schedule(this, locationUsage = LocationScheduleUsage.PROBATION) }
 
-      roomAttributes.isAvailableFor(probationTeam(), today().atTime(12, 0)) isEqualTo AvailabilityStatus.PROBATION_ANY
+      roomAttributes.isAvailableFor(
+        probationTeam(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.PROBATION_ANY
     }
 
     @Test
@@ -355,7 +383,58 @@ class LocationAttributesTest {
         schedule(this, locationUsage = LocationScheduleUsage.PROBATION, allowedParties = setOf("PROBATION_TEAM"))
       }
 
-      roomAttributes.isAvailableFor(probationTeam(code = "PROBATION_TEAM"), today().atTime(12, 0)) isEqualTo AvailabilityStatus.PROBATION_ROOM
+      roomAttributes.isAvailableFor(
+        probationTeam(code = "PROBATION_TEAM"),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.PROBATION_ROOM
+    }
+
+    @Test
+    fun `should be NONE for probation when schedule blocked and start time is not blocked but end time is`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(9, 0), endTime = LocalTime.of(10, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+      }
+
+      roomAttributes.isAvailableFor(
+        probationTeam(),
+        today(),
+        LocalTime.of(8, 30),
+        LocalTime.of(9, 30),
+      ) isEqualTo AvailabilityStatus.NONE
+    }
+
+    @Test
+    fun `should be NONE for probation when schedule blocked and start time is blocked but end time is not`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(9, 0), endTime = LocalTime.of(10, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+      }
+
+      roomAttributes.isAvailableFor(
+        probationTeam(),
+        today(),
+        LocalTime.of(9, 30),
+        LocalTime.of(10, 30),
+      ) isEqualTo AvailabilityStatus.NONE
     }
 
     @Test
@@ -371,7 +450,12 @@ class LocationAttributesTest {
         createdBy = PROBATION_USER,
       ).apply { schedule(this, locationUsage = LocationScheduleUsage.COURT) }
 
-      roomAttributes.isAvailableFor(probationTeam(), today().atTime(12, 0)) isEqualTo AvailabilityStatus.NONE
+      roomAttributes.isAvailableFor(
+        probationTeam(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.NONE
     }
 
     @Test
@@ -390,7 +474,128 @@ class LocationAttributesTest {
         schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.PROBATION)
       }
 
-      roomAttributes.isAvailableFor(probationTeam(), today().atTime(10, 0)) isEqualTo AvailabilityStatus.PROBATION_ANY
+      roomAttributes.isAvailableFor(
+        probationTeam(),
+        today(),
+        LocalTime.of(10, 0),
+        LocalTime.of(11, 0),
+      ) isEqualTo AvailabilityStatus.PROBATION_ANY
+    }
+
+    @Test
+    fun `should be PROBATION ANY when schedule is blocked and court but end time is on the boundary`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(9, 0), endTime = LocalTime.of(10, 0), locationUsage = LocationScheduleUsage.PROBATION)
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+      }
+
+      roomAttributes.isAvailableFor(
+        probationTeam(),
+        today(),
+        LocalTime.of(9, 0),
+        LocalTime.of(10, 0),
+      ) isEqualTo AvailabilityStatus.PROBATION_ANY
+    }
+
+    @Test
+    fun `should be NONE for specific probation schedule when the end time is out of bounds`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = setOf("PROBATION"),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = PROBATION_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.PROBATION, allowedParties = setOf("PROBATION"))
+      }
+
+      roomAttributes.isAvailableFor(
+        probationTeam(code = "PROBATION"),
+        today(),
+        LocalTime.of(10, 30),
+        LocalTime.of(11, 30),
+      ) isEqualTo AvailabilityStatus.NONE
+    }
+
+    @Test
+    fun `should be NONE for any probation schedule when the end time is out of bounds`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = PROBATION_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.PROBATION)
+      }
+
+      roomAttributes.isAvailableFor(
+        probationTeam(),
+        today(),
+        LocalTime.of(10, 30),
+        LocalTime.of(11, 30),
+      ) isEqualTo AvailabilityStatus.NONE
+    }
+
+    @Test
+    fun `should be SHARED for blocked schedule when the start time matches the schedule end time`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = PROBATION_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+      }
+
+      roomAttributes.isAvailableFor(
+        probationTeam(),
+        today(),
+        LocalTime.of(11, 0),
+        LocalTime.of(11, 30),
+      ) isEqualTo AvailabilityStatus.SHARED
+    }
+
+    @Test
+    fun `should be SHARED for blocked schedule when the end time matches the schedule start time`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = PROBATION_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+      }
+
+      roomAttributes.isAvailableFor(
+        probationTeam(),
+        today(),
+        LocalTime.of(9, 0),
+        LocalTime.of(10, 0),
+      ) isEqualTo AvailabilityStatus.SHARED
     }
   }
 
@@ -409,7 +614,12 @@ class LocationAttributesTest {
         createdBy = COURT_USER,
       )
 
-      roomAttributes.isAvailableFor(court(), LocalDateTime.now()) isEqualTo AvailabilityStatus.COURT_ANY
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.COURT_ANY
     }
 
     @Test
@@ -436,7 +646,12 @@ class LocationAttributesTest {
         )
       }
 
-      roomAttributes.isAvailableFor(court(), LocalDate.now().atTime(12, 0)) isEqualTo AvailabilityStatus.COURT_ANY
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.COURT_ANY
     }
 
     @Test
@@ -452,7 +667,12 @@ class LocationAttributesTest {
         createdBy = COURT_USER,
       )
 
-      roomAttributes.isAvailableFor(court(), LocalDateTime.now()) isEqualTo AvailabilityStatus.NONE
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.NONE
     }
 
     @Test
@@ -468,7 +688,12 @@ class LocationAttributesTest {
         createdBy = PROBATION_USER,
       )
 
-      roomAttributes.isAvailableFor(court(), LocalDateTime.now()) isEqualTo AvailabilityStatus.NONE
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.NONE
     }
 
     @Test
@@ -484,7 +709,12 @@ class LocationAttributesTest {
         allowedParties = setOf("COURT"),
       )
 
-      roomAttributes.isAvailableFor(court(code = "COURT"), LocalDateTime.now()) isEqualTo AvailabilityStatus.COURT_ROOM
+      roomAttributes.isAvailableFor(
+        court(code = "COURT"),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.COURT_ROOM
     }
 
     @Test
@@ -500,7 +730,12 @@ class LocationAttributesTest {
         allowedParties = setOf("COURT"),
       )
 
-      roomAttributes.isAvailableFor(court(code = "DIFFERENT_COURT"), LocalDateTime.now()) isEqualTo AvailabilityStatus.NONE
+      roomAttributes.isAvailableFor(
+        court(code = "DIFFERENT_COURT"),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.NONE
     }
 
     @Test
@@ -516,7 +751,12 @@ class LocationAttributesTest {
         createdBy = COURT_USER,
       )
 
-      roomAttributes.isAvailableFor(court(), LocalDateTime.now()) isEqualTo AvailabilityStatus.SHARED
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.SHARED
     }
 
     @Test
@@ -532,7 +772,12 @@ class LocationAttributesTest {
         createdBy = COURT_USER,
       )
 
-      roomAttributes.isAvailableFor(court(), today().atTime(12, 0)) isEqualTo AvailabilityStatus.SHARED
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.SHARED
     }
 
     @Test
@@ -548,7 +793,12 @@ class LocationAttributesTest {
         createdBy = COURT_USER,
       ).apply { schedule(this, locationUsage = LocationScheduleUsage.COURT) }
 
-      roomAttributes.isAvailableFor(court(), today().atTime(12, 0)) isEqualTo AvailabilityStatus.COURT_ANY
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.COURT_ANY
     }
 
     @Test
@@ -566,7 +816,12 @@ class LocationAttributesTest {
         schedule(this, locationUsage = LocationScheduleUsage.COURT, allowedParties = setOf("COURT"))
       }
 
-      roomAttributes.isAvailableFor(court(code = "COURT"), today().atTime(12, 0)) isEqualTo AvailabilityStatus.COURT_ROOM
+      roomAttributes.isAvailableFor(
+        court(code = "COURT"),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.COURT_ROOM
     }
 
     @Test
@@ -585,11 +840,62 @@ class LocationAttributesTest {
         schedule(this, locationUsage = LocationScheduleUsage.BLOCKED)
       }
 
-      roomAttributes.isAvailableFor(court(), today().atTime(12, 0)) isEqualTo AvailabilityStatus.NONE
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.NONE
     }
 
     @Test
-    fun `should be NONE for court schedule`() {
+    fun `should be NONE for a court when schedule blocked and start time is not blocked but end time is`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(9, 0), endTime = LocalTime.of(10, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+      }
+
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(8, 30),
+        LocalTime.of(9, 30),
+      ) isEqualTo AvailabilityStatus.NONE
+    }
+
+    @Test
+    fun `should be NONE for a court when schedule blocked and start time is blocked but end time is not`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(9, 0), endTime = LocalTime.of(10, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+      }
+
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(9, 30),
+        LocalTime.of(10, 30),
+      ) isEqualTo AvailabilityStatus.NONE
+    }
+
+    @Test
+    fun `should be NONE for probation schedule`() {
       val roomAttributes = LocationAttribute.decoratedRoom(
         dpsLocationId = UUID.randomUUID(),
         prison = pentonvillePrison,
@@ -601,7 +907,12 @@ class LocationAttributesTest {
         createdBy = COURT_USER,
       ).apply { schedule(this, locationUsage = LocationScheduleUsage.PROBATION) }
 
-      roomAttributes.isAvailableFor(court(), today().atTime(12, 0)) isEqualTo AvailabilityStatus.NONE
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.NONE
     }
 
     @Test
@@ -620,7 +931,203 @@ class LocationAttributesTest {
         schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.COURT)
       }
 
-      roomAttributes.isAvailableFor(court(), today().atTime(10, 0)) isEqualTo AvailabilityStatus.COURT_ANY
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(10, 0),
+        LocalTime.of(11, 0),
+      ) isEqualTo AvailabilityStatus.COURT_ANY
+    }
+
+    @Test
+    fun `should be COURT ANY when schedule is blocked and court but end time is on the boundary`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(9, 0), endTime = LocalTime.of(10, 0), locationUsage = LocationScheduleUsage.COURT)
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+      }
+
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(9, 0),
+        LocalTime.of(10, 0),
+      ) isEqualTo AvailabilityStatus.COURT_ANY
+    }
+
+    @Test
+    fun `should be NONE for specific court schedule when the end time is out bounds`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = setOf("COURT"),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.COURT, allowedParties = setOf("COURT"))
+      }
+
+      roomAttributes.isAvailableFor(
+        court(code = "COURT"),
+        today(),
+        LocalTime.of(10, 30),
+        LocalTime.of(11, 30),
+      ) isEqualTo AvailabilityStatus.NONE
+    }
+
+    @Test
+    fun `should be NONE for any court schedule when the end time is out bounds`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.COURT)
+      }
+
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(10, 30),
+        LocalTime.of(11, 30),
+      ) isEqualTo AvailabilityStatus.NONE
+    }
+
+    @Test
+    fun `should be SHARED for blocked schedule when the start time matches the schedule end time`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+      }
+
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(11, 0),
+        LocalTime.of(11, 30),
+      ) isEqualTo AvailabilityStatus.SHARED
+    }
+
+    @Test
+    fun `should be SHARED for blocked schedule when the end time matches the schedule start time`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(11, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+      }
+
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(9, 0),
+        LocalTime.of(10, 0),
+      ) isEqualTo AvailabilityStatus.SHARED
+    }
+
+    @Test
+    fun `should be NONE when blocked by overlapping probation schedule`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(8, 0), endTime = LocalTime.of(10, 0), locationUsage = LocationScheduleUsage.COURT)
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(12, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+        schedule(this, startTime = LocalTime.of(14, 0), endTime = LocalTime.of(16, 0), locationUsage = LocationScheduleUsage.PROBATION)
+      }
+
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(13, 30),
+        LocalTime.of(14, 30),
+      ) isEqualTo AvailabilityStatus.NONE
+    }
+
+    @Test
+    fun `should be SHARED when end time matches start of probation schedule`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(8, 0), endTime = LocalTime.of(10, 0), locationUsage = LocationScheduleUsage.COURT)
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(12, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+        schedule(this, startTime = LocalTime.of(14, 0), endTime = LocalTime.of(16, 0), locationUsage = LocationScheduleUsage.PROBATION)
+      }
+
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(13, 30),
+        LocalTime.of(14, 0),
+      ) isEqualTo AvailabilityStatus.SHARED
+    }
+
+    @Test
+    fun `should be SHARED when start time matches end of probation schedule`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply {
+        schedule(this, startTime = LocalTime.of(8, 0), endTime = LocalTime.of(10, 0), locationUsage = LocationScheduleUsage.COURT)
+        schedule(this, startTime = LocalTime.of(10, 0), endTime = LocalTime.of(12, 0), locationUsage = LocationScheduleUsage.BLOCKED)
+        schedule(this, startTime = LocalTime.of(14, 0), endTime = LocalTime.of(16, 0), locationUsage = LocationScheduleUsage.PROBATION)
+      }
+
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(16, 30),
+        LocalTime.of(17, 0),
+      ) isEqualTo AvailabilityStatus.SHARED
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/DateTimeAvailabilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/DateTimeAvailabilityServiceTest.kt
@@ -169,7 +169,7 @@ class DateTimeAvailabilityServiceTest {
         ),
       ) doReturn BookedLocations(emptyList())
 
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 0)))) doReturn AvailabilityStatus.PROBATION_ANY
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 0), LocalTime.of(10, 0)))) doReturn AvailabilityStatus.PROBATION_ANY
 
       val response = service().findAvailable(
         DateTimeAvailabilityRequest(
@@ -203,8 +203,8 @@ class DateTimeAvailabilityServiceTest {
         ),
       ) doReturn BookedLocations(emptyList())
 
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 0)))) doReturn AvailabilityStatus.PROBATION_ANY
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 0)))) doReturn AvailabilityStatus.PROBATION_ROOM
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 0), LocalTime.of(10, 0)))) doReturn AvailabilityStatus.PROBATION_ANY
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 0), LocalTime.of(10, 0)))) doReturn AvailabilityStatus.PROBATION_ROOM
 
       val response = service().findAvailable(
         DateTimeAvailabilityRequest(
@@ -239,8 +239,8 @@ class DateTimeAvailabilityServiceTest {
         ),
       ) doReturn BookedLocations(emptyList())
 
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 0)))) doReturn AvailabilityStatus.SHARED
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 0)))) doReturn AvailabilityStatus.NONE
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 0), LocalTime.of(10, 0)))) doReturn AvailabilityStatus.SHARED
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 0), LocalTime.of(10, 0)))) doReturn AvailabilityStatus.NONE
 
       val response = service().findAvailable(
         DateTimeAvailabilityRequest(
@@ -273,7 +273,7 @@ class DateTimeAvailabilityServiceTest {
         ),
       ) doReturn BookedLocations(emptyList())
 
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 0)))) doReturn AvailabilityStatus.PROBATION_ANY
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 0), LocalTime.of(10, 0)))) doReturn AvailabilityStatus.PROBATION_ANY
 
       val response = service().findAvailable(
         DateTimeAvailabilityRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/LocationAttributesAvailableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/LocationAttributesAvailableServiceTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.LocationAttribute
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ProbationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.today
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.CourtRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.LocationAttributeRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
@@ -32,10 +33,10 @@ class LocationAttributesAvailableServiceTest {
   fun `should fail if location attributes not found`() {
     whenever(locationAttributeRepository.findById(1)) doReturn Optional.empty()
 
-    assertThrows<EntityNotFoundException> { service.isLocationAvailableFor(LocationAvailableRequest.court(1, "COURT", now)) }
+    assertThrows<EntityNotFoundException> { service.isLocationAvailableFor(LocationAvailableRequest.court(1, "COURT", today(), now.toLocalTime(), now.toLocalTime())) }
       .message isEqualTo "Location attribute 1 not found"
 
-    assertThrows<EntityNotFoundException> { service.isLocationAvailableFor(LocationAvailableRequest.probation(1, "PROBATION", now)) }
+    assertThrows<EntityNotFoundException> { service.isLocationAvailableFor(LocationAvailableRequest.probation(1, "PROBATION", today(), now.toLocalTime(), now.toLocalTime())) }
       .message isEqualTo "Location attribute 1 not found"
   }
 
@@ -44,7 +45,7 @@ class LocationAttributesAvailableServiceTest {
     whenever(locationAttributeRepository.findById(1)) doReturn mock()
     whenever(courtRepository.findByCode("COURT")) doReturn null
 
-    assertThrows<EntityNotFoundException> { service.isLocationAvailableFor(LocationAvailableRequest.court(1, "COURT", now)) }
+    assertThrows<EntityNotFoundException> { service.isLocationAvailableFor(LocationAvailableRequest.court(1, "COURT", today(), now.toLocalTime(), now.toLocalTime())) }
       .message isEqualTo "Court code COURT not found"
 
     verify(courtRepository).findByCode("COURT")
@@ -55,7 +56,7 @@ class LocationAttributesAvailableServiceTest {
     whenever(locationAttributeRepository.findById(1)) doReturn mock()
     whenever(probationTeamRepository.findByCode("PROBATION")) doReturn null
 
-    assertThrows<EntityNotFoundException> { service.isLocationAvailableFor(LocationAvailableRequest.probation(1, "PROBATION", now)) }
+    assertThrows<EntityNotFoundException> { service.isLocationAvailableFor(LocationAvailableRequest.probation(1, "PROBATION", today(), now.toLocalTime(), now.toLocalTime())) }
       .message isEqualTo "Probation team PROBATION not found"
 
     verify(probationTeamRepository).findByCode("PROBATION")
@@ -65,35 +66,35 @@ class LocationAttributesAvailableServiceTest {
   fun `should be COURT ANY when location attribute is available for court`() {
     whenever(locationAttributeRepository.findById(1)) doReturn Optional.of(locationAttribute)
     whenever(courtRepository.findByCode("COURT")) doReturn court
-    whenever(locationAttribute.isAvailableFor(court, now)) doReturn AvailabilityStatus.COURT_ANY
+    whenever(locationAttribute.isAvailableFor(court, today(), now.toLocalTime(), now.toLocalTime())) doReturn AvailabilityStatus.COURT_ANY
 
-    service.isLocationAvailableFor(LocationAvailableRequest.court(1, "COURT", now)) isEqualTo AvailabilityStatus.COURT_ANY
+    service.isLocationAvailableFor(LocationAvailableRequest.court(1, "COURT", today(), now.toLocalTime(), now.toLocalTime())) isEqualTo AvailabilityStatus.COURT_ANY
   }
 
   @Test
   fun `should be NONE when location attribute is not available for court`() {
     whenever(locationAttributeRepository.findById(1)) doReturn Optional.of(locationAttribute)
     whenever(courtRepository.findByCode("COURT")) doReturn court
-    whenever(locationAttribute.isAvailableFor(court, now)) doReturn AvailabilityStatus.NONE
+    whenever(locationAttribute.isAvailableFor(court, today(), now.toLocalTime(), now.toLocalTime())) doReturn AvailabilityStatus.NONE
 
-    service.isLocationAvailableFor(LocationAvailableRequest.court(1, "COURT", now)) isEqualTo AvailabilityStatus.NONE
+    service.isLocationAvailableFor(LocationAvailableRequest.court(1, "COURT", today(), now.toLocalTime(), now.toLocalTime())) isEqualTo AvailabilityStatus.NONE
   }
 
   @Test
   fun `should be PROBATION ANY when location attribute is available for probation team`() {
     whenever(locationAttributeRepository.findById(1)) doReturn Optional.of(locationAttribute)
     whenever(probationTeamRepository.findByCode("PROBATION")) doReturn probationTeam
-    whenever(locationAttribute.isAvailableFor(probationTeam, now)) doReturn AvailabilityStatus.PROBATION_ANY
+    whenever(locationAttribute.isAvailableFor(probationTeam, today(), now.toLocalTime(), now.toLocalTime())) doReturn AvailabilityStatus.PROBATION_ANY
 
-    service.isLocationAvailableFor(LocationAvailableRequest.probation(1, "PROBATION", now)) isEqualTo AvailabilityStatus.PROBATION_ANY
+    service.isLocationAvailableFor(LocationAvailableRequest.probation(1, "PROBATION", today(), now.toLocalTime(), now.toLocalTime())) isEqualTo AvailabilityStatus.PROBATION_ANY
   }
 
   @Test
   fun `should be NONE when location attribute is not available for probation team`() {
     whenever(locationAttributeRepository.findById(1)) doReturn Optional.of(locationAttribute)
     whenever(probationTeamRepository.findByCode("PROBATION")) doReturn probationTeam
-    whenever(locationAttribute.isAvailableFor(probationTeam, now)) doReturn AvailabilityStatus.NONE
+    whenever(locationAttribute.isAvailableFor(probationTeam, today(), now.toLocalTime(), now.toLocalTime())) doReturn AvailabilityStatus.NONE
 
-    service.isLocationAvailableFor(LocationAvailableRequest.probation(1, "PROBATION", now)) isEqualTo AvailabilityStatus.NONE
+    service.isLocationAvailableFor(LocationAvailableRequest.probation(1, "PROBATION", today(), now.toLocalTime(), now.toLocalTime())) isEqualTo AvailabilityStatus.NONE
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/TimeSlotAvailabilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/TimeSlotAvailabilityServiceTest.kt
@@ -383,8 +383,8 @@ class TimeSlotAvailabilityServiceTest {
         ),
       ) doReturn BookedLocations(emptyList())
 
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 0)))) doReturn AvailabilityStatus.PROBATION_ANY
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 15)))) doReturn AvailabilityStatus.PROBATION_ANY
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 0), LocalTime.of(9, 30)))) doReturn AvailabilityStatus.PROBATION_ANY
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 15), LocalTime.of(9, 45)))) doReturn AvailabilityStatus.PROBATION_ANY
 
       val response = service().findAvailable(
         TimeSlotAvailabilityRequest(
@@ -418,10 +418,10 @@ class TimeSlotAvailabilityServiceTest {
         ),
       ) doReturn BookedLocations(emptyList())
 
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 0)))) doReturn AvailabilityStatus.SHARED
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 15)))) doReturn AvailabilityStatus.SHARED
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 0)))) doReturn AvailabilityStatus.PROBATION_ANY
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 15)))) doReturn AvailabilityStatus.PROBATION_ANY
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 0), LocalTime.of(9, 30)))) doReturn AvailabilityStatus.SHARED
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 15), LocalTime.of(9, 45)))) doReturn AvailabilityStatus.SHARED
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 0), LocalTime.of(9, 30)))) doReturn AvailabilityStatus.PROBATION_ANY
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 15), LocalTime.of(9, 45)))) doReturn AvailabilityStatus.PROBATION_ANY
 
       val response = service().findAvailable(
         TimeSlotAvailabilityRequest(
@@ -455,10 +455,10 @@ class TimeSlotAvailabilityServiceTest {
         ),
       ) doReturn BookedLocations(emptyList())
 
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 0)))) doReturn AvailabilityStatus.SHARED
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 15)))) doReturn AvailabilityStatus.SHARED
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 0)))) doReturn AvailabilityStatus.NONE
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 15)))) doReturn AvailabilityStatus.NONE
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 0), LocalTime.of(9, 30)))) doReturn AvailabilityStatus.SHARED
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 15), LocalTime.of(9, 45)))) doReturn AvailabilityStatus.SHARED
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 0), LocalTime.of(9, 30)))) doReturn AvailabilityStatus.NONE
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 15), LocalTime.of(9, 45)))) doReturn AvailabilityStatus.NONE
 
       val response = service().findAvailable(
         TimeSlotAvailabilityRequest(
@@ -492,10 +492,10 @@ class TimeSlotAvailabilityServiceTest {
         ),
       ) doReturn BookedLocations(emptyList())
 
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 0)))) doReturn AvailabilityStatus.SHARED
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 15)))) doReturn AvailabilityStatus.SHARED
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 0)))) doReturn AvailabilityStatus.PROBATION_ANY
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 15)))) doReturn AvailabilityStatus.PROBATION_ANY
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 0), LocalTime.of(9, 30)))) doReturn AvailabilityStatus.SHARED
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 15), LocalTime.of(9, 45)))) doReturn AvailabilityStatus.SHARED
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 0), LocalTime.of(9, 30)))) doReturn AvailabilityStatus.PROBATION_ANY
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(2, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 15), LocalTime.of(9, 45)))) doReturn AvailabilityStatus.PROBATION_ANY
 
       val response = service().findAvailable(
         TimeSlotAvailabilityRequest(
@@ -529,8 +529,8 @@ class TimeSlotAvailabilityServiceTest {
         ),
       ) doReturn BookedLocations(emptyList())
 
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 0)))) doReturn AvailabilityStatus.NONE
-      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow().atTime(9, 15)))) doReturn AvailabilityStatus.PROBATION_ANY
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 0), LocalTime.of(9, 30)))) doReturn AvailabilityStatus.NONE
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, BLACKPOOL_MC_PPOC, tomorrow(), LocalTime.of(9, 15), LocalTime.of(9, 45)))) doReturn AvailabilityStatus.PROBATION_ANY
 
       val response = service().findAvailable(
         TimeSlotAvailabilityRequest(


### PR DESCRIPTION
Details are on the JIRA BAVL-742.

This branch now encompasses another ticket JIRA BAVL-776.  This prevents end times bleeding over their allotted slots.  For example if a slot is for 10-12 then all start and end times must be within that slot.