### PR TITLE
BAVL-1001 add admin emails for dev namespace for manual testing of job (no cron in place yet).

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,6 +19,10 @@ generic-service:
     API_BASE_URL_NOMIS_MAPPING: "https://nomis-sync-prisoner-mapping-dev.hmpps.service.justice.gov.uk"
     BVLS_FRONTEND_URL: "https://book-a-video-link-dev.prison.service.justice.gov.uk"
 
+  namespace_secrets:
+    administration:
+      EMAILS: "EMAILS"
+
   allowlist:
     groups:
       - internal

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/administration/AdministrationEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/administration/AdministrationEmailService.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.NotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.PrisonsService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.LocationsService
-import kotlin.onSuccess
 
 @Service
 class AdministrationEmailService(
@@ -49,6 +48,8 @@ class AdministrationEmailService(
                 reason = "NEW_PRISON_VIDEO_ROOM",
               ),
             )
+          }.onFailure {
+            log.info("ADMINISTRATION_EMAIL: failed to send email for new prison video room.")
           }
         }
       }

--- a/utility/add-admin-emails.sh
+++ b/utility/add-admin-emails.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+ENV=$1
+EMAILS=$2
+
+# Temporarily disable any prod runs
+if [ "$ENV" = "prod" ]; then
+  echo "Prod is currently disabled."
+  return 1 2> /dev/null || exit 1
+fi
+
+while true; do
+
+echo
+read -r -p "You are about add admin emails '$EMAILS' to the BVLS service in '$ENV' environment. Do you want to proceed? (y/n) " yn
+
+case $yn in
+	[yY] ) echo ok, proceeding...;
+		break;;
+	[nN] ) echo exiting...;
+		exit;;
+	* ) echo invalid response;;
+esac
+done
+
+NAMESPACE="hmpps-book-a-video-link-$ENV"
+SECRETS_FILE="book-a-video-link-secrets.yaml"
+
+# Create the secrets YAML file
+cat <<EOF > $SECRETS_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: administration
+  namespace: $NAMESPACE
+type: Opaque
+stringData:
+  EMAILS: "$EMAILS"
+EOF
+
+# Apply the secret
+kubectl apply -f ./$SECRETS_FILE
+echo
+echo "Applied secrets to $NAMESPACE"
+
+rm -f ./$SECRETS_FILE
+
+# Restart the deployment pods
+echo
+echo "Restarting BVLS API deployment in namespace $NAMESPACE"
+kubectl -n "$NAMESPACE" rollout restart deployments/hmpps-book-a-video-link-api


### PR DESCRIPTION
Setting up API to read dev namespace env vars for admin emails job for manual testing of job in dev.

The cron to run the job is not yet needed.