### PR TITLE
BAVL-801: Enable HMP Cheltenham - initially as a grey-release prison

### DIFF
--- a/src/main/resources/migrations/common/V2025.04.28__enable_hmp_chelmsford.sql
+++ b/src/main/resources/migrations/common/V2025.04.28__enable_hmp_chelmsford.sql
@@ -1,0 +1,2 @@
+-- Enable HMP Chelmsford for self-service
+update prison set enabled = true where prison_id = 88 and code = 'CDI';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/PrisonsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/PrisonsResourceIntegrationTest.kt
@@ -43,14 +43,15 @@ class PrisonsResourceIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `should return a list of enabled prisons`() {
-    prisonRepository.findAllByEnabledIsTrue() hasSize 17
+    prisonRepository.findAllByEnabledIsTrue() hasSize 18
 
     val listOfEnabledPrisons = webTestClient.getPrisons(true)
 
-    assertThat(listOfEnabledPrisons).hasSize(17)
+    assertThat(listOfEnabledPrisons).hasSize(18)
     assertThat(listOfEnabledPrisons).extracting("code").contains("WWI")
     assertThat(listOfEnabledPrisons).extracting("code").contains("LPI")
     assertThat(listOfEnabledPrisons).extracting("code").contains("BXI")
+    assertThat(listOfEnabledPrisons).extracting("code").contains("CDI")
     assertThat(listOfEnabledPrisons).extracting("code").doesNotContain("LEI")
   }
 


### PR DESCRIPTION
The details of the manual steps are on the ticket BAVL-801 
i.e.
* Manual setting up of the feature-toggles secret for FEATURE_GREY_RELEASE_PRISONS
* Manual creation of the prison_contact rows in PREPROD and PROD.