### PR TITLE
BAVL-812 removing the master VLPM appointments feature toggle, now safe to remove.

### DIFF
--- a/helm_deploy/hmpps-book-a-video-link-api/values.yaml
+++ b/helm_deploy/hmpps-book-a-video-link-api/values.yaml
@@ -68,7 +68,6 @@ generic-service:
     sqs-domain-event-dlq-secret:
       HMPPS_SQS_QUEUES_BVLS_DLQ_NAME: "sqs_queue_name"
     feature-toggles:
-      FEATURE_MASTER_VLPM_TYPES: "FEATURE_MASTER_VLPM_TYPES"
 
   allowlist:
     groups:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/SupportedAppointmentTypes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/SupportedAppointmentTypes.kt
@@ -1,29 +1,20 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Feature
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType
 
 @Component
-class SupportedAppointmentTypes(private val featureSwitches: FeatureSwitches) {
+class SupportedAppointmentTypes {
 
   enum class Type(val code: String) {
     COURT("VLB"),
     PROBATION("VLPM"),
   }
 
-  fun typeOf(type: BookingType) = if (featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) {
-    when (type) {
-      BookingType.COURT -> Type.COURT
-      BookingType.PROBATION -> Type.PROBATION
-    }
-  } else {
-    Type.COURT
+  fun typeOf(type: BookingType) = when (type) {
+    BookingType.COURT -> Type.COURT
+    BookingType.PROBATION -> Type.PROBATION
   }
 
-  fun isSupported(appointmentType: String) = when (featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) {
-    true -> Type.entries.map(Type::code).contains(appointmentType)
-    false -> Type.COURT.code == appointmentType
-  }
+  fun isSupported(appointmentType: String) = Type.entries.map(Type::code).contains(appointmentType)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/FeatureSwitches.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/FeatureSwitches.kt
@@ -28,5 +28,5 @@ class FeatureSwitches(private val environment: Environment) {
 }
 
 enum class Feature(val label: String) {
-  FEATURE_MASTER_VLPM_TYPES("feature.master.vlpm.types"),
+  FEATURE_PLACEHOLDER("feature.placeholder.example"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendProbationBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendProbationBookingService.kt
@@ -40,7 +40,7 @@ class AmendProbationBookingService(
   @Transactional
   fun amend(videoBookingId: Long, request: AmendVideoBookingRequest, amendedBy: User): Pair<VideoBooking, Prisoner> {
     require(request.bookingType == BookingType.PROBATION) {
-      "PROBATION BOOKINGS: booking type is not probation"
+      "AMEND PROBATION BOOKING: booking type is not probation"
     }
 
     val booking = videoBookingRepository.findById(videoBookingId)
@@ -64,7 +64,7 @@ class AmendProbationBookingService(
       .also { thisBooking -> videoBookingRepository.saveAndFlush(thisBooking) }
       .also { thisBooking -> request.saveAdditionalDetailsFor(thisBooking) }
       .also { thisBooking -> bookingHistoryService.createBookingHistory(HistoryType.AMEND, thisBooking) }
-      .also { thisBooking -> log.info("BOOKINGS: probation team booking ${thisBooking.videoBookingId} amended") } to prisoner
+      .also { thisBooking -> log.info("AMEND PROBATION BOOKING: probation team booking ${thisBooking.videoBookingId} amended") } to prisoner
   }
 
   // We will only be creating appointments for one single prisoner as part of the initial rollout.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CancelVideoBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CancelVideoBookingService.kt
@@ -35,6 +35,6 @@ class CancelVideoBookingService(
     return booking.cancel(cancelledBy)
       .also { thisBooking -> videoBookingRepository.saveAndFlush(thisBooking) }
       .also { thisBooking -> bookingHistoryService.createBookingHistory(HistoryType.CANCEL, thisBooking) }
-      .also { thisBooking -> log.info("BOOKINGS: Booking ID ${thisBooking.videoBookingId} cancelled") }
+      .also { thisBooking -> log.info("CANCELLED BOOKING: Booking ID ${thisBooking.videoBookingId} cancelled") }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateProbationBookingService.kt
@@ -35,7 +35,7 @@ class CreateProbationBookingService(
   @Transactional
   fun create(request: CreateVideoBookingRequest, createdBy: User): Pair<VideoBooking, Prisoner> {
     require(request.bookingType == BookingType.PROBATION) {
-      "PROBATION BOOKINGS: booking type is not probation"
+      "CREATE PROBATION BOOKING: booking type is not probation"
     }
 
     require((createdBy is ExternalUser && createdBy.isProbationUser) || createdBy is PrisonUser) {
@@ -57,7 +57,7 @@ class CreateProbationBookingService(
       .also { thisBooking -> videoBookingRepository.saveAndFlush(thisBooking) }
       .also { thisBooking -> request.saveAdditionalDetailsFor(thisBooking) }
       .also { thisBooking -> bookingHistoryService.createBookingHistory(HistoryType.CREATE, thisBooking) }
-      .also { thisBooking -> log.info("PROBATION BOOKING: booking ${thisBooking.videoBookingId} created") } to prisoner
+      .also { thisBooking -> log.info("CREATE PROBATION BOOKING: booking ${thisBooking.videoBookingId} created") } to prisoner
   }
 
   private fun CreateVideoBookingRequest.saveAdditionalDetailsFor(booking: VideoBooking) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegate.kt
@@ -3,8 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Feature
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AmendVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
@@ -15,49 +13,40 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateV
  */
 @Service
 class VideoBookingServiceDelegate(
-  private val createVideoBookingService: CreateVideoBookingService,
+  private val createCourtBookingService: CreateCourtBookingService,
   private val createProbationBookingService: CreateProbationBookingService,
   private val amendCourtBookingService: AmendCourtBookingService,
   private val amendProbationBookingService: AmendProbationBookingService,
   private val cancelVideoBookingService: CancelVideoBookingService,
-  private val featureSwitches: FeatureSwitches,
 ) {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
   @Transactional
-  fun create(booking: CreateVideoBookingRequest, createdBy: User) = when (featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) {
-    false -> {
-      log.info("CREATE BOOKING DELEGATE: VLPM feature toggle is off.")
-      createVideoBookingService.create(booking, createdBy)
-    }
+  fun create(booking: CreateVideoBookingRequest, createdBy: User) = run {
+    log.info("BOOKING DELEGATE: creating video booking: $booking")
 
-    true -> {
-      log.info("CREATE BOOKING DELEGATE: VLPM feature toggle is on.")
-      when (booking.bookingType!!) {
-        BookingType.COURT -> createVideoBookingService.create(booking, createdBy)
-        BookingType.PROBATION -> createProbationBookingService.create(booking, createdBy)
-      }
+    when (booking.bookingType!!) {
+      BookingType.COURT -> createCourtBookingService.create(booking, createdBy)
+      BookingType.PROBATION -> createProbationBookingService.create(booking, createdBy)
     }
   }
 
   @Transactional
-  fun amend(videoBookingId: Long, booking: AmendVideoBookingRequest, amendedBy: User) = when (featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) {
-    false -> {
-      log.info("AMEND BOOKING DELEGATE: VLPM feature toggle is off.")
-      amendCourtBookingService.amend(videoBookingId, booking, amendedBy)
-    }
+  fun amend(videoBookingId: Long, booking: AmendVideoBookingRequest, amendedBy: User) = run {
+    log.info("BOOKING DELEGATE: amending video booking: $booking")
 
-    true -> {
-      log.info("AMEND BOOKING DELEGATE: VLPM feature toggle is on.")
-      when (booking.bookingType!!) {
-        BookingType.COURT -> amendCourtBookingService.amend(videoBookingId, booking, amendedBy)
-        BookingType.PROBATION -> amendProbationBookingService.amend(videoBookingId, booking, amendedBy)
-      }
+    when (booking.bookingType!!) {
+      BookingType.COURT -> amendCourtBookingService.amend(videoBookingId, booking, amendedBy)
+      BookingType.PROBATION -> amendProbationBookingService.amend(videoBookingId, booking, amendedBy)
     }
   }
 
   @Transactional
-  fun cancel(videoBookingId: Long, cancelledBy: User): VideoBooking = cancelVideoBookingService.cancel(videoBookingId, cancelledBy)
+  fun cancel(videoBookingId: Long, cancelledBy: User): VideoBooking = run {
+    log.info("BOOKING DELEGATE: cancelling video booking: $videoBookingId")
+
+    cancelVideoBookingService.cancel(videoBookingId, cancelledBy)
+  }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -35,11 +35,3 @@ api:
 bvls:
   frontend:
     url: http://localhost:3000
-
-feature:
-  check:
-    external-availability:
-      enabled: true
-  master:
-    vlpm:
-      types: true

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -31,14 +31,6 @@ bvls:
   frontend:
     url: http://localhost:3000
 
-feature:
-  check:
-    external-availability:
-      enabled: true
-  master:
-    vlpm:
-      types: true
-
 hmpps.sqs:
   provider: localstack
   queues:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/SupportedAppointmentTypesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/SupportedAppointmentTypesTest.kt
@@ -1,21 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common
 
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.mock
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Feature
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 
 class SupportedAppointmentTypesTest {
-  private val featureSwitches: FeatureSwitches = mock()
-  private val supportedAppointmentTypes = SupportedAppointmentTypes(featureSwitches)
+  private val supportedAppointmentTypes = SupportedAppointmentTypes()
 
   @Test
   fun `should match on appointment types`() {
@@ -23,53 +14,24 @@ class SupportedAppointmentTypesTest {
     SupportedAppointmentTypes.Type.PROBATION.code isEqualTo "VLPM"
   }
 
-  @Nested
-  @DisplayName("VLPM feature toggle off")
-  inner class ToggleOff {
-    @BeforeEach
-    fun before() {
-      whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn false
-    }
-
-    @Test
-    fun `should support VLB appointment type`() {
-      supportedAppointmentTypes.isSupported("VLB") isBool true
-    }
-
-    @Test
-    fun `should not support VLPM appointment type`() {
-      supportedAppointmentTypes.isSupported("VLPM") isBool false
-    }
-
-    @Test
-    fun `should support court appointment type only`() {
-      supportedAppointmentTypes.typeOf(BookingType.COURT) isEqualTo SupportedAppointmentTypes.Type.COURT
-      supportedAppointmentTypes.typeOf(BookingType.PROBATION) isEqualTo SupportedAppointmentTypes.Type.COURT
-    }
+  @Test
+  fun `should support VLB appointment type`() {
+    supportedAppointmentTypes.isSupported("VLB") isBool true
   }
 
-  @Nested
-  @DisplayName("VLPM feature toggle on")
-  inner class ToggleOn {
-    @BeforeEach
-    fun before() {
-      whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn true
-    }
+  @Test
+  fun `should support VLPM appointment type`() {
+    supportedAppointmentTypes.isSupported("VLPM") isBool true
+  }
 
-    @Test
-    fun `should support VLB appointment type`() {
-      supportedAppointmentTypes.isSupported("VLB") isBool true
-    }
+  @Test
+  fun `should not support UNKOWN appointment type`() {
+    supportedAppointmentTypes.isSupported("UNKOWN") isBool false
+  }
 
-    @Test
-    fun `should support VLPM appointment type`() {
-      supportedAppointmentTypes.isSupported("VLPM") isBool true
-    }
-
-    @Test
-    fun `should support court and probation appointment type`() {
-      supportedAppointmentTypes.typeOf(BookingType.COURT) isEqualTo SupportedAppointmentTypes.Type.COURT
-      supportedAppointmentTypes.typeOf(BookingType.PROBATION) isEqualTo SupportedAppointmentTypes.Type.PROBATION
-    }
+  @Test
+  fun `should support court and probation appointment type`() {
+    supportedAppointmentTypes.typeOf(BookingType.COURT) isEqualTo SupportedAppointmentTypes.Type.COURT
+    supportedAppointmentTypes.typeOf(BookingType.PROBATION) isEqualTo SupportedAppointmentTypes.Type.PROBATION
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/config/FeatureSwitchesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/config/FeatureSwitchesTest.kt
@@ -23,7 +23,7 @@ class FeatureSwitchesTest : IntegrationTestBase() {
   @MockitoBean
   private lateinit var listener: InboundEventsListener
 
-  @TestPropertySource(properties = ["feature.master.vlpm.types=true"])
+  @TestPropertySource(properties = ["feature.placeholder.example=true"])
   @Nested
   @DisplayName("Features are enabled when set")
   inner class EnabledFeatures(@Autowired val featureSwitches: FeatureSwitches) {
@@ -51,7 +51,7 @@ class FeatureSwitchesTest : IntegrationTestBase() {
   inner class DefaultedFeatures(@Autowired val featureSwitches: FeatureSwitches) {
     @Test
     fun `different feature types can be defaulted `() {
-      featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES, true) isBool true
+      featureSwitches.isEnabled(Feature.FEATURE_PLACEHOLDER, true) isBool true
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationBookingIntegrationTest.kt
@@ -7,7 +7,6 @@ import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
@@ -63,7 +62,6 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 
 @ContextConfiguration(classes = [TestEmailConfiguration::class])
-@TestPropertySource(properties = ["feature.master.vlpm.types=true"])
 @Sql("classpath:integration-test-data/seed-probation-team-user-access.sql")
 class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ScheduleResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ScheduleResourceIntegrationTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
-import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
@@ -30,7 +29,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.Outbou
 import java.time.LocalDate
 import java.time.LocalTime
 
-@TestPropertySource(properties = ["feature.master.vlpm.types=true"])
 class ScheduleResourceIntegrationTest : IntegrationTestBase() {
   @Autowired
   private lateinit var videoBookingRepository: VideoBookingRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -32,7 +32,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.HARROW
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.LocationKeyValue
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.NORWICH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_PENTONVILLE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
@@ -748,22 +747,6 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
       status isEqualTo 400
       userMessage isEqualTo "Exception: Prison with code RSI is not enabled for self service"
       developerMessage isEqualTo "Prison with code RSI is not enabled for self service"
-    }
-  }
-
-  @Test
-  fun `should fail to create a probation booking when user is prison user`() {
-    val error = webTestClient.createBookingFails(probationBookingRequest(), PRISON_USER_BIRMINGHAM)
-      .expectStatus().isBadRequest
-      .expectStatus().is4xxClientError
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(ErrorResponse::class.java)
-      .returnResult().responseBody!!
-
-    with(error) {
-      status isEqualTo 400
-      userMessage isEqualTo "Exception: Only probation users can create probation bookings."
-      developerMessage isEqualTo "Only probation users can create probation bookings."
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateCourtBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateCourtBookingServiceTest.kt
@@ -16,7 +16,6 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationValidator
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationsInsidePrisonClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerValidator
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toMinutePrecision
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
@@ -37,7 +36,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisonerSearchPrisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.readOnlyCourt
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
@@ -46,15 +44,13 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Appoint
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.CourtRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.ProbationTeamRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.security.CaseloadAccessException
 import java.time.LocalDateTime
 import java.time.LocalTime
 
-class CreateVideoBookingServiceTest {
+class CreateCourtBookingServiceTest {
   private val courtRepository: CourtRepository = mock()
-  private val probationTeamRepository: ProbationTeamRepository = mock()
   private val videoBookingRepository: VideoBookingRepository = mock()
 
   private val bookingHistoryService: BookingHistoryService = mock()
@@ -68,9 +64,8 @@ class CreateVideoBookingServiceTest {
 
   private val appointmentsService = AppointmentsService(prisonAppointmentRepository, prisonRepository, locationsInsidePrisonClient, locationValidator)
 
-  private val service = CreateVideoBookingService(
+  private val service = CreateCourtBookingService(
     courtRepository,
-    probationTeamRepository,
     videoBookingRepository,
     appointmentsService,
     bookingHistoryService,
@@ -621,153 +616,9 @@ class CreateVideoBookingServiceTest {
   }
 
   @Test
-  fun `should create a probation video booking for probation user`() {
-    val prisonCode = BIRMINGHAM
-    val prisonerNumber = "123456"
-    val probationBookingRequest = probationBookingRequest(prisonCode = prisonCode, prisonerNumber = prisonerNumber, location = birminghamLocation)
-    val requestedProbationTeam = probationTeam(probationBookingRequest.probationTeamCode!!)
+  fun `should fail to create when not a court booking`() {
+    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest(), COURT_USER) }
 
-    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn requestedProbationTeam
-    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
-    whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
-    whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, prisonCode)) doReturn prisonerSearchPrisoner(prisonerNumber, prisonCode)
-    whenever(locationValidator.validatePrisonLocation(BIRMINGHAM, birminghamLocation.key)) doReturn birminghamLocation
-    whenever(locationsInsidePrisonClient.getLocationByKey(birminghamLocation.key)) doReturn birminghamLocation
-
-    val (booking, prisoner) = service.create(probationBookingRequest, PROBATION_USER)
-
-    booking isEqualTo persistedVideoBooking
-    prisoner isEqualTo prisoner(prisonerNumber, prisonCode)
-
-    verify(videoBookingRepository).saveAndFlush(newBookingCaptor.capture())
-
-    with(newBookingCaptor.firstValue) {
-      bookingType isEqualTo BookingType.PROBATION
-      probationTeam isEqualTo requestedProbationTeam
-      createdTime isCloseTo LocalDateTime.now()
-      probationMeetingType isEqualTo probationBookingRequest.probationMeetingType?.name
-      comments isEqualTo "probation booking comments"
-      videoUrl isEqualTo probationBookingRequest.videoLinkUrl
-      createdBy isEqualTo PROBATION_USER.username
-      createdTime isCloseTo LocalDateTime.now()
-
-      appointments() hasSize 1
-
-      with(appointments().single()) {
-        val onePrisoner = probationBookingRequest.prisoners.single()
-
-        prisonCode isEqualTo onePrisoner.prisonCode
-        prisonerNumber isEqualTo onePrisoner.prisonerNumber
-        appointmentType isEqualTo onePrisoner.appointments.single().type?.name
-        appointmentDate isEqualTo onePrisoner.appointments.single().date!!
-        startTime isEqualTo onePrisoner.appointments.single().startTime!!.toMinutePrecision()
-        endTime isEqualTo onePrisoner.appointments.single().endTime!!.toMinutePrecision()
-        prisonLocationId isEqualTo birminghamLocation.id
-      }
-    }
-
-    verify(locationValidator).validatePrisonLocation(BIRMINGHAM, birminghamLocation.key)
-    verify(prisonerValidator).validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)
-    verify(bookingHistoryService).createBookingHistory(any(), any())
-  }
-
-  @Test
-  fun `should fail to create a probation video booking when new appointment overlaps existing for probation user`() {
-    val prisonCode = BIRMINGHAM
-    val prisonerNumber = "123456"
-    val probationBookingRequest = probationBookingRequest(
-      prisonCode = prisonCode,
-      prisonerNumber = prisonerNumber,
-      startTime = LocalTime.of(8, 30),
-      endTime = LocalTime.of(9, 30),
-      location = birminghamLocation,
-    )
-    val requestedProbationTeam = probationTeam(probationBookingRequest.probationTeamCode!!)
-
-    val overlappingAppointment: PrisonAppointment = mock {
-      on { startTime } doReturn LocalTime.of(9, 0)
-      on { endTime } doReturn LocalTime.of(10, 0)
-    }
-
-    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn requestedProbationTeam
-    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
-    whenever(prisonAppointmentRepository.findActivePrisonAppointmentsAtLocationOnDate(BIRMINGHAM, birminghamLocation.id, tomorrow())) doReturn listOf(overlappingAppointment)
-    whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
-    whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
-    whenever(locationValidator.validatePrisonLocation(BIRMINGHAM, birminghamLocation.key)) doReturn birminghamLocation
-    whenever(locationsInsidePrisonClient.getLocationsByKeys(setOf(birminghamLocation.key))) doReturn listOf(birminghamLocation)
-
-    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest, PROBATION_USER) }
-
-    error.message isEqualTo "Requested probation appointment overlaps with an existing appointment at location ${birminghamLocation.key}"
-  }
-
-  @Test
-  fun `should fail to create a probation video booking when not probation user`() {
-    assertThrows<IllegalArgumentException> { service.create(probationBookingRequest(), PRISON_USER_BIRMINGHAM) }.message isEqualTo "Only probation users can create probation bookings."
-    assertThrows<IllegalArgumentException> { service.create(probationBookingRequest(), COURT_USER) }.message isEqualTo "Only probation users can create probation bookings."
-    assertThrows<IllegalArgumentException> { service.create(probationBookingRequest(), SERVICE_USER) }.message isEqualTo "Only probation users can create probation bookings."
-
-    verify(videoBookingRepository, never()).saveAndFlush(any())
-  }
-
-  @Test
-  fun `should fail to create a probation video booking when team not found for probation user`() {
-    val probationBookingRequest = probationBookingRequest()
-
-    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn null
-
-    val error = assertThrows<EntityNotFoundException> { service.create(probationBookingRequest, PROBATION_USER) }
-
-    error.message isEqualTo "Probation team with code ${probationBookingRequest.probationTeamCode} not found"
-
-    verifyNoInteractions(videoBookingRepository)
-  }
-
-  @Test
-  fun `should fail to create a probation video booking when prison not found for probation user`() {
-    val probationBookingRequest = probationBookingRequest(prisonCode = BIRMINGHAM)
-
-    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn probationTeam()
-    whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn null
-
-    val error = assertThrows<EntityNotFoundException> { service.create(probationBookingRequest, PROBATION_USER) }
-
-    error.message isEqualTo "Prison with code $BIRMINGHAM not found"
-
-    verifyNoInteractions(videoBookingRepository)
-  }
-
-  @Test
-  fun `should fail to create a probation video booking when team not enabled for probation user`() {
-    val probationBookingRequest = probationBookingRequest()
-    val disabledProbationTeam = probationTeam(probationBookingRequest.probationTeamCode!!, false)
-
-    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn disabledProbationTeam
-
-    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest, PROBATION_USER) }
-
-    error.message isEqualTo "Probation team with code ${probationBookingRequest.probationTeamCode} is not enabled"
-
-    verifyNoInteractions(videoBookingRepository)
-  }
-
-  @Test
-  fun `should fail to create a probation video booking when appointment type not probation specific for probation user`() {
-    val prisonCode = BIRMINGHAM
-    val prisonerNumber = "123456"
-    val probationBookingRequest = probationBookingRequest(prisonCode = prisonCode, prisonerNumber = prisonerNumber, appointmentType = AppointmentType.VLB_COURT_MAIN)
-    val requestedProbationTeam = probationTeam(probationBookingRequest.probationTeamCode!!)
-
-    whenever(probationTeamRepository.findByCode(probationBookingRequest.probationTeamCode!!)) doReturn requestedProbationTeam
-    whenever(videoBookingRepository.saveAndFlush(any())) doReturn persistedVideoBooking
-    whenever(prisonRepository.findByCode(BIRMINGHAM)) doReturn prison(BIRMINGHAM)
-    whenever(prisonerValidator.validatePrisonerAtPrison(prisonerNumber, BIRMINGHAM)) doReturn prisonerSearchPrisoner(prisonerNumber, BIRMINGHAM)
-    whenever(locationValidator.validatePrisonLocations(BIRMINGHAM, setOf(birminghamLocation.key))) doReturn listOf(birminghamLocation)
-    whenever(locationsInsidePrisonClient.getLocationByKey(birminghamLocation.key)) doReturn birminghamLocation
-
-    val error = assertThrows<IllegalArgumentException> { service.create(probationBookingRequest, PROBATION_USER) }
-
-    error.message isEqualTo "Appointment type VLB_COURT_MAIN is not valid for probation appointments"
+    error.message isEqualTo "CREATE COURT BOOKING: booking type is not court"
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegateTest.kt
@@ -2,13 +2,9 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
-import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Feature
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.amendCourtBookingRequest
@@ -17,14 +13,13 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBookingRe
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
 
 class VideoBookingServiceDelegateTest {
-  private val createVideoBookingService: CreateVideoBookingService = mock()
+  private val createCourtBookingService: CreateCourtBookingService = mock()
   private val createProbationBookingService: CreateProbationBookingService = mock()
   private val amendCourtBookingService: AmendCourtBookingService = mock()
   private val amendProbationBookingService: AmendProbationBookingService = mock()
   private val cancelVideoBookingService: CancelVideoBookingService = mock()
-  private val featureSwitches: FeatureSwitches = mock()
   private val delegate =
-    VideoBookingServiceDelegate(createVideoBookingService, createProbationBookingService, amendCourtBookingService, amendProbationBookingService, cancelVideoBookingService, featureSwitches)
+    VideoBookingServiceDelegate(createCourtBookingService, createProbationBookingService, amendCourtBookingService, amendProbationBookingService, cancelVideoBookingService)
 
   private val courtBookingRequest = courtBookingRequest()
   private val probationBookingRequest = probationBookingRequest()
@@ -32,55 +27,25 @@ class VideoBookingServiceDelegateTest {
   private val amendProbationBookingRequest = amendProbationBookingRequest()
 
   @Test
-  fun `should delegate to correct create booking service when FEATURE_MASTER_VLPM_TYPES toggle off`() {
-    whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn false
-
+  fun `should delegate to correct create booking service`() {
     delegate.create(courtBookingRequest, COURT_USER)
-    verify(createVideoBookingService).create(courtBookingRequest, COURT_USER)
-
-    delegate.create(probationBookingRequest, PROBATION_USER)
-    verify(createVideoBookingService).create(probationBookingRequest, PROBATION_USER)
-
-    verifyNoInteractions(createProbationBookingService)
-  }
-
-  @Test
-  fun `should delegate to correct create booking service when FEATURE_MASTER_VLPM_TYPES toggle on`() {
-    whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn true
-
-    delegate.create(courtBookingRequest, COURT_USER)
-    verify(createVideoBookingService).create(courtBookingRequest, COURT_USER)
+    verify(createCourtBookingService).create(courtBookingRequest, COURT_USER)
 
     delegate.create(probationBookingRequest, PROBATION_USER)
     verify(createProbationBookingService).create(probationBookingRequest, PROBATION_USER)
 
-    verifyNoMoreInteractions(createVideoBookingService)
+    verifyNoMoreInteractions(createCourtBookingService)
   }
 
   @Test
-  fun `should delegate to correct amend booking service when FEATURE_MASTER_VLPM_TYPES toggle off`() {
-    whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn false
-
-    delegate.amend(1, amendCourtBookingRequest, COURT_USER)
-    verify(amendCourtBookingService).amend(1, amendCourtBookingRequest, COURT_USER)
-
-    delegate.amend(2, amendProbationBookingRequest, PROBATION_USER)
-    verify(amendCourtBookingService).amend(2, amendProbationBookingRequest, PROBATION_USER)
-
-    verifyNoInteractions(createVideoBookingService, createProbationBookingService, amendProbationBookingService)
-  }
-
-  @Test
-  fun `should delegate to correct amend booking service when FEATURE_MASTER_VLPM_TYPES toggle on`() {
-    whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn true
-
+  fun `should delegate to correct amend booking service`() {
     delegate.amend(1, amendCourtBookingRequest, COURT_USER)
     verify(amendCourtBookingService).amend(1, amendCourtBookingRequest, COURT_USER)
 
     delegate.amend(2, amendProbationBookingRequest, PROBATION_USER)
     verify(amendProbationBookingService).amend(2, amendProbationBookingRequest, PROBATION_USER)
 
-    verifyNoInteractions(createVideoBookingService, createProbationBookingService)
+    verifyNoInteractions(createCourtBookingService, createProbationBookingService)
   }
 
   @Test
@@ -88,6 +53,6 @@ class VideoBookingServiceDelegateTest {
     delegate.cancel(1, COURT_USER)
     verify(cancelVideoBookingService).cancel(1, COURT_USER)
 
-    verifyNoInteractions(createVideoBookingService, createProbationBookingService, amendCourtBookingService)
+    verifyNoInteractions(createCourtBookingService, createProbationBookingService, amendCourtBookingService)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/PrisonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/PrisonServiceTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events
 
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -13,8 +12,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.Pris
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Feature
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.appointment
@@ -36,8 +33,7 @@ class PrisonServiceTest {
   private val prisonApiClient: PrisonApiClient = mock()
   private val nomisMappingService: NomisMappingService = mock()
   private val prisonerSearchClient: PrisonerSearchClient = mock()
-  private val featureSwitches: FeatureSwitches = mock()
-  private val supportedAppointmentTypes = SupportedAppointmentTypes(featureSwitches)
+  private val supportedAppointmentTypes = SupportedAppointmentTypes()
   private val service = PrisonService(prisonApiClient, nomisMappingService, supportedAppointmentTypes, prisonerSearchClient)
 
   private val birminghamLocation = Location(
@@ -70,69 +66,8 @@ class PrisonServiceTest {
   )
 
   @Nested
-  @DisplayName("Map correct appointment type for bookings when probation VLPM feature is not live")
-  inner class MapToCourtAppointmentType {
-
-    @BeforeEach
-    fun before() {
-      whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn false
-    }
-
-    @Test
-    fun `should create VLB court appointment`() {
-      whenever(nomisMappingService.getNomisLocationId(courtAppointment.prisonLocationId)) doReturn birminghamLocation.locationId
-      whenever(prisonerSearchClient.getPrisoner(courtAppointment.prisonerNumber)) doReturn prisonerSearchPrisoner(
-        prisonerNumber = courtAppointment.prisonerNumber,
-        prisonCode = courtAppointment.prisonCode(),
-        bookingId = 1,
-      )
-
-      service.createAppointment(courtAppointment)
-
-      verify(nomisMappingService).getNomisLocationId(courtAppointment.prisonLocationId)
-      verify(prisonApiClient).createAppointment(
-        bookingId = 1,
-        appointmentDate = LocalDate.of(2100, 1, 1),
-        startTime = LocalTime.of(11, 0),
-        endTime = LocalTime.of(11, 30),
-        locationId = 123456,
-        comments = "Court hearing comments",
-        appointmentType = SupportedAppointmentTypes.Type.COURT,
-      )
-    }
-
-    @Test
-    fun `should create VLB probation appointment`() {
-      whenever(nomisMappingService.getNomisLocationId(probationAppointment.prisonLocationId)) doReturn birminghamLocation.locationId
-      whenever(prisonerSearchClient.getPrisoner(probationAppointment.prisonerNumber)) doReturn prisonerSearchPrisoner(
-        prisonerNumber = probationAppointment.prisonerNumber,
-        prisonCode = probationAppointment.prisonCode(),
-        bookingId = 1,
-      )
-
-      service.createAppointment(probationAppointment)
-
-      verify(nomisMappingService).getNomisLocationId(probationAppointment.prisonLocationId)
-      verify(prisonApiClient).createAppointment(
-        bookingId = 1,
-        appointmentDate = LocalDate.of(2100, 1, 1),
-        startTime = LocalTime.of(11, 0),
-        endTime = LocalTime.of(11, 30),
-        locationId = 123456,
-        comments = "Probation meeting comments",
-        appointmentType = SupportedAppointmentTypes.Type.COURT,
-      )
-    }
-  }
-
-  @Nested
-  @DisplayName("Map correct appointment type for bookings when probation VLPM feature is live")
+  @DisplayName("Map correct appointment type for bookings")
   inner class MapToCourtAndProbationAppointmentType {
-
-    @BeforeEach
-    fun before() {
-      whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn true
-    }
 
     @Test
     fun `should create VLB court appointment`() {
@@ -185,7 +120,7 @@ class PrisonServiceTest {
   @DisplayName("Matching appointments")
   inner class MatchingAppointments {
     @Test
-    fun `should find matching VLB court appointment when not supported VLPM appointment type`() {
+    fun `should find matching VLB court appointment`() {
       val matchingAppointment = prisonerSchedule(courtAppointment, birminghamLocation, VLB)
 
       whenever(
@@ -203,27 +138,7 @@ class PrisonServiceTest {
     }
 
     @Test
-    fun `should find matching VLB court appointment when supported VLPM appointment type`() {
-      whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn true
-
-      val matchingAppointment = prisonerSchedule(courtAppointment, birminghamLocation, VLB)
-
-      whenever(
-        prisonApiClient.getPrisonersAppointmentsAtLocations(
-          prisonCode = courtAppointment.prisonCode(),
-          prisonerNumber = courtAppointment.prisonerNumber,
-          onDate = courtAppointment.appointmentDate,
-          birminghamLocation.locationId,
-        ),
-      ) doReturn listOf(matchingAppointment)
-
-      whenever(nomisMappingService.getNomisLocationId(courtAppointment.prisonLocationId)) doReturn birminghamLocation.locationId
-
-      service.findMatchingAppointments(courtAppointment).containsExactly(listOf(matchingAppointment.eventId))
-    }
-
-    @Test
-    fun `should find matching probation VLB appointment when not supported VLPM appointment type`() {
+    fun `should find matching probation VLB appointment`() {
       val matchingAppointment = prisonerSchedule(probationAppointment, birminghamLocation, VLB)
 
       whenever(
@@ -241,29 +156,7 @@ class PrisonServiceTest {
     }
 
     @Test
-    fun `should find matching probation VLB appointment when supported VLPM appointment type`() {
-      whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn true
-
-      val matchingAppointment = prisonerSchedule(probationAppointment, birminghamLocation, VLB)
-
-      whenever(
-        prisonApiClient.getPrisonersAppointmentsAtLocations(
-          prisonCode = probationAppointment.prisonCode(),
-          prisonerNumber = probationAppointment.prisonerNumber,
-          onDate = probationAppointment.appointmentDate,
-          birminghamLocation.locationId,
-        ),
-      ) doReturn listOf(matchingAppointment)
-
-      whenever(nomisMappingService.getNomisLocationId(probationAppointment.prisonLocationId)) doReturn birminghamLocation.locationId
-
-      service.findMatchingAppointments(probationAppointment) containsExactly listOf(matchingAppointment.eventId)
-    }
-
-    @Test
-    fun `should find matching VLPM appointment when supported VLPM appointment type`() {
-      whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn true
-
+    fun `should find matching probation VLPM appointment`() {
       val matchingAppointment = prisonerSchedule(probationAppointment, birminghamLocation, VLPM)
 
       whenever(
@@ -314,46 +207,6 @@ class PrisonServiceTest {
       whenever(nomisMappingService.getNomisLocationId(courtAppointment.prisonLocationId)) doReturn birminghamLocation.locationId
 
       service.findMatchingAppointments(probationAppointment).isEmpty() isBool true
-    }
-
-    @Test
-    fun `should not find matching appointment when supported VLPM appointment type`() {
-      whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn true
-
-      val vlpmAppointment = prisonerSchedule(probationAppointment, birminghamLocation, VLPM)
-
-      whenever(
-        prisonApiClient.getPrisonersAppointmentsAtLocations(
-          prisonCode = probationAppointment.prisonCode(),
-          prisonerNumber = probationAppointment.prisonerNumber,
-          onDate = probationAppointment.appointmentDate,
-          birminghamLocation.locationId,
-        ),
-      ) doReturn listOf(vlpmAppointment)
-
-      whenever(nomisMappingService.getNomisLocationId(probationAppointment.prisonLocationId)) doReturn birminghamLocation.locationId
-
-      service.findMatchingAppointments(probationAppointment) containsExactly listOf(vlpmAppointment.eventId)
-    }
-
-    @Test
-    fun `should not find matching appointment when unsupported VLPM appointment type`() {
-      whenever(featureSwitches.isEnabled(Feature.FEATURE_MASTER_VLPM_TYPES)) doReturn false
-
-      val vlpmAppointment = prisonerSchedule(probationAppointment, birminghamLocation, VLPM)
-
-      whenever(
-        prisonApiClient.getPrisonersAppointmentsAtLocations(
-          prisonCode = probationAppointment.prisonCode(),
-          prisonerNumber = probationAppointment.prisonerNumber,
-          onDate = probationAppointment.appointmentDate,
-          birminghamLocation.locationId,
-        ),
-      ) doReturn listOf(vlpmAppointment)
-
-      whenever(nomisMappingService.getNomisLocationId(probationAppointment.prisonLocationId)) doReturn birminghamLocation.locationId
-
-      service.findMatchingAppointments(courtAppointment).isEmpty() isBool true
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/BookedLocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/BookedLocationsServiceTest.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.Pris
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonapi.ScheduledAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.SupportedAppointmentTypes
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toHourMinuteStyle
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
@@ -42,8 +41,7 @@ class BookedLocationsServiceTest {
   private val prisonApiClient: PrisonApiClient = mock()
   private val nomisMappingClient: NomisMappingClient = mock()
   private val videoBookingRepository: VideoBookingRepository = mock()
-  private val featureSwitches: FeatureSwitches = mock()
-  private val supportedAppointmentTypes = SupportedAppointmentTypes(featureSwitches)
+  private val supportedAppointmentTypes = SupportedAppointmentTypes()
 
   private val service = BookedLocationsService(
     activitiesAppointmentsClient,


### PR DESCRIPTION
Note the tests removed in the PR are now redundant and no longer needed.  They would have been related to the toggle being off and still using the old code/path which has now been removed 