### PR TITLE
BAVL-949 it is now safe to remove the comments field as all data has been migrated accross to the notes_for_staff field.

### DIFF
--- a/src/main/resources/migrations/common/V2025.07.11__remove_comments_fields.sql
+++ b/src/main/resources/migrations/common/V2025.07.11__remove_comments_fields.sql
@@ -1,0 +1,3 @@
+ALTER TABLE video_booking DROP COLUMN IF EXISTS comments;
+ALTER TABLE prison_appointment DROP COLUMN IF EXISTS comments;
+

--- a/src/test/resources/integration-test-data/seed-bookings-happening-today.sql
+++ b/src/test/resources/integration-test-data/seed-bookings-happening-today.sql
@@ -1,9 +1,9 @@
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (1000, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (1000, 17, '123456', 'VLB_COURT_MAIN', 'comments about the hearing', 'b13f9018-f22d-456f-a690-d80e3d0feb5f'::uuid, current_date, '12:00', '13:00');
 
-insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time)
 values (1001, 'PROBATION', 'ACTIVE', 1, 'PSR', 'comments about the meeting', 'test_user', current_timestamp);
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (1001, 17, '123456', 'VLB_PROBATION', 'comments about the meeting', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, current_date, '12:00', '13:00');

--- a/src/test/resources/integration-test-data/seed-bookings-happening-tomorrow.sql
+++ b/src/test/resources/integration-test-data/seed-bookings-happening-tomorrow.sql
@@ -1,9 +1,9 @@
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (1000, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (1000, 67, '123456', 'VLB_COURT_MAIN', 'comments about the hearing', '103f3f31-4cc7-4c71-aa32-994b3de471b1'::uuid, current_date + 1, '12:00', '13:00');
 
-insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time)
 values (1001, 'PROBATION', 'ACTIVE', 1, 'PSR', 'comments about the meeting', 'test_user', current_timestamp);
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (1001, 67, '123456', 'VLB_PROBATION', 'comments about the meeting', '103f3f31-4cc7-4c71-aa32-994b3de471b1'::uuid, current_date + 1, '12:00', '13:00');

--- a/src/test/resources/integration-test-data/seed-cancelled-booking-for-tomorrow.sql
+++ b/src/test/resources/integration-test-data/seed-cancelled-booking-for-tomorrow.sql
@@ -1,4 +1,4 @@
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (4000, 'COURT', 'CANCELLED', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (4000, 33, '78910', 'VLB_COURT_MAIN', 'comments about the hearing', 'ba0df03b-7864-47d5-9729-0301b74ecbe2'::uuid, current_date + 1, '9:00', '10:00');

--- a/src/test/resources/integration-test-data/seed-court-events-by-hearing-date-data-extract.sql
+++ b/src/test/resources/integration-test-data/seed-court-events-by-hearing-date-data-extract.sql
@@ -1,28 +1,28 @@
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (-1000, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'court_user', '2024-07-24T01:00:00');
 
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (-1000, 1, 'ABCDEF', 'VLB_COURT_MAIN', 'comments about the hearing', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '2100-07-24', '12:00', '13:00');
 
-insert into booking_history(booking_history_id, video_booking_id, history_type, court_id, hearing_type, comments, created_by, created_time)
+insert into booking_history(booking_history_id, video_booking_id, history_type, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (-1000, -1000, 'CREATE', 1, 'TRIBUNAL','comments about the hearing', 'court_user', '2024-07-24T01:00:00');
 
 insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)
 values (-1000, 'PVI', 'ABCDEF', '2100-07-24', 'VLB_COURT_MAIN', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '12:00', '13:00');
 
-insert into booking_history(booking_history_id, video_booking_id, history_type, court_id, hearing_type, comments, created_by, created_time)
+insert into booking_history(booking_history_id, video_booking_id, history_type, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (-1100, -1000, 'AMEND', 1, 'APPEAL','comments about the hearing', 'court_user', '2024-07-24T02:00:00');
 
 insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)
 values (-1100, 'PVI', 'ABCDEF', '2100-07-25', 'VLB_COURT_MAIN', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '12:00', '13:00');
 
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time, migrated_description, video_url)
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time, migrated_description, video_url)
 values (-2000, 'COURT', 'ACTIVE', 409, 'TRIBUNAL', 'comments about the hearing', 'court_user', '2024-07-24T01:00:00', 'Free text court name', 'cvp-link');
 
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (-2000, 1, 'ABCDEF', 'VLB_COURT_MAIN', 'comments about the hearing', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '2100-07-24', '12:00', '13:00');
 
-insert into booking_history(booking_history_id, video_booking_id, history_type, court_id, hearing_type, comments, created_by, created_time)
+insert into booking_history(booking_history_id, video_booking_id, history_type, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (-2000, -2000, 'CREATE',409, 'TRIBUNAL','comments about the hearing', 'court_user', '2024-07-24T01:00:00');
 
 insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)

--- a/src/test/resources/integration-test-data/seed-events-by-booking-date-data-extract.sql
+++ b/src/test/resources/integration-test-data/seed-events-by-booking-date-data-extract.sql
@@ -1,22 +1,22 @@
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time, hmcts_number)
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time, hmcts_number)
 values (-2000, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'court_user', '2024-01-01T01:00:00', '54321');
 
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (-2000, 1, 'ABCDEF', 'VLB_COURT_MAIN', 'comments about the hearing', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '2099-01-24', '12:00', '13:00');
 
-insert into booking_history(booking_history_id, video_booking_id, history_type, court_id, hearing_type, comments, created_by, created_time)
+insert into booking_history(booking_history_id, video_booking_id, history_type, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (-2000, -2000, 'CREATE', 1, 'TRIBUNAL','comments about the hearing', 'court_user', '2024-01-01T01:00:00');
 
 insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)
 values (-2000, 'PVI', 'ABCDEF', '2099-01-24', 'VLB_COURT_MAIN', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '12:00', '13:00');
 
-insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time)
 values (-3000, 'PROBATION', 'ACTIVE', 1, 'PSR', 'comments about the meeting', 'probation_user', '2024-01-01T01:00:00');
 
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (-3000, 1, 'ABCDEF', 'VLB_PROBATION', 'comments about the meeting', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '2099-01-24', '16:00', '17:00');
 
-insert into booking_history(booking_history_id, video_booking_id, history_type, probation_team_id, probation_meeting_type, comments, created_by, created_time)
+insert into booking_history(booking_history_id, video_booking_id, history_type, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time)
 values (-3000, -3000, 'CREATE', 1, 'PSR','comments about the meeting', 'probation_user', '2024-01-01T01:00:00');
 
 insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)

--- a/src/test/resources/integration-test-data/seed-historic-booking.sql
+++ b/src/test/resources/integration-test-data/seed-historic-booking.sql
@@ -1,5 +1,5 @@
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (-3, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
 
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (-3, 1, 'ABCDEF', 'VLB_COURT_MAIN', 'comments about the hearing', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, current_date - 1, '12:00', '13:00');

--- a/src/test/resources/integration-test-data/seed-migrated-bookings.sql
+++ b/src/test/resources/integration-test-data/seed-migrated-bookings.sql
@@ -1,9 +1,9 @@
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time, migrated_video_booking_id)
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time, migrated_video_booking_id)
 values (1002, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp, 10001);
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (1002, 17, '123456', 'VLB_COURT_MAIN', 'comments about the hearing', 'b13f9018-f22d-456f-a690-d80e3d0feb5f'::uuid, current_date + 1, '12:00', '13:00');
 
-insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, comments, created_by, created_time, migrated_video_booking_id)
+insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time, migrated_video_booking_id)
 values (1003, 'PROBATION', 'ACTIVE', 1, 'PSR', 'comments about the meeting', 'test_user', current_timestamp, 10002);
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (1003, 17, '123456', 'VLB_PROBATION', 'comments about the meeting', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, current_date + 1, '12:00', '13:00');

--- a/src/test/resources/integration-test-data/seed-prisoner-merge.sql
+++ b/src/test/resources/integration-test-data/seed-prisoner-merge.sql
@@ -1,22 +1,22 @@
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (-100, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
 
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (-100, 1, 'OLD123', 'VLB_COURT_MAIN', 'comments about the hearing', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, current_date, '12:00', '13:00');
 
-insert into booking_history (booking_history_id, video_booking_id, history_type, court_id, hearing_type, comments, created_by, created_time)
+insert into booking_history (booking_history_id, video_booking_id, history_type, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (-1, -100, 'CREATE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
 
 insert into booking_history_appointment(booking_history_appointment_id, booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)
 values (-1, -1, 'PVI', 'OLD123', current_date, 'VLB_COURT_MAIN', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '12:00', '13:00');
 
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (-200, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
 
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (-200, 2, 'OLD123', 'VLB_COURT_MAIN', 'comments about the hearing', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, current_date, '09:00', '10:00');
 
-insert into booking_history (booking_history_id, video_booking_id, history_type, court_id, hearing_type, comments, created_by, created_time)
+insert into booking_history (booking_history_id, video_booking_id, history_type, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (-2, -200, 'CREATE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
 
 insert into booking_history_appointment(booking_history_appointment_id, booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)

--- a/src/test/resources/integration-test-data/seed-probation-events-by-meeting-date-data.sql
+++ b/src/test/resources/integration-test-data/seed-probation-events-by-meeting-date-data.sql
@@ -1,23 +1,23 @@
 
-insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time)
 values (-4000, 'PROBATION', 'ACTIVE', 1, 'PSR', 'comments about the meeting', 'probation_user', '2024-01-01T01:00:00');
 
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (-4000, 1, 'ABCDEF', 'VLB_PROBATION', 'comments about the meeting', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '2099-01-25', '16:00', '17:00');
 
-insert into booking_history(booking_history_id, video_booking_id, history_type, probation_team_id, probation_meeting_type, comments, created_by, created_time)
+insert into booking_history(booking_history_id, video_booking_id, history_type, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time)
 values (-4000, -4000, 'CREATE', 1, 'PSR','comments about the meeting', 'probation_user', '2024-01-01T01:00:00');
 
 insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)
 values (-4000, 'PVI', 'ABCDEF', '2099-01-25', 'VLB_PROBATION', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '16:00', '17:00');
 
-insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, comments, created_by, created_time, migrated_description)
+insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time, migrated_description)
 values (-4100, 'PROBATION', 'ACTIVE', 28, 'PSR', 'comments about the meeting', 'probation_user', '2024-01-01T01:00:00', 'Free text probation team name');
 
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (-4100, 1, 'DEFGHI', 'VLB_PROBATION', 'comments about the meeting', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '2099-01-25', '16:00', '17:00');
 
-insert into booking_history(booking_history_id, video_booking_id, history_type, probation_team_id, probation_meeting_type, comments, created_by, created_time)
+insert into booking_history(booking_history_id, video_booking_id, history_type, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time)
 values (-4100, -4100, 'CREATE', 28, 'PSR','comments about the meeting', 'probation_user', '2024-01-01T01:00:00');
 
 insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)

--- a/src/test/resources/integration-test-data/seed-search-for-booking.sql
+++ b/src/test/resources/integration-test-data/seed-search-for-booking.sql
@@ -1,19 +1,19 @@
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (1000, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (1000, 17, '123456', 'VLB_COURT_MAIN', 'comments about the hearing', 'b13f9018-f22d-456f-a690-d80e3d0feb5f'::uuid, current_date, '12:00', '13:00');
 
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (2000, 'COURT', 'CANCELLED', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp - interval '1 second');
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (2000, 17, '78910', 'VLB_COURT_MAIN', 'comments about the hearing', 'ba0df03b-7864-47d5-9729-0301b74ecbe2'::uuid, current_date + 1, '9:00', '10:00');
 
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (3000, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (3000, 17, '78910', 'VLB_COURT_MAIN', 'comments about the hearing', 'ba0df03b-7864-47d5-9729-0301b74ecbe2'::uuid, current_date + 1, '9:00', '10:00');
 
-insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, comments, created_by, created_time)
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
 values (4000, 'COURT', 'CANCELLED', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
-insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, comments, prison_location_id, appointment_date,  start_time, end_time)
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
 values (4000, 17, '78910', 'VLB_COURT_MAIN', 'comments about the hearing', 'ba0df03b-7864-47d5-9729-0301b74ecbe2'::uuid, current_date + 1, '9:00', '10:00');


### PR DESCRIPTION
It is now safe to remove this field as it is no longer used inside or outside the API.

It has been superseded by notes_for_staff.

All old comments data has been moved across to the notes_for_staff in production.