### PR TITLE
BAVL-752 initial commit for supporting the appointments changed event for release and transfer of prisoners.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonersearch/PrisonerSearchClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonersearch/PrisonerSearchClient.kt
@@ -40,4 +40,5 @@ data class Prisoner(
   val dateOfBirth: LocalDate,
   val bookingId: String? = null,
   val lastPrisonId: String? = null,
+  val lastMovementTypeCode: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/DomainEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/DomainEvents.kt
@@ -98,6 +98,17 @@ data class AppointmentScheduleInformation(
   val agencyLocationId: String,
 ) : AdditionalInformation
 
+class PrisonerAppointmentsChangedEvent(
+  val personReference: PersonReference,
+  additionalInformation: AppointmentsChangedInformation,
+) : DomainEvent<AppointmentsChangedInformation>(DomainEventType.PRISONER_APPOINTMENTS_CHANGED, additionalInformation) {
+  fun prisonerNumber() = personReference.identifiers.first { it.type == "NOMS" }.value
+  fun prisonCode() = additionalInformation.prisonId
+  fun isCancelAppointments() = additionalInformation.action == "YES"
+}
+
+data class AppointmentsChangedInformation(val action: String, val prisonId: String, val user: String) : AdditionalInformation
+
 enum class DomainEventType(val eventType: String, val description: String = "") {
   VIDEO_BOOKING_CREATED(
     "book-a-video-link.video-booking.created",
@@ -131,6 +142,9 @@ enum class DomainEventType(val eventType: String, val description: String = "") 
   },
   PRISONER_VIDEO_APPOINTMENT_CANCELLED("prison-offender-events.prisoner.video-appointment.cancelled") {
     override fun toInboundEvent(mapper: ObjectMapper, message: String) = mapper.readValue<PrisonerVideoAppointmentCancelledEvent>(message)
+  },
+  PRISONER_APPOINTMENTS_CHANGED("prison-offender-events.prisoner.appointments-changed") {
+    override fun toInboundEvent(mapper: ObjectMapper, message: String) = mapper.readValue<PrisonerAppointmentsChangedEvent>(message)
   },
   ;
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsService.kt
@@ -4,6 +4,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.AppointmentCreatedEventHandler
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerAppointmentsChangedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerMergedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerReleasedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerVideoAppointmentCancelledEventHandler
@@ -20,6 +21,7 @@ class InboundEventsService(
   private val prisonerReleasedEventHandler: PrisonerReleasedEventHandler,
   private val prisonerMergedEventHandler: PrisonerMergedEventHandler,
   private val prisonerVideoAppointmentCancelledEventHandler: PrisonerVideoAppointmentCancelledEventHandler,
+  private val prisonerAppointmentsChangedEventHandler: PrisonerAppointmentsChangedEventHandler,
 ) {
   companion object {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -34,6 +36,7 @@ class InboundEventsService(
       is VideoBookingCancelledEvent -> videoBookingCancelledEventHandler.handle(event)
       is VideoBookingCreatedEvent -> videoBookingCreatedEventHandler.handle(event)
       is PrisonerVideoAppointmentCancelledEvent -> prisonerVideoAppointmentCancelledEventHandler.handle(event)
+      is PrisonerAppointmentsChangedEvent -> prisonerAppointmentsChangedEventHandler.handle(event)
       else -> log.warn("Unsupported domain event ${event.javaClass.name}")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerAppointmentsChangedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerAppointmentsChangedEventHandler.kt
@@ -38,7 +38,9 @@ class PrisonerAppointmentsChangedEventHandler(
         .distinct()
 
       if (bookings.isNotEmpty()) {
-        val prisoner = prisonerSearchClient.getPrisoner(event.prisonerNumber()).throwNullPointerIfNotFound { "Unable to find prisoner ${event.prisonerNumber()}" }
+        val prisoner = prisonerSearchClient.getPrisoner(event.prisonerNumber()).throwNullPointerIfNotFound { "PRISONER_APPOINTMENTS_CHANGED_EVENT: unable to find prisoner ${event.prisonerNumber()}" }
+
+        log.info("PRISONER_APPOINTMENTS_CHANGED_EVENT: ${prisoner.prisonerNumber}, last prison code: ${prisoner.lastPrisonId}, last movement type code ${prisoner.lastMovementTypeCode}")
 
         when (prisoner.lastMovementTypeCode) {
           RELEASED -> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerAppointmentsChangedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerAppointmentsChangedEventHandler.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.TimeSource
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingFacade
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserService
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PrisonerAppointmentsChangedEvent
+
+private const val RELEASED = "REL"
+private const val TRANSFERRED = "TRN"
+
+/**
+ * This event is raised on the back of a prison user deciding what to do with a prisoners appointments on the back of a
+ * movement (via NOMIS) e.g. transfer, release. They are given the option to cancel any existing appointments.
+ */
+@Component
+class PrisonerAppointmentsChangedEventHandler(
+  private val prisonAppointmentRepository: PrisonAppointmentRepository,
+  private val prisonerSearchClient: PrisonerSearchClient,
+  private val bookingFacade: BookingFacade,
+  private val timeSource: TimeSource,
+) : DomainEventHandler<PrisonerAppointmentsChangedEvent> {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  override fun handle(event: PrisonerAppointmentsChangedEvent) {
+    if (event.isCancelAppointments()) {
+      val now = timeSource.now()
+
+      val bookings = prisonAppointmentRepository.findActivePrisonerPrisonAppointmentsAfter(event.prisonerNumber(), now.toLocalDate(), now.toLocalTime())
+        .map { it.videoBooking.videoBookingId }
+        .distinct()
+
+      if (bookings.isNotEmpty()) {
+        val prisoner = prisonerSearchClient.getPrisoner(event.prisonerNumber()).throwNullPointerIfNotFound { "Unable to find prisoner ${event.prisonerNumber()}" }
+
+        when (prisoner.lastMovementTypeCode) {
+          RELEASED -> {
+            log.info("PRISONER_APPOINTMENTS_CHANGED_EVENT: processing release for prisoner ${event.prisonerNumber()} - $event")
+            bookings.forEach { bookingFacade.prisonerReleased(it, UserService.getServiceAsUser()) }
+          }
+          TRANSFERRED -> {
+            log.info("PRISONER_APPOINTMENTS_CHANGED_EVENT: processing transfer for prisoner ${event.prisonerNumber()} - $event")
+            bookings.forEach { bookingFacade.prisonerTransferred(it, UserService.getServiceAsUser()) }
+          }
+          null -> log.info("PRISONER_APPOINTMENTS_CHANGED_EVENT: no-op - last movement type is null for prisoner ${event.prisonerNumber()} - $event")
+          else -> log.info("PRISONER_APPOINTMENTS_CHANGED_EVENT: no-op - last movement type ${prisoner.lastMovementTypeCode} for prisoner ${event.prisonerNumber()} - $event")
+        }
+
+        return
+      }
+    }
+
+    log.info("PRISONER_APPOINTMENTS_CHANGED_EVENT: no action taken for prisoner ${event.prisonerNumber()} - $event.")
+  }
+
+  private fun Prisoner?.throwNullPointerIfNotFound(lazyMessage: () -> String): Prisoner {
+    if (this == null) {
+      throw NullPointerException(lazyMessage())
+    }
+
+    return this
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -91,6 +91,7 @@ fun prisonerSearchPrisoner(
   lastName: String = "Bloggs",
   bookingId: Long = -1,
   lastPrisonCode: String? = null,
+  lastMovementTypeCode: String? = null,
 ) = Prisoner(
   prisonerNumber = prisonerNumber,
   prisonId = prisonCode,
@@ -99,6 +100,7 @@ fun prisonerSearchPrisoner(
   bookingId = bookingId.toString(),
   dateOfBirth = LocalDate.of(2000, 1, 1),
   lastPrisonId = lastPrisonCode,
+  lastMovementTypeCode = lastMovementTypeCode,
 )
 
 fun userEmailAddress(username: String, email: String, verified: Boolean = true) = EmailAddressDto(username, verified, email)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonerSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonerSearchApiMockServer.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonerSearch
 
 class PrisonerSearchApiMockServer : MockServer(8092) {
 
-  fun stubGetPrisoner(prisonerNumber: String, prisonCode: String = "WWI", lastPrisonCode: String? = null) {
+  fun stubGetPrisoner(prisonerNumber: String, prisonCode: String = "WWI", lastPrisonCode: String? = null, lastMovementTypeCode: String? = null) {
     stubFor(
       get("/prisoner/$prisonerNumber")
         .willReturn(
@@ -22,6 +22,7 @@ class PrisonerSearchApiMockServer : MockServer(8092) {
                   prisonerNumber = prisonerNumber,
                   prisonCode = prisonCode,
                   lastPrisonCode = lastPrisonCode,
+                  lastMovementTypeCode = lastMovementTypeCode,
                 ),
               ),
             )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/InboundEventsServiceTest.kt
@@ -5,6 +5,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.AppointmentCreatedEventHandler
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerAppointmentsChangedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerMergedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerReleasedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers.PrisonerVideoAppointmentCancelledEventHandler
@@ -21,6 +22,7 @@ class InboundEventsServiceTest {
   private val prisonerReleasedEventHandler: PrisonerReleasedEventHandler = mock()
   private val prisonerMergedEventHandler: PrisonerMergedEventHandler = mock()
   private val prisonerVideoAppointmentCancelledEventHandler: PrisonerVideoAppointmentCancelledEventHandler = mock()
+  private val prisonerAppointmentsChangedEventHandler: PrisonerAppointmentsChangedEventHandler = mock()
 
   private val service = InboundEventsService(
     appointmentCreatedEventHandler,
@@ -30,6 +32,7 @@ class InboundEventsServiceTest {
     prisonerReleasedEventHandler,
     prisonerMergedEventHandler,
     prisonerVideoAppointmentCancelledEventHandler,
+    prisonerAppointmentsChangedEventHandler,
   )
 
   @Test
@@ -99,5 +102,12 @@ class InboundEventsServiceTest {
     val event = mock<PrisonerVideoAppointmentCancelledEvent>()
     service.process(event)
     verify(prisonerVideoAppointmentCancelledEventHandler).handle(event)
+  }
+
+  @Test
+  fun `should call prisoner appointments changed event handler when prisoner appointment changed event`() {
+    val event = mock<PrisonerAppointmentsChangedEvent>()
+    service.process(event)
+    verify(prisonerAppointmentsChangedEventHandler).handle(event)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerAppointmentsChangedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/PrisonerAppointmentsChangedEventHandlerTest.kt
@@ -1,0 +1,77 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.handlers
+
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.TimeSource
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.SERVICE_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonerSearchPrisoner
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withMainCourtPrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingFacade
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.AppointmentsChangedInformation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.Identifier
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PersonReference
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.PrisonerAppointmentsChangedEvent
+import java.time.LocalDateTime
+
+class PrisonerAppointmentsChangedEventHandlerTest {
+  private val prisonAppointmentRepository: PrisonAppointmentRepository = mock()
+  private val prisonerSearchClient: PrisonerSearchClient = mock()
+  private val bookingFacade: BookingFacade = mock()
+  private val timeSource = TimeSource { LocalDateTime.of(2024, 4, 9, 12, 0) }
+  private val videoBooking = courtBooking().withMainCourtPrisonAppointment()
+  private val prisoner = prisonerSearchPrisoner(prisonerNumber = "123456", prisonCode = "OUT")
+  private val handler = PrisonerAppointmentsChangedEventHandler(prisonAppointmentRepository, prisonerSearchClient, bookingFacade, timeSource)
+
+  @Test
+  fun `should transfer prisoner on cancel`() {
+    whenever(prisonAppointmentRepository.findActivePrisonerPrisonAppointmentsAfter("123456", timeSource.today(), timeSource.now().toLocalTime())) doReturn videoBooking.appointments()
+    whenever(prisonerSearchClient.getPrisoner("123456")) doReturn prisoner.copy(lastMovementTypeCode = "TRN")
+
+    handler.handle(event(true))
+    verify(bookingFacade).prisonerTransferred(videoBooking.videoBookingId, SERVICE_USER)
+  }
+
+  @Test
+  fun `should not transfer prisoner on not cancel`() {
+    handler.handle(event(false))
+
+    verifyNoInteractions(prisonAppointmentRepository)
+    verifyNoInteractions(prisonerSearchClient)
+    verifyNoInteractions(bookingFacade)
+  }
+
+  @Test
+  fun `should release prisoner on cancel`() {
+    whenever(prisonAppointmentRepository.findActivePrisonerPrisonAppointmentsAfter("123456", timeSource.today(), timeSource.now().toLocalTime())) doReturn videoBooking.appointments()
+    whenever(prisonerSearchClient.getPrisoner("123456")) doReturn prisoner.copy(lastMovementTypeCode = "REL")
+
+    handler.handle(event(true))
+    verify(bookingFacade).prisonerReleased(videoBooking.videoBookingId, SERVICE_USER)
+  }
+
+  @Test
+  fun `should not release prisoner on not cancel`() {
+    handler.handle(event(false))
+
+    verifyNoInteractions(prisonAppointmentRepository)
+    verifyNoInteractions(prisonerSearchClient)
+    verifyNoInteractions(bookingFacade)
+  }
+
+  private fun event(cancel: Boolean) = PrisonerAppointmentsChangedEvent(
+    personReference = PersonReference(listOf(Identifier("NOMS", "123456"))),
+    additionalInformation = AppointmentsChangedInformation(
+      action = if (cancel) "YES" else "NO",
+      prisonId = PENTONVILLE,
+      user = "SOME_USER",
+    ),
+  )
+}


### PR DESCRIPTION
There is no cloud platform configuration for this event at time of writing.  Until we push that out this event code will never fire.

There has been no change to the existing release event at the moment i.e. it will still operate as before.