### PR TITLE
BAVL-925 pulling the use of the new attributes into the service layer, telemetry and court reminder job.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
@@ -123,24 +123,6 @@ class VideoBooking private constructor(
     )
   }
 
-  @Deprecated(message = "Use amend court booking with CVP link details instead")
-  fun amendCourtBooking(
-    hearingType: String,
-    comments: String?,
-    notesForStaff: String?,
-    notesForPrisoners: String?,
-    videoUrl: String?,
-    amendedBy: User,
-  ) = amendCourtBooking(
-    hearingType = hearingType,
-    comments = comments,
-    notesForStaff = notesForStaff,
-    notesForPrisoners = notesForPrisoners,
-    cvpLinkDetails = videoUrl?.let(CvpLinkDetails::videoUrl),
-    guestPin = null,
-    amendedBy = amendedBy,
-  )
-
   fun amendCourtBooking(
     hearingType: String,
     comments: String?,
@@ -226,26 +208,6 @@ class VideoBooking private constructor(
 
   companion object {
 
-    @Deprecated(message = "Use new court booking with CVP link details instead")
-    fun newCourtBooking(
-      court: Court,
-      hearingType: String,
-      comments: String?,
-      notesForStaff: String?,
-      notesForPrisoners: String?,
-      videoUrl: String?,
-      createdBy: User,
-    ): VideoBooking = newCourtBooking(
-      court = court,
-      hearingType = hearingType,
-      comments = comments,
-      notesForStaff = notesForStaff,
-      notesForPrisoners = notesForPrisoners,
-      cvpLinkDetails = videoUrl?.let(CvpLinkDetails::videoUrl),
-      guestPin = null,
-      createdBy = createdBy,
-    )
-
     fun newCourtBooking(
       court: Court,
       hearingType: String,
@@ -305,8 +267,17 @@ enum class StatusCode {
  */
 class CvpLinkDetails private constructor(val hmctsNumber: String? = null, val videoUrl: String? = null) {
   companion object {
-    fun hmctsNumber(value: String) = CvpLinkDetails(hmctsNumber = value)
-    fun videoUrl(value: String) = CvpLinkDetails(videoUrl = value)
+    fun hmctsNumber(value: String) = run {
+      require(value.isNotBlank() && value.length <= 8) { "CVP HMCTS number must not be blank or greater than 8 characters" }
+
+      CvpLinkDetails(hmctsNumber = value)
+    }
+
+    fun url(value: String) = run {
+      require(value.isNotBlank() && value.length <= 120) { "CVP URL must not be blank or greater than 120 characters" }
+
+      CvpLinkDetails(videoUrl = value)
+    }
   }
 
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendCourtBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendCourtBookingService.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Toggles
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.CvpLinkDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.StatusCode
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
@@ -54,10 +55,12 @@ class AmendCourtBookingService(
   private fun amendCourt(existingBooking: VideoBooking, request: AmendVideoBookingRequest, amendedBy: User): Pair<VideoBooking, Prisoner> {
     val prisoner = request.prisoner().validate()
 
+    // TODO use HMCTS number and guest pin when added to request/model.
     return existingBooking.amendCourtBooking(
       hearingType = request.courtHearingType!!.name,
       comments = if (toggles.isMasterPublicAndPrivateNotes()) existingBooking.comments else request.comments,
-      videoUrl = request.videoLinkUrl,
+      cvpLinkDetails = request.videoLinkUrl?.let(CvpLinkDetails::url),
+      guestPin = null,
       amendedBy = amendedBy,
       notesForStaff = if (toggles.isMasterPublicAndPrivateNotes()) request.notesForStaff else existingBooking.notesForStaff,
       notesForPrisoners = if (toggles.isMasterPublicAndPrivateNotes()) request.notesForPrisoners else existingBooking.notesForPrisoners,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateCourtBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateCourtBookingService.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerValidator
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.requireNot
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.CvpLinkDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prisoner
@@ -54,11 +55,13 @@ class CreateCourtBookingService(
 
     val prisoner = request.prisoner().validate()
 
+    // TODO use HMCTS number and guest pin when added to request/model.
     return VideoBooking.newCourtBooking(
       court = court,
       hearingType = request.courtHearingType!!.name,
       comments = request.comments,
-      videoUrl = request.videoLinkUrl,
+      cvpLinkDetails = request.videoLinkUrl?.let(CvpLinkDetails::url),
+      guestPin = null,
       createdBy = createdBy,
       notesForStaff = request.notesForStaff,
       notesForPrisoners = request.notesForPrisoners,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/CourtHearingLinkReminderJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/CourtHearingLinkReminderJob.kt
@@ -29,7 +29,7 @@ class CourtHearingLinkReminderJob(
       .map { it.videoBooking }
       // Migrated bookings will not have the court hearing link field populated, and most probably will have the hearing link provided in the comments
       // Disabling this email for migrated bookings. This can be removed a few days after go-live once the majority of future bookings have taken place.
-      .filter { it.isBookingType(COURT) && !it.isMigrated() && it.videoUrl == null && it.court!!.enabled && it.prisonIsEnabledForSelfService() }
+      .filter { it.isBookingType(COURT) && !it.isMigrated() && it.videoUrl == null && it.hmctsNumber == null && it.court!!.enabled && it.prisonIsEnabledForSelfService() }
   },
   { bookings -> bookings.forEach { bookingFacade.courtHearingLinkReminder(it, getServiceAsUser()) } },
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/TelemetryService.kt
@@ -43,7 +43,8 @@ sealed class TelemetryEvent(val eventType: String) {
       "post_location_id" to (post()?.prisonLocationId?.toString() ?: ""),
       "post_start" to (post()?.start()?.toIsoDateTime() ?: ""),
       "post_end" to (post()?.end()?.toIsoDateTime() ?: ""),
-      "cvp_link" to (videoUrl != null).toString(),
+      "cvp_link" to (videoUrl != null || hmctsNumber != null).toString(),
+      "guest_pin" to (guestPin != null).toString(),
     )
   } else {
     mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingTest.kt
@@ -37,7 +37,7 @@ class VideoBookingTest {
       court(code = "COURT_CODE"),
       hearingType = "TRIBUNAL",
       comments = "Some prison user comments",
-      cvpLinkDetails = CvpLinkDetails.videoUrl("prison-user-video-url"),
+      cvpLinkDetails = CvpLinkDetails.url("prison-user-video-url"),
       createdBy = PRISON_USER_BIRMINGHAM,
       guestPin = "123456",
       notesForStaff = "Some private staff notes",
@@ -67,7 +67,7 @@ class VideoBookingTest {
       court(code = "COURT_CODE"),
       hearingType = "TRIBUNAL",
       comments = "Some prison user comments",
-      cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS1234"),
+      cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS123"),
       createdBy = PRISON_USER_BIRMINGHAM,
       guestPin = "123456",
       notesForStaff = "Some private staff notes",
@@ -80,7 +80,7 @@ class VideoBookingTest {
       hearingType isEqualTo "TRIBUNAL"
       comments isEqualTo "Some prison user comments"
       videoUrl isEqualTo null
-      hmctsNumber isEqualTo "HMCTS1234"
+      hmctsNumber isEqualTo "HMCTS123"
       guestPin isEqualTo "123456"
       createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
       createdTime isCloseTo now()
@@ -97,7 +97,7 @@ class VideoBookingTest {
       court(code = "COURT_CODE"),
       hearingType = "TRIBUNAL",
       comments = "Some prison user comments",
-      cvpLinkDetails = CvpLinkDetails.videoUrl("prison-user-video-url"),
+      cvpLinkDetails = CvpLinkDetails.url("prison-user-video-url"),
       guestPin = "123456",
       createdBy = PRISON_USER_BIRMINGHAM,
       notesForStaff = "Some private staff notes",
@@ -125,7 +125,7 @@ class VideoBookingTest {
       comments = "Amended comments",
       notesForStaff = "Amended staff notes",
       notesForPrisoners = "Amended prisoners notes",
-      cvpLinkDetails = CvpLinkDetails.videoUrl("amended-prison-user-video-url"),
+      cvpLinkDetails = CvpLinkDetails.url("amended-prison-user-video-url"),
       guestPin = "654321",
       COURT_USER,
     )
@@ -149,7 +149,7 @@ class VideoBookingTest {
       court(code = "COURT_CODE"),
       hearingType = "TRIBUNAL",
       comments = "Some prison user comments",
-      cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS1234"),
+      cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS123"),
       guestPin = "123456",
       createdBy = PRISON_USER_BIRMINGHAM,
       notesForStaff = "Some private staff notes",
@@ -162,7 +162,7 @@ class VideoBookingTest {
       hearingType isEqualTo "TRIBUNAL"
       comments isEqualTo "Some prison user comments"
       videoUrl isEqualTo null
-      hmctsNumber isEqualTo "HMCTS1234"
+      hmctsNumber isEqualTo "HMCTS123"
       guestPin isEqualTo "123456"
       createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
       createdTime isCloseTo now()
@@ -177,7 +177,7 @@ class VideoBookingTest {
       comments = "Amended comments",
       notesForStaff = "Amended staff notes",
       notesForPrisoners = "Amended prisoners notes",
-      cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS4321"),
+      cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS321"),
       guestPin = "654321",
       COURT_USER,
     )
@@ -188,7 +188,7 @@ class VideoBookingTest {
       notesForStaff isEqualTo "Amended staff notes"
       notesForPrisoners isEqualTo "Some public prisoners notes"
       videoUrl isEqualTo null
-      hmctsNumber isEqualTo "HMCTS4321"
+      hmctsNumber isEqualTo "HMCTS321"
       guestPin isEqualTo "654321"
       amendedBy isEqualTo COURT_USER.username
       amendedTime isCloseTo now()
@@ -201,7 +201,8 @@ class VideoBookingTest {
       court(code = "COURT_CODE"),
       hearingType = "TRIBUNAL",
       comments = "Some prison user comments",
-      videoUrl = "prison-user-video-url",
+      cvpLinkDetails = CvpLinkDetails.url("prison-user-video-url"),
+      guestPin = "123456",
       createdBy = PRISON_USER_BIRMINGHAM,
       notesForStaff = "Some private staff notes",
       notesForPrisoners = "Some public prisoners notes",
@@ -213,6 +214,8 @@ class VideoBookingTest {
       hearingType isEqualTo "TRIBUNAL"
       comments isEqualTo "Some prison user comments"
       videoUrl isEqualTo "prison-user-video-url"
+      hmctsNumber isEqualTo null
+      guestPin isEqualTo "123456"
       createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
       createdTime isCloseTo now()
       createdByPrison isBool true
@@ -226,7 +229,8 @@ class VideoBookingTest {
       comments = "Amended comments",
       notesForStaff = "Amended staff notes",
       notesForPrisoners = "Amended prisoners notes",
-      videoUrl = "amended-prison-user-video-url",
+      cvpLinkDetails = CvpLinkDetails.url("amended-prison-user-video-url"),
+      guestPin = "654321",
       PRISON_USER_BIRMINGHAM,
     )
 
@@ -236,6 +240,7 @@ class VideoBookingTest {
       notesForStaff isEqualTo "Amended staff notes"
       notesForPrisoners isEqualTo "Amended prisoners notes"
       videoUrl isEqualTo "amended-prison-user-video-url"
+      guestPin isEqualTo "654321"
       amendedBy isEqualTo PRISON_USER_BIRMINGHAM.username
       amendedTime isCloseTo now()
     }
@@ -247,7 +252,8 @@ class VideoBookingTest {
       court(code = "COURT_CODE"),
       hearingType = "APPEAL",
       comments = "Some court user comments",
-      videoUrl = "court-user-video-url",
+      cvpLinkDetails = CvpLinkDetails.url("court-user-video-url"),
+      guestPin = "123456",
       createdBy = COURT_USER,
       notesForStaff = "Some private staff notes",
       notesForPrisoners = "Should be ignored for external user",
@@ -259,6 +265,7 @@ class VideoBookingTest {
       hearingType isEqualTo "APPEAL"
       comments isEqualTo "Some court user comments"
       videoUrl isEqualTo "court-user-video-url"
+      guestPin isEqualTo "123456"
       createdBy isEqualTo COURT_USER.username
       createdByPrison isBool false
       statusCode isEqualTo StatusCode.ACTIVE
@@ -273,7 +280,8 @@ class VideoBookingTest {
       court(code = "COURT_CODE"),
       hearingType = "APPEAL",
       comments = "Some court user comments",
-      videoUrl = "court-user-video-url",
+      cvpLinkDetails = CvpLinkDetails.url("court-user-video-url"),
+      guestPin = "123456",
       createdBy = COURT_USER,
       notesForStaff = "Some private staff notes",
       notesForPrisoners = "Should be ignored for external user",
@@ -285,6 +293,7 @@ class VideoBookingTest {
       hearingType isEqualTo "APPEAL"
       comments isEqualTo "Some court user comments"
       videoUrl isEqualTo "court-user-video-url"
+      guestPin isEqualTo "123456"
       createdBy isEqualTo COURT_USER.username
       createdByPrison isBool false
       statusCode isEqualTo StatusCode.ACTIVE
@@ -297,7 +306,8 @@ class VideoBookingTest {
       comments = "Amended comments",
       notesForStaff = "Amended staff notes",
       notesForPrisoners = "Amended prisoners notes",
-      videoUrl = "amended-prison-user-video-url",
+      cvpLinkDetails = CvpLinkDetails.url("amended-court-user-video-url"),
+      guestPin = "654321",
       COURT_USER,
     )
 
@@ -306,7 +316,8 @@ class VideoBookingTest {
       comments isEqualTo "Amended comments"
       notesForStaff isEqualTo "Amended staff notes"
       notesForPrisoners isEqualTo null
-      videoUrl isEqualTo "amended-prison-user-video-url"
+      videoUrl isEqualTo "amended-court-user-video-url"
+      guestPin isEqualTo "654321"
       amendedBy isEqualTo COURT_USER.username
       amendedTime isCloseTo now()
     }
@@ -318,7 +329,8 @@ class VideoBookingTest {
       court(code = "COURT_CODE"),
       hearingType = "APPEAL",
       comments = "Some court user comments",
-      videoUrl = "court-user-video-url",
+      cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS123"),
+      guestPin = "123456",
       createdBy = COURT_USER,
       notesForStaff = "Some private staff notes",
       notesForPrisoners = "Should be ignored for external user",
@@ -329,7 +341,9 @@ class VideoBookingTest {
       isBookingType(BookingType.COURT) isBool true
       hearingType isEqualTo "APPEAL"
       comments isEqualTo "Some court user comments"
-      videoUrl isEqualTo "court-user-video-url"
+      videoUrl isEqualTo null
+      hmctsNumber isEqualTo "HMCTS123"
+      guestPin isEqualTo "123456"
       createdBy isEqualTo COURT_USER.username
       createdByPrison isBool false
       statusCode isEqualTo StatusCode.ACTIVE
@@ -342,7 +356,8 @@ class VideoBookingTest {
       comments = "Amended comments",
       notesForStaff = "Amended staff notes",
       notesForPrisoners = "Amended prisoners notes",
-      videoUrl = "amended-prison-user-video-url",
+      cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS321"),
+      guestPin = "654321",
       PRISON_USER_BIRMINGHAM,
     )
 
@@ -351,7 +366,9 @@ class VideoBookingTest {
       comments isEqualTo "Amended comments"
       notesForStaff isEqualTo "Amended staff notes"
       notesForPrisoners isEqualTo "Amended prisoners notes"
-      videoUrl isEqualTo "amended-prison-user-video-url"
+      hmctsNumber isEqualTo "HMCTS321"
+      guestPin isEqualTo "654321"
+      videoUrl isEqualTo null
       amendedBy isEqualTo PRISON_USER_BIRMINGHAM.username
       amendedTime isCloseTo now()
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/EntityFactory.kt
@@ -76,7 +76,7 @@ fun courtBooking(
   comments: String? = "Court hearing comments",
   notesForStaff: String? = null,
   notesForPrisoners: String? = null,
-  cvpLinkDetails: CvpLinkDetails? = CvpLinkDetails.videoUrl("https://court.hearing.link"),
+  cvpLinkDetails: CvpLinkDetails? = CvpLinkDetails.url("https://court.hearing.link"),
   guestPin: String? = null,
 ) = VideoBooking.newCourtBooking(
   court = court,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/CourtHearingLinkReminderJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/CourtHearingLinkReminderJobTest.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.CvpLinkDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.court
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withMainCourtPrisonAppointment
@@ -83,7 +84,15 @@ class CourtHearingLinkReminderJobTest {
 
   @Test
   fun `should not call court hearing link reminder for bookings with video URL`() {
-    val booking = courtBooking().withMainCourtPrisonAppointment()
+    val booking = courtBooking(cvpLinkDetails = CvpLinkDetails.url("url")).withMainCourtPrisonAppointment()
+    whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(TUESDAY, "VLB_COURT_MAIN")) doReturn booking.appointments()
+    runJobOn(MONDAY)
+    verify(bookingFacade, never()).courtHearingLinkReminder(any(), any())
+  }
+
+  @Test
+  fun `should not call court hearing link reminder for bookings with HMCTS number`() {
+    val booking = courtBooking(cvpLinkDetails = CvpLinkDetails.hmctsNumber("12345678")).withMainCourtPrisonAppointment()
     whenever(prisonAppointmentRepository.findAllActivePrisonAppointmentsOnDate(TUESDAY, "VLB_COURT_MAIN")) doReturn booking.appointments()
     runJobOn(MONDAY)
     verify(bookingFacade, never()).courtHearingLinkReminder(any(), any())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/VideoLinkBookingMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/VideoLinkBookingMappersTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping
 
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.CvpLinkDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.CHESTERFIELD_JUSTICE_CENTRE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
@@ -25,7 +26,8 @@ class VideoLinkBookingMappersTest {
       court(code = CHESTERFIELD_JUSTICE_CENTRE),
       CourtHearingType.TRIBUNAL.name,
       comments = "some comments for the court booking",
-      videoUrl = null,
+      cvpLinkDetails = null,
+      guestPin = null,
       createdBy = COURT_USER,
       notesForStaff = "Some private staff notes",
       notesForPrisoners = "Some public prisoners notes",
@@ -62,7 +64,8 @@ class VideoLinkBookingMappersTest {
       court(code = CHESTERFIELD_JUSTICE_CENTRE),
       CourtHearingType.TRIBUNAL.name,
       comments = "some comments for the court booking",
-      videoUrl = "court-video-url",
+      cvpLinkDetails = CvpLinkDetails.url("court-video-url"),
+      guestPin = "123456",
       createdBy = COURT_USER,
       notesForStaff = "Some private staff notes",
       notesForPrisoners = "Some public prisoners notes",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingAmendedTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingAmendedTelemetryEventTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.CvpLinkDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_CENTRE
@@ -38,7 +39,8 @@ class CourtBookingAmendedTelemetryEventTest {
       hearingType = "APPEAL",
       createdBy = COURT_USER,
       comments = null,
-      videoUrl = "http://booking.created.url",
+      cvpLinkDetails = CvpLinkDetails.url("http://booking.created.url"),
+      guestPin = "123456",
       notesForStaff = "Some staff notes",
       notesForPrisoners = "Some prisoners notes",
     ).addAppointment(
@@ -88,6 +90,7 @@ class CourtBookingAmendedTelemetryEventTest {
         "post_start" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
         "post_end" to tomorrow().atTime(LocalTime.of(12, 0)).toIsoDateTime(),
         "cvp_link" to "true",
+        "guest_pin" to "true",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(
@@ -106,7 +109,8 @@ class CourtBookingAmendedTelemetryEventTest {
       hearingType = "APPEAL",
       createdBy = PRISON_USER_RISLEY,
       comments = null,
-      videoUrl = null,
+      cvpLinkDetails = null,
+      guestPin = null,
       notesForStaff = null,
       notesForPrisoners = null,
     ).addAppointment(
@@ -140,6 +144,7 @@ class CourtBookingAmendedTelemetryEventTest {
         "post_start" to "",
         "post_end" to "",
         "cvp_link" to "false",
+        "guest_pin" to "false",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingCancelledTelemetryEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/telemetry/CourtBookingCancelledTelemetryEventTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.telemetry
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDateTime
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.CvpLinkDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_CENTRE
@@ -31,7 +32,8 @@ class CourtBookingCancelledTelemetryEventTest {
     hearingType = "APPEAL",
     createdBy = COURT_USER,
     comments = null,
-    videoUrl = "http://booking.created.url",
+    cvpLinkDetails = CvpLinkDetails.url("http://booking.created.url"),
+    guestPin = "123456",
     notesForStaff = null,
     notesForPrisoners = null,
   ).addAppointment(
@@ -83,6 +85,7 @@ class CourtBookingCancelledTelemetryEventTest {
         "post_start" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
         "post_end" to tomorrow().atTime(LocalTime.of(12, 0)).toIsoDateTime(),
         "cvp_link" to "true",
+        "guest_pin" to "true",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(
@@ -117,6 +120,7 @@ class CourtBookingCancelledTelemetryEventTest {
         "post_start" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
         "post_end" to tomorrow().atTime(LocalTime.of(12, 0)).toIsoDateTime(),
         "cvp_link" to "true",
+        "guest_pin" to "true",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(
@@ -151,6 +155,7 @@ class CourtBookingCancelledTelemetryEventTest {
         "post_start" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
         "post_end" to tomorrow().atTime(LocalTime.of(12, 0)).toIsoDateTime(),
         "cvp_link" to "true",
+        "guest_pin" to "true",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(
@@ -185,6 +190,7 @@ class CourtBookingCancelledTelemetryEventTest {
         "post_start" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
         "post_end" to tomorrow().atTime(LocalTime.of(12, 0)).toIsoDateTime(),
         "cvp_link" to "true",
+        "guest_pin" to "true",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(
@@ -219,6 +225,7 @@ class CourtBookingCancelledTelemetryEventTest {
         "post_start" to tomorrow().atTime(LocalTime.of(11, 0)).toIsoDateTime(),
         "post_end" to tomorrow().atTime(LocalTime.of(12, 0)).toIsoDateTime(),
         "cvp_link" to "true",
+        "guest_pin" to "true",
       )
 
       metrics() containsEntriesExactlyInAnyOrder mapOf(


### PR DESCRIPTION
This brings the new attributes up to the service layer though still not fully in use.

It also addresses the court reminder job for missing url which now also needs to check the presence of the hmcts number and brings the telemetry events inline as well.