### PR TITLE
BAVL-778: Availability check to take account of cancelled appointments via Prison API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
@@ -177,6 +177,7 @@ data class ScheduledAppointment(
   val firstName: String,
   val lastName: String,
   val createUserId: String,
+  val eventStatus: String,
 ) {
   fun isTheSameAppointmentType(appointmentType: SupportedAppointmentTypes.Type) = appointmentTypeCode == appointmentType.code
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/AvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/AvailabilityService.kt
@@ -179,11 +179,13 @@ class ExternalAppointmentsService(
 ) {
   /**
    * Get the prison appointments on a date at a specific internal location ID in the prison
+   * - filter any prison API appointments that are cancelled
    * - filter any appointments where the end-time is null (we cannot infer the duration)
-   * - filter any VLB appointment types as these will be retrieved from BVLS itself for checking.
+   * - filter any BVLS-mastered appointment types as these will be retrieved from BVLS itself for checking.
    */
   fun getAppointmentSlots(prisonCode: String, date: LocalDate, location: UUID) = nomisMappingClient.getNomisLocationMappingBy(location)
     ?.let { prisonApiClient.getScheduledAppointments(prisonCode, date, it.nomisLocationId) }
+    ?.filterNot { it.eventStatus == "CANC" }
     ?.filter { it.endTime != null }
     ?.filterNot { supportedAppointmentTypes.isSupported(it.appointmentTypeCode) }
     ?.map { ExternalAppointmentSlot(location, it.offenderNo, it.startTime.toLocalDate(), it.startTime.toLocalTime(), it.endTime!!.toLocalTime()) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/BookedLocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/BookedLocationsService.kt
@@ -72,6 +72,7 @@ class BookedLocationsService(
         .let { BookedLocations(it) }
 
       false -> prisonApiClient.getScheduledAppointments(prisonCode, date, nomisToDpsLocations.keys)
+        .filterNot { it.eventStatus == "CANC" }
         .mapNotNull { result ->
           // Only include if result does not match existing BVLS appointment
           if (existingAppointments.none { existing -> result.matches(existing) }) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/PrisonApiMockServer.kt
@@ -139,6 +139,7 @@ class PrisonApiMockServer : MockServer(8094) {
                         endTime = LocalDateTime.now(),
                         firstName = "firstname-$index",
                         lastName = "lastname-$index",
+                        eventStatus = "SCH",
                       ),
                     )
                   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/BookedLocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/BookedLocationsServiceTest.kt
@@ -309,6 +309,7 @@ class BookedLocationsServiceTest {
             endTime = LocalTime.of(11, 0),
             prisonerNumber = "123456",
             locationId = 1,
+            eventStatus = "SCH",
           ),
           scheduledAppointment(
             prisonCode = RISLEY,
@@ -317,6 +318,16 @@ class BookedLocationsServiceTest {
             endTime = LocalTime.of(12, 0),
             prisonerNumber = "123456",
             locationId = 2,
+            eventStatus = "SCH",
+          ),
+          scheduledAppointment(
+            prisonCode = RISLEY,
+            date = tomorrow(),
+            startTime = LocalTime.of(12, 0),
+            endTime = LocalTime.of(13, 0),
+            prisonerNumber = "123456",
+            locationId = 2,
+            eventStatus = "CANC",
           ),
         )
       }
@@ -414,9 +425,10 @@ class BookedLocationsServiceTest {
       endTime: LocalTime,
       prisonerNumber: String,
       locationId: Long,
+      eventStatus: String = "SCH",
     ): ScheduledAppointment = ScheduledAppointment(
       id = locationId,
-      agencyId = prisonerNumber,
+      agencyId = prisonCode,
       locationId = locationId,
       locationDescription = "location description $locationId",
       appointmentTypeCode = "VLB",
@@ -427,6 +439,7 @@ class BookedLocationsServiceTest {
       firstName = "first name $locationId",
       lastName = "last name $locationId",
       createUserId = "user id",
+      eventStatus = eventStatus,
     )
   }
 }


### PR DESCRIPTION
This PR:
* Retrieves and extra eventStatus field from Prison API for appointments at locations
* Ignores appointments that are cancelled (eventStatus=CANC) in the list
* Does not block rooms where cancelled appointments exist