### PR TITLE
BAVL-888: Adds public/private notes to booking history and prison appoinment.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/BookingHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/BookingHistory.kt
@@ -48,6 +48,10 @@ class BookingHistory(
 
   val comments: String? = null,
 
+  val notesForStaff: String? = null,
+
+  val notesForPrisoners: String? = null,
+
   val createdBy: String,
 
   val createdTime: LocalDateTime = LocalDateTime.now(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/PrisonAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/PrisonAppointment.kt
@@ -46,6 +46,8 @@ class PrisonAppointment private constructor(
   val endTime: LocalTime,
 
   val notesForPrisoners: String? = null,
+
+  val notesForStaff: String? = null,
 ) {
 
   fun prisonCode() = prison.code
@@ -93,6 +95,7 @@ class PrisonAppointment private constructor(
       prisonLocationId = locationId,
       comments = videoBooking.comments,
       notesForPrisoners = videoBooking.notesForPrisoners,
+      notesForStaff = videoBooking.notesForStaff,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
@@ -194,12 +194,6 @@ class VideoBooking private constructor(
 
   fun probationMeeting(): PrisonAppointment? = appointments().singleOrNull { it.appointmentType == "VLB_PROBATION" }
 
-  fun prisonerNotes(notes: String?, user: User) {
-    if (user is PrisonUser) {
-      notesForPrisoners = notes
-    }
-  }
-
   companion object {
 
     fun newCourtBooking(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingHistoryService.kt
@@ -39,6 +39,8 @@ class BookingHistoryService(private val bookingHistoryRepository: BookingHistory
       probationMeetingType = booking.probationMeetingType.takeIf { booking.isBookingType(PROBATION) },
       videoUrl = booking.videoUrl,
       comments = booking.comments,
+      notesForStaff = booking.notesForStaff,
+      notesForPrisoners = booking.notesForPrisoners,
       createdBy = booking.amendedBy ?: booking.createdBy,
       createdTime = booking.amendedTime ?: booking.createdTime,
     ).apply {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/VideoBookingAmendedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/handlers/VideoBookingAmendedEventHandler.kt
@@ -36,7 +36,9 @@ class VideoBookingAmendedEventHandler(
             .sortedByDescending { history -> history.createdTime }
             .let {
               if (event.additionalInformation.videoBookingId < 0) {
-                require(amendedBooking.isBookingType(BookingType.PROBATION)) { "Booking type must be probation" }
+                // This feature allows negative video booking ids received in events to trigger a re-sync of appointments
+                // without a booking history row first being created (provided something has changed on the appointment)
+                // e.g. by an SQL update applied beforehand.
                 log.info("Processing negative videoBookingId ${event.additionalInformation.videoBookingId}")
 
                 it[0]
@@ -102,7 +104,9 @@ class VideoBookingAmendedEventHandler(
       endTime == historyAppointment.endTime &&
       prisonerNumber == historyAppointment.prisonerNumber &&
       prisonLocationId == historyAppointment.prisonLocationId &&
-      comments == historyAppointment.bookingHistory.comments
+      comments == historyAppointment.bookingHistory.comments &&
+      notesForPrisoners == historyAppointment.bookingHistory.notesForPrisoners &&
+      notesForStaff == historyAppointment.bookingHistory.notesForStaff
   }
 
   private fun PrisonAppointment.isEarlierThanBefore(historyAppointment: BookingHistoryAppointment) = run {

--- a/src/main/resources/migrations/common/V2025.06.01__public_private_notes_part_two.sql
+++ b/src/main/resources/migrations/common/V2025.06.01__public_private_notes_part_two.sql
@@ -1,0 +1,3 @@
+ALTER TABLE booking_history ADD COLUMN notes_for_prisoners VARCHAR(1000);
+ALTER TABLE booking_history ADD COLUMN notes_for_staff VARCHAR(1000);
+ALTER TABLE prison_appointment ADD COLUMN notes_for_staff VARCHAR(1000);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -85,7 +85,13 @@ fun courtBooking(
   notesForPrisoners = notesForPrisoners,
 )
 
-fun bookingHistory(historyType: HistoryType, booking: VideoBooking, comments: String? = "history comments") = BookingHistory(
+fun bookingHistory(
+  historyType: HistoryType,
+  booking: VideoBooking,
+  comments: String? = "history comments",
+  notesForStaff: String? = null,
+  notesForPrisoners: String? = null,
+) = BookingHistory(
   bookingHistoryId = 1L,
   videoBookingId = booking.videoBookingId,
   historyType = historyType,
@@ -94,6 +100,8 @@ fun bookingHistory(historyType: HistoryType, booking: VideoBooking, comments: St
   hearingType = CourtHearingType.TRIBUNAL.name,
   videoUrl = "https://edited.video.url",
   comments = comments,
+  notesForStaff = notesForStaff,
+  notesForPrisoners = notesForPrisoners,
   createdBy = booking.createdBy,
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingHistoryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingHistoryServiceTest.kt
@@ -68,6 +68,8 @@ class BookingHistoryServiceTest {
       hearingType isEqualTo courtBooking.hearingType
       comments isEqualTo "Court hearing comments"
       videoUrl isEqualTo courtBooking.videoUrl
+      notesForStaff isEqualTo courtBooking.notesForStaff
+      notesForPrisoners isEqualTo courtBooking.notesForPrisoners
       createdBy isEqualTo COURT_USER.username
       createdTime isCloseTo LocalDateTime.now()
       appointments() hasSize 1
@@ -104,6 +106,8 @@ class BookingHistoryServiceTest {
       createdTime isCloseTo LocalDateTime.now()
       probationMeetingType isEqualTo probationBooking.probationMeetingType
       comments isEqualTo "Probation meeting comments"
+      notesForPrisoners isEqualTo probationBooking.notesForPrisoners
+      notesForStaff isEqualTo probationBooking.notesForStaff
       videoUrl isEqualTo probationBooking.videoUrl
       createdBy isEqualTo PROBATION_USER.username
       createdTime isCloseTo LocalDateTime.now()
@@ -141,6 +145,9 @@ class BookingHistoryServiceTest {
 
     with(historyCaptor.firstValue) {
       historyType isEqualTo HistoryType.AMEND
+      comments isEqualTo courtBooking.comments
+      notesForPrisoners isEqualTo courtBooking.notesForPrisoners
+      notesForStaff isEqualTo courtBooking.notesForStaff
       createdBy isEqualTo "amended by someone else"
       createdTime isEqualTo today().atStartOfDay()
       appointments() hasSize 1
@@ -166,6 +173,9 @@ class BookingHistoryServiceTest {
 
     with(historyCaptor.firstValue) {
       historyType isEqualTo HistoryType.CANCEL
+      comments isEqualTo courtBooking.comments
+      notesForPrisoners isEqualTo courtBooking.notesForPrisoners
+      notesForStaff isEqualTo courtBooking.notesForStaff
       createdBy isEqualTo "court cancellation user"
       createdTime isCloseTo LocalDateTime.now()
       appointments() hasSize 1
@@ -194,6 +204,9 @@ class BookingHistoryServiceTest {
 
     with(historyCaptor.firstValue) {
       historyType isEqualTo HistoryType.AMEND
+      comments isEqualTo probationBooking.comments
+      notesForPrisoners isEqualTo probationBooking.notesForPrisoners
+      notesForStaff isEqualTo probationBooking.notesForStaff
       createdBy isEqualTo "amended by someone else"
       createdTime isEqualTo today().atStartOfDay()
       appointments() hasSize 1
@@ -219,6 +232,9 @@ class BookingHistoryServiceTest {
 
     with(historyCaptor.firstValue) {
       historyType isEqualTo HistoryType.CANCEL
+      comments isEqualTo probationBooking.comments
+      notesForPrisoners isEqualTo probationBooking.notesForPrisoners
+      notesForStaff isEqualTo probationBooking.notesForStaff
       createdBy isEqualTo "probation cancellation user"
       createdTime isCloseTo LocalDateTime.now()
       appointments() hasSize 1


### PR DESCRIPTION
Enables the re-sync of downstream appointments using the utility endpoint