### PR TITLE
BAVL-842 resolve issue for non-rolled out prisons where overlapping synced appointments are lost on amendening.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/prisonapi/PrisonApiClient.kt
@@ -59,12 +59,14 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
   fun getPrisonersAppointmentsAtLocations(prisonCode: String, prisonerNumber: String, onDate: LocalDate, vararg locationIds: Long): List<PrisonerSchedule> = if (locationIds.isNotEmpty()) {
     log.info("PRISON-API CLIENT: query params - prisonCode=$prisonCode, prisonerNumber=$prisonerNumber, onDate=$onDate, locationIds=${locationIds.toList()}")
     getPrisonersAppointments(prisonCode, prisonerNumber, onDate)
-      .also { log.info("PRISON-API CLIENT: matches pre-location filter: $it") }
+      .also { log.info("PRISON-API CLIENT: matches pre-location filter: ${it.map { ps -> ps.obfuscated() }}") }
       .filter { it.locationId in locationIds }
-      .also { log.info("PRISON-API CLIENT matches post-location filter: $it") }
+      .also { log.info("PRISON-API CLIENT matches post-location filter: ${it.map { ps -> ps.obfuscated() }}") }
   } else {
     emptyList()
   }
+
+  private fun PrisonerSchedule.obfuscated() = copy(firstName = "XXX", lastName = "XXX")
 
   private fun getPrisonersAppointments(prisonCode: String, prisonerNumber: String, onDate: LocalDate): List<PrisonerSchedule> = prisonApiWebClient
     .post()


### PR DESCRIPTION
This fix is for non-rolled out prisons only (A&A needs further checking to see if it is a problem).

This change resolves an issue where synced appointments were being lost if the amended appointment times overlapped the old ones.  This would only be an issue for court bookings that have at least two appointments.

Essentially this change ensures all historic appointments are removed from prison-api (NOMIS) before the creation of new (amended) ones.