### PR TITLE
BAVL-975 bring the service inline with A&A for the maxixmum days into the future a booking (appointent) can be.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/VideoLinkBookingController.kt
@@ -31,7 +31,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.VideoL
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingFacade
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ExternalUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.PrisonUser
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.RequestBookingService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.VideoLinkBookingsService
 
 @Tag(name = "Video Link Booking Controller")
@@ -40,7 +39,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.VideoLinkBook
 @AuthApiResponses
 class VideoLinkBookingController(
   val bookingFacade: BookingFacade,
-  val requestBookingService: RequestBookingService,
   val videoLinkBookingsService: VideoLinkBookingsService,
 ) {
 
@@ -204,7 +202,7 @@ class VideoLinkBookingController(
     @Parameter(description = "The request with the requested video link booking details", required = true)
     request: RequestVideoBookingRequest,
     httpRequest: HttpServletRequest,
-  ) = requestBookingService.request(request, httpRequest.getBvlsRequestContext().user as ExternalUser)
+  ) = bookingFacade.request(request, httpRequest.getBvlsRequestContext().user as ExternalUser)
 
   @Operation(summary = "Endpoint to search for a unique matching video link booking.")
   @ApiResponses(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/BookingFacade.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AmendVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.RequestVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.AdditionalBookingDetailRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.NotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
@@ -94,6 +95,10 @@ class BookingFacade(
 
   fun cancel(videoBookingId: Long, cancelledBy: ExternalUser) {
     cancelBooking(videoBookingId, cancelledBy)
+  }
+
+  fun request(booking: RequestVideoBookingRequest, user: ExternalUser) {
+    videoBookingServiceDelegate.request(booking, user)
   }
 
   private fun cancelBooking(videoBookingId: Long, cancelledBy: User) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegate.kt
@@ -1,12 +1,16 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
+import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AmendVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.RequestVideoBookingRequest
+import java.time.LocalDate
 
 /**
  * Responsible for delegating video booking specific operations to the appropriate video booking service.
@@ -18,6 +22,8 @@ class VideoBookingServiceDelegate(
   private val amendCourtBookingService: AmendCourtBookingService,
   private val amendProbationBookingService: AmendProbationBookingService,
   private val cancelVideoBookingService: CancelVideoBookingService,
+  private val requestBookingService: RequestBookingService,
+  @Value("\${applications.max-appointment-start-date-from-today:1000}") private val maxStartDateOffsetDays: Long = 1000,
 ) {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -26,6 +32,8 @@ class VideoBookingServiceDelegate(
   @Transactional
   fun create(booking: CreateVideoBookingRequest, createdBy: User) = run {
     log.info("BOOKING DELEGATE: creating video booking: $booking")
+
+    checkStartDateNotTooFarInFuture(booking.prisoners.first().appointments.first().date!!)
 
     when (booking.bookingType!!) {
       BookingType.COURT -> createCourtBookingService.create(booking, createdBy)
@@ -36,6 +44,8 @@ class VideoBookingServiceDelegate(
   @Transactional
   fun amend(videoBookingId: Long, booking: AmendVideoBookingRequest, amendedBy: User) = run {
     log.info("BOOKING DELEGATE: amending video booking: $booking")
+
+    checkStartDateNotTooFarInFuture(booking.prisoners.first().appointments.first().date!!)
 
     when (booking.bookingType!!) {
       BookingType.COURT -> amendCourtBookingService.amend(videoBookingId, booking, amendedBy)
@@ -48,5 +58,17 @@ class VideoBookingServiceDelegate(
     log.info("BOOKING DELEGATE: cancelling video booking: $videoBookingId")
 
     cancelVideoBookingService.cancel(videoBookingId, cancelledBy)
+  }
+
+  fun request(booking: RequestVideoBookingRequest, user: ExternalUser) {
+    checkStartDateNotTooFarInFuture(booking.prisoners.first().appointments.first().date!!)
+
+    requestBookingService.request(booking, user)
+  }
+
+  private fun checkStartDateNotTooFarInFuture(startDate: LocalDate) {
+    if (startDate > LocalDate.now().plusDays(maxStartDateOffsetDays)) {
+      throw ValidationException("Start date cannot be more than $maxStartDateOffsetDays days into the future")
+    }
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -198,3 +198,6 @@ video-link-booking:
 hmpps:
   sqs:
     queueAdminRole: BOOK_A_VIDEO_LINK_ADMIN
+
+applications:
+  max-appointment-start-date-from-today: 1826

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -304,6 +304,7 @@ fun requestProbationVideoLinkRequest(
   comments: String? = null,
   appointments: List<RequestedAppointment> = emptyList(),
   notesForStaff: String? = null,
+  date: LocalDate? = tomorrow(),
 ): RequestVideoBookingRequest {
   val prisoner = UnknownPrisonerDetails(
     prisonCode = prisonCode,
@@ -314,7 +315,7 @@ fun requestProbationVideoLinkRequest(
       listOf(
         RequestedAppointment(
           type = AppointmentType.VLB_PROBATION,
-          date = tomorrow(),
+          date = date,
           startTime = startTime,
           endTime = endTime,
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegateTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
+import jakarta.validation.ValidationException
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -10,7 +12,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.amendCourtBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.amendProbationBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.requestProbationVideoLinkRequest
+import java.time.LocalDate
 
 class VideoBookingServiceDelegateTest {
   private val createCourtBookingService: CreateCourtBookingService = mock()
@@ -18,13 +23,25 @@ class VideoBookingServiceDelegateTest {
   private val amendCourtBookingService: AmendCourtBookingService = mock()
   private val amendProbationBookingService: AmendProbationBookingService = mock()
   private val cancelVideoBookingService: CancelVideoBookingService = mock()
+  private val requestBookingService: RequestBookingService = mock()
+  private val maxDaysIntoFuture = 100L
+
   private val delegate =
-    VideoBookingServiceDelegate(createCourtBookingService, createProbationBookingService, amendCourtBookingService, amendProbationBookingService, cancelVideoBookingService)
+    VideoBookingServiceDelegate(
+      createCourtBookingService,
+      createProbationBookingService,
+      amendCourtBookingService,
+      amendProbationBookingService,
+      cancelVideoBookingService,
+      requestBookingService,
+      maxDaysIntoFuture,
+    )
 
   private val courtBookingRequest = courtBookingRequest()
   private val probationBookingRequest = probationBookingRequest()
   private val amendCourtBookingRequest = amendCourtBookingRequest()
   private val amendProbationBookingRequest = amendProbationBookingRequest()
+  private val requestVideoBookingRequest = requestProbationVideoLinkRequest()
 
   @Test
   fun `should delegate to correct create booking service`() {
@@ -54,5 +71,29 @@ class VideoBookingServiceDelegateTest {
     verify(cancelVideoBookingService).cancel(1, COURT_USER)
 
     verifyNoInteractions(createCourtBookingService, createProbationBookingService, amendCourtBookingService)
+  }
+
+  @Test
+  fun `should delegate to request booking service service`() {
+    delegate.request(requestVideoBookingRequest, COURT_USER)
+
+    verify(requestBookingService).request(requestVideoBookingRequest, COURT_USER)
+
+    verifyNoInteractions(createCourtBookingService, createProbationBookingService, amendCourtBookingService, cancelVideoBookingService)
+  }
+
+  @Test
+  fun `should fail when start date is too far into the future`() {
+    val futureDate = LocalDate.now().plusDays(maxDaysIntoFuture + 1)
+
+    val functions = listOf<() -> Unit>(
+      { delegate.create(courtBookingRequest(date = futureDate), COURT_USER) },
+      { delegate.amend(1, amendCourtBookingRequest(appointmentDate = futureDate), COURT_USER) },
+      { delegate.request(requestProbationVideoLinkRequest(date = futureDate), COURT_USER) },
+    )
+
+    functions.forEach {
+      assertThrows<ValidationException> { it.invoke() }.message isEqualTo "Start date cannot be more than $maxDaysIntoFuture days into the future"
+    }
   }
 }


### PR DESCRIPTION
This change brings the API inline with A&A appointment validation which prevents bookings from being too far into the future.

Given this is an edge case and we have only seen this happen once we have chosen the path of least resistance here and just put the enforcement in the API only and not the UI's. Doing in the UI's as well would require 3 services to be changed.

What users will see in the UI when they try and save:

![validation](https://github.com/user-attachments/assets/0a5585b6-9f8e-41b1-b4e2-19cbeec4eba0)
