### PR TITLE
BAVL-924 this change adds the video URL (CVP link) to court CSV extracts in the final column of the CSV files.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingEvent.kt
@@ -70,4 +70,6 @@ data class VideoBookingEvent(
   val type: String,
 
   val user: String,
+
+  val cvpLink: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CsvDataExtractionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CsvDataExtractionService.kt
@@ -155,6 +155,7 @@ class CsvDataExtractionService(
   "postLocationName",
   "hearingType",
   "user",
+  "cvpLink",
 )
 data class CourtBookingEvent(
   val eventId: Long,
@@ -176,13 +177,14 @@ data class CourtBookingEvent(
   val postLocationName: String?,
   val hearingType: String,
   val user: String,
+  val cvpLink: String?,
 ) {
-  constructor(vbh: VideoBookingEvent, locations: Set<Location>) : this(
-    vbh.eventId,
-    vbh.timestamp,
-    vbh.videoBookingId,
+  constructor(vbe: VideoBookingEvent, locations: Set<Location>) : this(
+    vbe.eventId,
+    vbe.timestamp,
+    vbe.videoBookingId,
     // Old BVLS has DELETE instead of CANCEL and UPDATE instead of AMEND
-    vbh.eventType.let {
+    vbe.eventType.let {
       if (it == "CANCEL") {
         "DELETE"
       } else if (it == "AMEND") {
@@ -191,21 +193,22 @@ data class CourtBookingEvent(
         it
       }
     },
-    vbh.prisonCode,
-    vbh.courtDescription!!,
-    vbh.courtCode!!,
-    vbh.createdByPrison.not(),
-    vbh.mainDate.atTime(vbh.mainStartTime),
-    vbh.mainDate.atTime(vbh.mainEndTime),
-    vbh.preDate?.atTime(vbh.preStartTime),
-    vbh.preDate?.atTime(vbh.preEndTime),
-    vbh.postDate?.atTime(vbh.postStartTime),
-    vbh.postDate?.atTime(vbh.postEndTime),
-    vbh.mainLocationId.let { id -> locations.singleOrNull { it.id == id }?.let { it.localName ?: it.key } ?: id.toString() },
-    vbh.preLocationId?.let { id -> locations.singleOrNull { it.id == id }?.let { it.localName ?: it.key } ?: id.toString() },
-    vbh.postLocationId?.let { id -> locations.singleOrNull { it.id == id }?.let { it.localName ?: it.key } ?: id.toString() },
-    vbh.type,
-    vbh.user,
+    vbe.prisonCode,
+    vbe.courtDescription!!,
+    vbe.courtCode!!,
+    vbe.createdByPrison.not(),
+    vbe.mainDate.atTime(vbe.mainStartTime),
+    vbe.mainDate.atTime(vbe.mainEndTime),
+    vbe.preDate?.atTime(vbe.preStartTime),
+    vbe.preDate?.atTime(vbe.preEndTime),
+    vbe.postDate?.atTime(vbe.postStartTime),
+    vbe.postDate?.atTime(vbe.postEndTime),
+    vbe.mainLocationId.let { id -> locations.singleOrNull { it.id == id }?.let { it.localName ?: it.key } ?: id.toString() },
+    vbe.preLocationId?.let { id -> locations.singleOrNull { it.id == id }?.let { it.localName ?: it.key } ?: id.toString() },
+    vbe.postLocationId?.let { id -> locations.singleOrNull { it.id == id }?.let { it.localName ?: it.key } ?: id.toString() },
+    vbe.type,
+    vbe.user,
+    vbe.cvpLink,
   )
 }
 
@@ -251,12 +254,12 @@ data class ProbationBookingEvent(
   val meetingType: String,
   val user: String,
 ) {
-  constructor(vbh: VideoBookingEvent, locations: Set<Location>) : this(
-    vbh.eventId,
-    vbh.timestamp,
-    vbh.videoBookingId,
+  constructor(vbe: VideoBookingEvent, locations: Set<Location>) : this(
+    vbe.eventId,
+    vbe.timestamp,
+    vbe.videoBookingId,
     // Old BVLS has DELETE instead of CANCEL and UPDATE instead of AMEND
-    vbh.eventType.let {
+    vbe.eventType.let {
       if (it == "CANCEL") {
         "DELETE"
       } else if (it == "AMEND") {
@@ -265,20 +268,20 @@ data class ProbationBookingEvent(
         it
       }
     },
-    vbh.prisonCode,
-    vbh.probationTeamDescription!!,
-    vbh.probationTeamCode!!,
-    vbh.createdByPrison.not(),
-    vbh.mainDate.atTime(vbh.mainStartTime),
-    vbh.mainDate.atTime(vbh.mainEndTime),
+    vbe.prisonCode,
+    vbe.probationTeamDescription!!,
+    vbe.probationTeamCode!!,
+    vbe.createdByPrison.not(),
+    vbe.mainDate.atTime(vbe.mainStartTime),
+    vbe.mainDate.atTime(vbe.mainEndTime),
     null,
     null,
     null,
     null,
-    vbh.mainLocationId.let { id -> locations.singleOrNull { it.id == id }?.let { it.localName ?: it.key } ?: id.toString() },
+    vbe.mainLocationId.let { id -> locations.singleOrNull { it.id == id }?.let { it.localName ?: it.key } ?: id.toString() },
     null,
     null,
-    vbh.type,
-    vbh.user,
+    vbe.type,
+    vbe.user,
   )
 }

--- a/src/main/resources/migrations/common/R__v_video_booking_event.sql
+++ b/src/main/resources/migrations/common/R__v_video_booking_event.sql
@@ -28,7 +28,8 @@ select
   bha_post.end_time as post_end_time,
   true as court_booking,
   rc.description as type,
-  bh.created_by as "user"
+  bh.created_by as "user",
+  vlb.video_url as cvp_link
 from video_booking vlb
   join booking_history bh on bh.video_booking_id = vlb.video_booking_id
   join booking_history_appointment bha_main on bha_main.booking_history_id = bh.booking_history_id and bha_main.appointment_type = 'VLB_COURT_MAIN'
@@ -64,7 +65,8 @@ select
     null as post_end_time,
     false as court_booking,
     rc.description as type,
-    bh.created_by as "user"
+    bh.created_by as "user",
+    null as cvp_link
 from video_booking vlb
   join booking_history bh on bh.video_booking_id = vlb.video_booking_id
   join booking_history_appointment bha_main on bha_main.booking_history_id = bh.booking_history_id and bha_main.appointment_type = 'VLB_PROBATION'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CsvDataExtractionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CsvDataExtractionIntegrationTest.kt
@@ -26,8 +26,8 @@ class CsvDataExtractionIntegrationTest : IntegrationTestBase() {
     val response = webTestClient.downloadCourtDataByHearingDate(LocalDate.of(2100, 7, 24), 1)
 
     // This should pick up the amended event in favour of the create event.
-    response contains "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user\n"
-    response contains "-2000,2024-07-24T01:00:00,-2000,CREATE,PVI,\"Free text court name\",UNKNOWN,true,2100-07-24T12:00:00,2100-07-24T13:00:00,,,,,\"Pentonville room 3\",,,Tribunal,court_user\n"
+    response contains "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user,cvpLink\n"
+    response contains "-2000,2024-07-24T01:00:00,-2000,CREATE,PVI,\"Free text court name\",UNKNOWN,true,2100-07-24T12:00:00,2100-07-24T13:00:00,,,,,\"Pentonville room 3\",,,Tribunal,court_user,cvp-link\n"
   }
 
   @Sql("classpath:integration-test-data/seed-events-by-booking-date-data-extract.sql")
@@ -36,8 +36,8 @@ class CsvDataExtractionIntegrationTest : IntegrationTestBase() {
     val courtResponse = webTestClient.downloadCourtDataByBookingDate(LocalDate.of(2024, 1, 1), 1)
 
     courtResponse contains "video-links-by-court-booking-date-from-2024-01-01-for-1-days.csv"
-    courtResponse contains "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user\n"
-    courtResponse contains "-2000,2024-01-01T01:00:00,-2000,CREATE,PVI,\"Derby Justice Centre\",DRBYMC,true,2099-01-24T12:00:00,2099-01-24T13:00:00,,,,,\"Pentonville room 3\",,,Tribunal,court_user"
+    courtResponse contains "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user,cvpLink\n"
+    courtResponse contains "-2000,2024-01-01T01:00:00,-2000,CREATE,PVI,\"Derby Justice Centre\",DRBYMC,true,2099-01-24T12:00:00,2099-01-24T13:00:00,,,,,\"Pentonville room 3\",,,Tribunal,court_user,cvp-link"
 
     val probationResponse = webTestClient.downloadProbationDataByBookingDate(LocalDate.of(2024, 1, 1), 2)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CsvDataExtractionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CsvDataExtractionServiceTest.kt
@@ -58,6 +58,7 @@ class CsvDataExtractionServiceTest {
     courtBooking = true,
     type = "Appeal",
     user = "court_user",
+    cvpLink = "cvp-link",
   )
   private val wandsworthCancelCourtBookingEvent = wandsworthCreateCourtBookingEvent.copy(eventType = "CANCEL")
   private val wandsworthAmendCourtBookingEvent = wandsworthCreateCourtBookingEvent.copy(eventType = "AMEND")
@@ -87,8 +88,8 @@ class CsvDataExtractionServiceTest {
     verify(videoBookingEventRepository, never()).findByDateOfBookingBetween(any(), any(), any())
 
     csvOutputStream.toString() isEqualTo
-      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user\n" +
-      "1,2024-07-01T09:00:00,1,CREATE,$WANDSWORTH,\"court description\",\"court code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T09:00:00,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T12:00:00,\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",Appeal,court_user\n"
+      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user,cvpLink\n" +
+      "1,2024-07-01T09:00:00,1,CREATE,$WANDSWORTH,\"court description\",\"court code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T09:00:00,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T12:00:00,\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",Appeal,court_user,cvp-link\n"
   }
 
   @Test
@@ -124,8 +125,8 @@ class CsvDataExtractionServiceTest {
     verify(videoBookingEventRepository, never()).findByDateOfBookingBetween(any(), any(), any())
 
     csvOutputStream.toString() isEqualTo
-      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user\n" +
-      "1,2024-07-01T09:00:00,1,CREATE,$WANDSWORTH,\"court description\",\"court code\",false,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T09:00:00,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T12:00:00,\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",Appeal,court_user\n"
+      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user,cvpLink\n" +
+      "1,2024-07-01T09:00:00,1,CREATE,$WANDSWORTH,\"court description\",\"court code\",false,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T09:00:00,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T12:00:00,\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",Appeal,court_user,cvp-link\n"
   }
 
   @Test
@@ -138,8 +139,8 @@ class CsvDataExtractionServiceTest {
     verify(videoBookingEventRepository, never()).findByMainDateBetween(any(), any(), any())
 
     csvOutputStream.toString() isEqualTo
-      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user\n" +
-      "1,2024-07-01T09:00:00,1,DELETE,$RISLEY,\"court description\",\"court code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T09:00:00,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T12:00:00,\"${risleyLocation.localName}\",\"${risleyLocation.localName}\",\"${risleyLocation.localName}\",Appeal,court_user\n"
+      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user,cvpLink\n" +
+      "1,2024-07-01T09:00:00,1,DELETE,$RISLEY,\"court description\",\"court code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T09:00:00,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T12:00:00,\"${risleyLocation.localName}\",\"${risleyLocation.localName}\",\"${risleyLocation.localName}\",Appeal,court_user,cvp-link\n"
   }
 
   @Test
@@ -154,8 +155,8 @@ class CsvDataExtractionServiceTest {
     verify(videoBookingEventRepository, never()).findByMainDateBetween(any(), any(), any())
 
     csvOutputStream.toString() isEqualTo
-      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user\n" +
-      "1,2024-07-01T09:00:00,1,DELETE,$RISLEY,\"court description\",\"court code\",false,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T09:00:00,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T12:00:00,\"${risleyLocation.localName}\",\"${risleyLocation.localName}\",\"${risleyLocation.localName}\",Appeal,court_user\n"
+      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user,cvpLink\n" +
+      "1,2024-07-01T09:00:00,1,DELETE,$RISLEY,\"court description\",\"court code\",false,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T09:00:00,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T12:00:00,\"${risleyLocation.localName}\",\"${risleyLocation.localName}\",\"${risleyLocation.localName}\",Appeal,court_user,cvp-link\n"
   }
 
   @Test
@@ -168,8 +169,8 @@ class CsvDataExtractionServiceTest {
     verify(videoBookingEventRepository, never()).findByDateOfBookingBetween(any(), any(), any())
 
     csvOutputStream.toString() isEqualTo
-      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user\n" +
-      "1,2024-07-01T09:00:00,1,DELETE,$WANDSWORTH,\"court description\",\"court code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T09:00:00,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T12:00:00,\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",Appeal,court_user\n"
+      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user,cvpLink\n" +
+      "1,2024-07-01T09:00:00,1,DELETE,$WANDSWORTH,\"court description\",\"court code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T09:00:00,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T12:00:00,\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",Appeal,court_user,cvp-link\n"
   }
 
   @Test
@@ -182,8 +183,8 @@ class CsvDataExtractionServiceTest {
     verify(videoBookingEventRepository, never()).findByDateOfBookingBetween(any(), any(), any())
 
     csvOutputStream.toString() isEqualTo
-      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user\n" +
-      "1,2024-07-01T09:00:00,1,UPDATE,$WANDSWORTH,\"court description\",\"court code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T09:00:00,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T12:00:00,\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",Appeal,court_user\n"
+      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,court,courtId,madeByTheCourt,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,hearingType,user,cvpLink\n" +
+      "1,2024-07-01T09:00:00,1,UPDATE,$WANDSWORTH,\"court description\",\"court code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T09:00:00,2024-07-10T10:00:00,2024-07-10T11:00:00,2024-07-10T12:00:00,\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",\"${wandsworthLocation.localName}\",Appeal,court_user,cvp-link\n"
   }
 
   @Test

--- a/src/test/resources/integration-test-data/seed-court-events-by-hearing-date-data-extract.sql
+++ b/src/test/resources/integration-test-data/seed-court-events-by-hearing-date-data-extract.sql
@@ -16,8 +16,8 @@ values (-1100, -1000, 'AMEND', 1, 'APPEAL','comments about the hearing', 'court_
 insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)
 values (-1100, 'PVI', 'ABCDEF', '2100-07-25', 'VLB_COURT_MAIN', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '12:00', '13:00');
 
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time, migrated_description)
-values (-2000, 'COURT', 'ACTIVE', 409, 'TRIBUNAL', 'comments about the hearing', 'court_user', '2024-07-24T01:00:00', 'Free text court name');
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time, migrated_description, video_url)
+values (-2000, 'COURT', 'ACTIVE', 409, 'TRIBUNAL', 'comments about the hearing', 'court_user', '2024-07-24T01:00:00', 'Free text court name', 'cvp-link');
 
 insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
 values (-2000, 1, 'ABCDEF', 'VLB_COURT_MAIN', 'comments about the hearing', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '2100-07-24', '12:00', '13:00');

--- a/src/test/resources/integration-test-data/seed-events-by-booking-date-data-extract.sql
+++ b/src/test/resources/integration-test-data/seed-events-by-booking-date-data-extract.sql
@@ -1,5 +1,5 @@
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
-values (-2000, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'court_user', '2024-01-01T01:00:00');
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time, video_url)
+values (-2000, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'court_user', '2024-01-01T01:00:00', 'cvp-link');
 
 insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
 values (-2000, 1, 'ABCDEF', 'VLB_COURT_MAIN', 'comments about the hearing', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '2099-01-24', '12:00', '13:00');


### PR DESCRIPTION
This changes includes the CVP link (video URL) if there is one (or nothing if not) in both court CSV extracts by booking date and by hearing date.