### PR TITLE
BAVL-915 adding the daily schedule to the list of deployments that needs restarting when the FEATURE_HMCTS_LINK_GUEST_PIN is changed.

### DIFF
--- a/utility/disable-bvls-hmcts-link-guest-pin.sh
+++ b/utility/disable-bvls-hmcts-link-guest-pin.sh
@@ -48,3 +48,7 @@ rm -f ./$SECRETS_FILE
 echo
 echo "Restarting BVLS UI deployment on namespace $NAMESPACE"
 kubectl -n "$NAMESPACE" rollout restart deployments/hmpps-book-a-video-link-ui
+
+echo
+echo "Restarting Daily Schedule deployment on namespace $NAMESPACE"
+kubectl -n "$NAMESPACE" rollout restart deployments/hmpps-video-conference-schedule-ui

--- a/utility/enable-bvls-hmcts-link-guest-pin.sh
+++ b/utility/enable-bvls-hmcts-link-guest-pin.sh
@@ -48,3 +48,7 @@ rm -f ./$SECRETS_FILE
 echo
 echo "Restarting BVLS UI deployment on namespace $NAMESPACE"
 kubectl -n "$NAMESPACE" rollout restart deployments/hmpps-book-a-video-link-ui
+
+echo
+echo "Restarting Daily Schedule deployment on namespace $NAMESPACE"
+kubectl -n "$NAMESPACE" rollout restart deployments/hmpps-video-conference-schedule-ui


### PR DESCRIPTION
The daily schedule service also needs restarting when the FEATURE_HMCTS_LINK_GUEST_PIN is changed.  It does not need its own file, it can piggy back on existing disable and enable scripts because the toggle name is shared across services.