### PR TITLE
BAVL-849 ensure existing comments/notes are maintained when toggle is on/off.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -361,22 +361,24 @@ fun additionalDetails(
   contactPhoneNumber = contactNumber,
 )
 
-fun VideoBooking.hasBookingType(that: BookingType): VideoBooking = also { it.bookingType isEqualTo that }
-fun VideoBooking.hasProbationTeam(that: ProbationTeam): VideoBooking = also { it.probationTeam isEqualTo that }
-fun VideoBooking.hasMeetingType(that: ProbationMeetingType): VideoBooking = also { it.probationMeetingType isEqualTo that.name }
-fun VideoBooking.hasComments(that: String): VideoBooking = also { it.comments isEqualTo that }
-fun VideoBooking.hasVideoUrl(that: String): VideoBooking = also { it.videoUrl isEqualTo that }
-fun VideoBooking.hasCreatedBy(that: User): VideoBooking = also { it.createdBy isEqualTo that.username }
+fun VideoBooking.hasBookingType(that: BookingType) = also { it.bookingType isEqualTo that }
+fun VideoBooking.hasHearingType(that: CourtHearingType) = also { it.hearingType isEqualTo that.name }
+fun VideoBooking.hasProbationTeam(that: ProbationTeam) = also { it.probationTeam isEqualTo that }
+fun VideoBooking.hasMeetingType(that: ProbationMeetingType) = also { it.probationMeetingType isEqualTo that.name }
+fun VideoBooking.hasComments(that: String) = also { it.comments isEqualTo that }
+fun VideoBooking.hasVideoUrl(that: String) = also { it.videoUrl isEqualTo that }
+fun VideoBooking.hasCreatedBy(that: User) = also { it.createdBy isEqualTo that.username }
 fun VideoBooking.hasCreatedTimeCloseTo(that: LocalDateTime) = also { it.createdTime isCloseTo that }
-fun VideoBooking.hasCreatedByPrison(that: Boolean): VideoBooking = also { it.createdByPrison isBool that }
-fun VideoBooking.hasAmendedBy(that: User): VideoBooking = also { it.amendedBy isEqualTo that.username }
+fun VideoBooking.hasCreatedByPrison(that: Boolean) = also { it.createdByPrison isBool that }
+fun VideoBooking.hasAmendedBy(that: User) = also { it.amendedBy isEqualTo that.username }
 fun VideoBooking.hasAmendedTimeCloseTo(that: LocalDateTime) = also { it.amendedTime isCloseTo that }
-fun VideoBooking.hasStaffNotes(that: String): VideoBooking = also { it.notesForStaff isEqualTo that }
-fun VideoBooking.hasPrisonersNotes(that: String?): VideoBooking = also { it.notesForPrisoners isEqualTo that }
+fun VideoBooking.hasStaffNotes(that: String) = also { it.notesForStaff isEqualTo that }
+fun VideoBooking.hasPrisonersNotes(that: String?) = also { it.notesForPrisoners isEqualTo that }
 
 fun PrisonAppointment.hasPrisonCode(that: String): PrisonAppointment = also { it.prisonCode() isEqualTo that }
 fun PrisonAppointment.hasPrisonerNumber(that: String): PrisonAppointment = also { it.prisonerNumber isEqualTo that }
 fun PrisonAppointment.hasAppointmentTypeProbation(): PrisonAppointment = also { it.appointmentType isEqualTo "VLB_PROBATION" }
+fun PrisonAppointment.hasAppointmentTypeMain(): PrisonAppointment = also { it.appointmentType isEqualTo "VLB_COURT_MAIN" }
 fun PrisonAppointment.hasAppointmentDate(that: LocalDate): PrisonAppointment = also { it.appointmentDate isEqualTo that }
 fun PrisonAppointment.hasStartTime(that: LocalTime): PrisonAppointment = also { it.startTime isEqualTo that }
 fun PrisonAppointment.hasEndTime(that: LocalTime): PrisonAppointment = also { it.endTime isEqualTo that }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -334,7 +334,6 @@ fun requestProbationVideoLinkRequest(
 }
 
 fun amendCourtBookingRequest(
-  courtCode: String = "DRBYMC",
   prisonCode: String = "WWI",
   prisonerNumber: String = "123456",
   locationSuffix: String = "A-1-001",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -987,7 +987,6 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     val bookingId = webTestClient.createBooking(courtBookingRequest, COURT_USER)
 
     val amendBookingRequest = amendCourtBookingRequest(
-      courtCode = DERBY_JUSTICE_CENTRE,
       prisonerNumber = "123456",
       prisonCode = PENTONVILLE,
       location = pentonvilleLocation,
@@ -1051,7 +1050,6 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     val bookingId = webTestClient.createBooking(courtBookingRequest, COURT_USER)
 
     val amendBookingRequest = amendCourtBookingRequest(
-      courtCode = CHESTERFIELD_JUSTICE_CENTRE,
       prisonerNumber = "123456",
       prisonCode = BIRMINGHAM,
       location = birminghamLocation,
@@ -1123,7 +1121,6 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     val videoBookingId = webTestClient.createBooking(courtBookingRequest2, COURT_USER)
 
     val clashingBookingRequest = amendCourtBookingRequest(
-      courtCode = DERBY_JUSTICE_CENTRE,
       prisonerNumber = "123456",
       prisonCode = BIRMINGHAM,
       location = birminghamLocation,
@@ -1172,7 +1169,6 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     locationsInsidePrisonApi().stubPostLocationByKeys(listOf(LocationKeyValue(birminghamLocation.key, locationId)), BIRMINGHAM)
 
     val amendBookingRequest = amendCourtBookingRequest(
-      courtCode = DERBY_JUSTICE_CENTRE,
       prisonerNumber = "123456",
       prisonCode = BIRMINGHAM,
       location = birminghamLocation,
@@ -1242,7 +1238,6 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     val videoBookingId = webTestClient.createBooking(courtBookingRequest, prisonUser)
 
     val amendBookingRequest = amendCourtBookingRequest(
-      courtCode = DERBY_JUSTICE_CENTRE,
       prisonerNumber = "123456",
       prisonCode = RISLEY,
       location = risleyLocation,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendCourtBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendCourtBookingServiceTest.kt
@@ -2,24 +2,26 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
 import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationValidator
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.LocationsInsidePrisonClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Toggles
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.CHESTERFIELD_JUSTICE_CENTRE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_CENTRE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
@@ -32,7 +34,22 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.amendProbation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasAmendedBy
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasAmendedTimeCloseTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasAppointmentDate
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasAppointmentTypeMain
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasBookingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasComments
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasEndTime
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasHearingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasPrisonCode
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasPrisonerNumber
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasPrisonersNotes
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasStaffNotes
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasStartTime
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasVideoUrl
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.pentonvilleLocation
@@ -65,6 +82,7 @@ class AmendCourtBookingServiceTest {
   private val locationsInsidePrisonClient: LocationsInsidePrisonClient = mock()
   private val locationValidator: LocationValidator = mock()
   private val prisonerSearchClient: PrisonerSearchClient = mock()
+  private val toggles: Toggles = mock()
 
   private val appointmentsService = AppointmentsService(prisonAppointmentRepository, prisonRepository, locationsInsidePrisonClient, locationValidator)
 
@@ -74,6 +92,7 @@ class AmendCourtBookingServiceTest {
     appointmentsService,
     bookingHistoryService,
     prisonerSearchClient,
+    toggles,
   )
 
   private var amendedBookingCaptor = argumentCaptor<VideoBooking>()
@@ -83,7 +102,6 @@ class AmendCourtBookingServiceTest {
     val prisonerNumber = "123456"
     val courtBooking = courtBooking(court = court(DERBY_JUSTICE_CENTRE)).withMainCourtPrisonAppointment()
     val amendCourtBookingRequest = amendCourtBookingRequest(
-      courtCode = CHESTERFIELD_JUSTICE_CENTRE,
       prisonCode = BIRMINGHAM,
       prisonerNumber = prisonerNumber,
       appointments = listOf(
@@ -540,6 +558,135 @@ class AmendCourtBookingServiceTest {
     val error = assertThrows<IllegalArgumentException> { service.amend(1, amendProbationBookingRequest(), COURT_USER) }
 
     error.message isEqualTo "AMEND COURT BOOKING: booking type is not court"
+  }
+
+  @Nested
+  inner class FeatureToggleForNotesComments {
+    @Test
+    fun `should amend existing comments (and not notes) when toggle off`() {
+      val prisonerNumber = "123456"
+      val courtBooking = courtBooking(court = court(DERBY_JUSTICE_CENTRE), comments = "create comments").withMainCourtPrisonAppointment()
+      val amendCourtBookingRequest = amendCourtBookingRequest(
+        prisonCode = BIRMINGHAM,
+        prisonerNumber = prisonerNumber,
+        comments = "amend comments",
+        notesForStaff = "amend notes for staff",
+        notesForPrisoners = "amend notes for prisoners",
+        appointments = listOf(
+          Appointment(
+            type = AppointmentType.VLB_COURT_MAIN,
+            locationKey = birminghamLocation.key,
+            date = tomorrow(),
+            startTime = LocalTime.of(9, 30),
+            endTime = LocalTime.of(10, 0),
+          ),
+        ),
+      )
+
+      withBookingFixture(1, courtBooking)
+      withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
+
+      whenever(toggles.isMasterPublicAndPrivateNotes()) doReturn false
+      whenever(locationValidator.validatePrisonLocations(BIRMINGHAM, setOf(birminghamLocation.key))) doReturn listOf(birminghamLocation)
+      whenever(locationsInsidePrisonClient.getLocationsByKeys(setOf(birminghamLocation.key))) doReturn listOf(birminghamLocation)
+
+      service.amend(1, amendCourtBookingRequest, COURT_USER).also { (booking, prisoner) ->
+        booking isEqualTo persistedVideoBooking
+        prisoner isEqualTo prisoner(prisonerNumber, BIRMINGHAM)
+      }
+
+      inOrder(videoBookingRepository, prisonRepository, prisonerSearchClient, locationValidator, bookingHistoryService) {
+        verify(videoBookingRepository).findById(any())
+        verify(prisonRepository).findByCode(BIRMINGHAM)
+        verify(prisonerSearchClient).getPrisoner(prisonerNumber)
+        verify(locationValidator).validatePrisonLocations(BIRMINGHAM, setOf(birminghamLocation.key))
+        verify(videoBookingRepository).saveAndFlush(amendedBookingCaptor.capture())
+        verify(bookingHistoryService).createBookingHistory(HistoryType.AMEND, courtBooking)
+      }
+
+      amendedBookingCaptor
+        .firstValue
+        .hasBookingType(BookingType.COURT)
+        .hasHearingType(amendCourtBookingRequest.courtHearingType!!)
+        .hasVideoUrl(amendCourtBookingRequest.videoLinkUrl!!)
+        .hasComments("amend comments")
+        .hasStaffNotes("Some private staff notes")
+        .hasPrisonersNotes(null)
+        .hasAmendedBy(COURT_USER)
+        .hasAmendedTimeCloseTo(LocalDateTime.now())
+        .mainHearing()!!
+        .hasPrisonCode(BIRMINGHAM)
+        .hasPrisonerNumber(prisonerNumber)
+        .hasLocation(birminghamLocation)
+        .hasAppointmentDate(tomorrow())
+        .hasStartTime(LocalTime.of(9, 30))
+        .hasEndTime(LocalTime.of(10, 0))
+        .hasAppointmentTypeMain()
+    }
+
+    @Test
+    fun `should amend existing notes (and not comments) when toggle is on`() {
+      val prisonerNumber = "123456"
+      val courtBooking = courtBooking(court = court(DERBY_JUSTICE_CENTRE), comments = "create comments").withMainCourtPrisonAppointment()
+      val amendCourtBookingRequest = amendCourtBookingRequest(
+        prisonCode = BIRMINGHAM,
+        prisonerNumber = prisonerNumber,
+        comments = "amend comments",
+        notesForStaff = "some amend notes for staff",
+        notesForPrisoners = "some amend notes for prisoners",
+        appointments = listOf(
+          Appointment(
+            type = AppointmentType.VLB_COURT_MAIN,
+            locationKey = birminghamLocation.key,
+            date = tomorrow(),
+            startTime = LocalTime.of(9, 30),
+            endTime = LocalTime.of(10, 0),
+          ),
+        ),
+      )
+
+      withBookingFixture(1, courtBooking)
+      withPrisonPrisonerFixture(BIRMINGHAM, prisonerNumber)
+
+      whenever(toggles.isMasterPublicAndPrivateNotes()) doReturn true
+      whenever(locationValidator.validatePrisonLocations(BIRMINGHAM, setOf(birminghamLocation.key))) doReturn listOf(birminghamLocation)
+      whenever(locationsInsidePrisonClient.getLocationsByKeys(setOf(birminghamLocation.key))) doReturn listOf(birminghamLocation)
+      whenever(locationsInsidePrisonClient.getLocationByKey(birminghamLocation.key)) doReturn birminghamLocation
+
+      service.amend(1, amendCourtBookingRequest, PRISON_USER_BIRMINGHAM).also { (booking, prisoner) ->
+        booking isEqualTo persistedVideoBooking
+        prisoner isEqualTo prisoner(prisonerNumber, BIRMINGHAM)
+      }
+
+      inOrder(videoBookingRepository, prisonRepository, prisonerSearchClient, locationValidator, bookingHistoryService) {
+        verify(videoBookingRepository).findById(any())
+        verify(prisonRepository).findByCode(BIRMINGHAM)
+        verify(prisonerSearchClient).getPrisoner(prisonerNumber)
+        verify(locationValidator).validatePrisonLocations(BIRMINGHAM, setOf(birminghamLocation.key))
+        verify(videoBookingRepository).saveAndFlush(amendedBookingCaptor.capture())
+        verify(bookingHistoryService).createBookingHistory(HistoryType.AMEND, courtBooking)
+      }
+
+      amendedBookingCaptor
+        .firstValue
+        .hasBookingType(BookingType.COURT)
+        .hasHearingType(amendCourtBookingRequest.courtHearingType!!)
+        .hasVideoUrl(amendCourtBookingRequest.videoLinkUrl!!)
+        // note old comments are not lost/overwritten
+        .hasComments("create comments")
+        .hasStaffNotes("some amend notes for staff")
+        .hasPrisonersNotes("some amend notes for prisoners")
+        .hasAmendedBy(PRISON_USER_BIRMINGHAM)
+        .hasAmendedTimeCloseTo(LocalDateTime.now())
+        .mainHearing()!!
+        .hasPrisonCode(BIRMINGHAM)
+        .hasPrisonerNumber(prisonerNumber)
+        .hasLocation(birminghamLocation)
+        .hasAppointmentDate(tomorrow())
+        .hasStartTime(LocalTime.of(9, 30))
+        .hasEndTime(LocalTime.of(10, 0))
+        .hasAppointmentTypeMain()
+    }
   }
 
   private fun withBookingFixture(bookingId: Long, booking: VideoBooking) {


### PR DESCRIPTION
This change is to ensure existing comments or notes are not accidentally lost when the feature toggle is switch on/off.