### PR TITLE
BAVL-754 enable the probation details reminder email in production.

### DIFF
--- a/helm_deploy/hmpps-book-a-video-link-api/values.yaml
+++ b/helm_deploy/hmpps-book-a-video-link-api/values.yaml
@@ -80,4 +80,4 @@ generic-prometheus-alerts:
 
 cron:
   courtHearingLinkReminderJob: "0 15 * * *"
-  probationOfficerDetailsReminderJob: "0 0 29 Feb Sat"
+  probationOfficerDetailsReminderJob: "0 15 * * *"


### PR DESCRIPTION
Helm config change to enable the probation reminder email job in production.