### PR TITLE
BAVL-959 disable preprod jobs from running over the weekend due to dependent services turned off at weekends.

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -33,3 +33,7 @@ generic-prometheus-alerts:
     - "hmpps-book-a-video-link-preprod-hmpps_book_a_video_link_domain_queue"
   sqsNumberAlertQueueNames:
     - "hmpps-book-a-video-link-preprod-hmpps_book_a_video_link_domain_dlq"
+
+cron:
+  courtHearingLinkReminderJob: "0 15 * * 1-5"
+  probationOfficerDetailsReminderJob: "0 15 * * 1-5"


### PR DESCRIPTION
The jobs fail to run at the weekend due to dependent DPS service downtime.