### PR TITLE
BAVL-778: Ignore cancelled appointments from A&A which were blocking rooms.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/BookedLocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/BookedLocationsService.kt
@@ -55,6 +55,8 @@ class BookedLocationsService(
 
     return when (activitiesAppointmentsClient.isAppointmentsRolledOutAt(prisonCode)) {
       true -> activitiesAppointmentsClient.getScheduledAppointments(prisonCode, date, nomisToDpsLocations.keys)
+        // Do not consider cancelled appointments
+        .filterNot { it.isCancelled }
         .mapNotNull { result ->
           // Only include if result does not match existing BVLS appointment
           if (existingAppointments.none { existing -> result.matches(existing) }) {


### PR DESCRIPTION
This PR:
* Ignores cancelled appointments returned from A&A appointments search when checking whether a room is available.
* Wrote a failing test first - which failed - then implemented the change to make the test pass.