### PR TITLE
BAVL-975 small change to error message for date check to be in sync with UI fields names. Also removed unnecessary override param value.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegate.kt
@@ -23,10 +23,14 @@ class VideoBookingServiceDelegate(
   private val amendProbationBookingService: AmendProbationBookingService,
   private val cancelVideoBookingService: CancelVideoBookingService,
   private val requestBookingService: RequestBookingService,
-  @Value("\${applications.max-appointment-start-date-from-today:1000}") private val maxStartDateOffsetDays: Long = 1000,
+  @Value("\${applications.max-appointment-start-date-from-today:1000}") private val maxStartDateOffsetDays: Long,
 ) {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  init {
+    log.info("BOOKING DELEGATE: max start date offset set to $maxStartDateOffsetDays days.")
   }
 
   @Transactional
@@ -68,7 +72,7 @@ class VideoBookingServiceDelegate(
 
   private fun checkStartDateNotTooFarInFuture(startDate: LocalDate) {
     if (startDate > LocalDate.now().plusDays(maxStartDateOffsetDays)) {
-      throw ValidationException("Start date cannot be more than $maxStartDateOffsetDays days into the future")
+      throw ValidationException("Date cannot be more than $maxStartDateOffsetDays days into the future")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegateTest.kt
@@ -93,7 +93,7 @@ class VideoBookingServiceDelegateTest {
     )
 
     functions.forEach {
-      assertThrows<ValidationException> { it.invoke() }.message isEqualTo "Start date cannot be more than $maxDaysIntoFuture days into the future"
+      assertThrows<ValidationException> { it.invoke() }.message isEqualTo "Date cannot be more than $maxDaysIntoFuture days into the future"
     }
   }
 }


### PR DESCRIPTION
Refactored so error message field name inline with the field name used for 'date' in the UI's.