### PR TITLE
BAVL-1010: Endpoint to provide room configuration data as CSV extract

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/CsvDataExtractionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/CsvDataExtractionController.kt
@@ -108,7 +108,7 @@ class CsvDataExtractionController(private val service: CsvDataExtractionService)
   @Operation(description = "Return room decoration data for all active prisons in BVLS.")
   @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN')")
   fun downloadPrisonRoomConfigurationData(): ResponseEntity<StreamingResponseBody> = streamedCsvResponse(
-    "prison-room-configuration.csv",
+    "prison-room-configuration-${LocalDate.now().toIsoDate()}.csv",
   ) { os -> service.prisonRoomConfigurationToCsv(os) }
 
   private fun streamedCsvResponse(startDate: LocalDate, days: Long, filename: String, block: (outputStream: OutputStream) -> Unit): ResponseEntity<StreamingResponseBody> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CsvDataExtractionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CsvDataExtractionIntegrationTest.kt
@@ -6,6 +6,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toIsoDate
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.LocationKeyValue
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.contains
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.pentonvilleLocation
@@ -18,6 +19,17 @@ class CsvDataExtractionIntegrationTest : IntegrationTestBase() {
   @BeforeEach
   fun before() {
     locationsInsidePrisonApi().stubNonResidentialAppointmentLocationsAtPrison(PENTONVILLE, pentonvilleLocation.copy(id = UUID.fromString("926d8f38-7149-4fda-b51f-85abcbcb0d00"), leafLevel = false))
+
+    // Stub for room configuration download - to match SQL-loaded data for the test
+    locationsInsidePrisonApi().stubVideoLinkLocationsAtPrison(
+      listOf(
+        LocationKeyValue("ROOM-1", UUID.fromString("e58ed763-928c-4155-bee9-aaaaaaaaaaaa")),
+        LocationKeyValue("ROOM-2", UUID.fromString("e58ed763-928c-4155-bee9-bbbbbbbbbbbb")),
+        LocationKeyValue("ROOM-3", UUID.fromString("e58ed763-928c-4155-bee9-cccccccccccc")),
+      ),
+      true,
+      "BMI",
+    )
   }
 
   @Sql("classpath:integration-test-data/seed-court-events-by-hearing-date-data-extract.sql")
@@ -66,6 +78,19 @@ class CsvDataExtractionIntegrationTest : IntegrationTestBase() {
       .jsonPath("developerMessage").isEqualTo("CSV extracts are limited to a years worth of data.")
   }
 
+  @Sql("classpath:test_data/clean-all-data.sql", "classpath:integration-test-data/seed-BMI-decorated-locations.sql")
+  @Test
+  fun `should download prison room configuration data CSV`() {
+    val roomData = webTestClient.downloadRoomConfigurationData()
+
+    roomData contains "prisonCode,prisonDescription,roomKey,roomDescription,roomVideoLink,roomSetup,roomStatus,permission,allowedParties,schedule\n"
+    roomData contains "BMI,\"Birmingham (HMP)\",ROOM-1,\"BMI ROOM-1\",/link/1,Customised,Active,Court,,No\n"
+    roomData contains "BMI,\"Birmingham (HMP)\",ROOM-2,\"BMI ROOM-2\",/link/2,Customised,Active,Probation,,No\n"
+    roomData contains "BMI,\"Birmingham (HMP)\",ROOM-3,\"BMI ROOM-3\",/link/3,Customised,Active,Schedule,,\"Monday-Thursday 09:00-17:00 Court \"\n"
+    roomData contains "BMI,\"Birmingham (HMP)\",ROOM-3,\"BMI ROOM-3\",/link/3,Customised,Active,Schedule,,\"Friday-Friday 09:00-17:00 Probation \"\n"
+    roomData contains "BMI,\"Birmingham (HMP)\",ROOM-3,\"BMI ROOM-3\",/link/3,Customised,Active,Schedule,,\"Saturday-Sunday 09:00-17:00 Blocked \"\n"
+  }
+
   private fun WebTestClient.badRequestWhenRequestTooManyDaysOfData() = this
     .get()
     .uri("/download-csv/court-data-by-hearing-date?start-date=2024-07-30&days=366")
@@ -108,6 +133,18 @@ class CsvDataExtractionIntegrationTest : IntegrationTestBase() {
   private fun WebTestClient.downloadProbationDataByMeetingDate(startDate: LocalDate, days: Long) = this
     .get()
     .uri("/download-csv/probation-data-by-meeting-date?start-date={startDate}&days={days}", startDate.toIsoDate(), days)
+    .accept(MediaType.parseMediaType("text/csv"), MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(roles = listOf("ROLE_BOOK_A_VIDEO_LINK_ADMIN")))
+    .exchange()
+    .expectStatus().isOk
+    .expectHeader().contentType(MediaType.parseMediaType("text/csv"))
+    .expectBody()
+    .returnResult()
+    .toString()
+
+  private fun WebTestClient.downloadRoomConfigurationData() = this
+    .get()
+    .uri("/download-csv/prison-room-configuration-data")
     .accept(MediaType.parseMediaType("text/csv"), MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(roles = listOf("ROLE_BOOK_A_VIDEO_LINK_ADMIN")))
     .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CsvDataExtractionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CsvDataExtractionServiceTest.kt
@@ -21,13 +21,16 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.today
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationScheduleUsage
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationUsage
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.RoomAttributes
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.RoomSchedule
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingEventRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.LocationsService
 import java.io.ByteArrayOutputStream
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -264,25 +267,53 @@ class CsvDataExtractionServiceTest {
 
     csvOutputStream.toString() isEqualTo
       "prisonCode,prisonDescription,roomKey,roomDescription,roomVideoLink,roomSetup,roomStatus,permission,schedule\n" +
-      "MDI,\"HMP Moorland\",MDI-RM-1,\"Room 1\",/video-link-url,Customised,Active,Shared,No\n"
+      "MDI,\"HMP Moorland\",MDI-RM-1,\"Room 1\",/video-link-url,Customised,Active,Schedule,\"Monday-Tuesday 10:00-11:00 Court (ABERCV)\"\n" +
+      "MDI,\"HMP Moorland\",MDI-RM-1,\"Room 1\",/video-link-url,Customised,Active,Schedule,\"Wednesday-Thursday 10:00-11:00 Probation (BARNET)\"\n" +
+      "MDI,\"HMP Moorland\",MDI-RM-2,\"Room 2\",/video-link-url,Customised,Active,Schedule,\"Monday-Tuesday 10:00-11:00 Court (ABERCV)\"\n" +
+      "MDI,\"HMP Moorland\",MDI-RM-2,\"Room 2\",/video-link-url,Customised,Active,Schedule,\"Wednesday-Thursday 10:00-11:00 Probation (BARNET)\"\n"
   }
 
   private val listOfPrisons = listOf(
     Prison(prisonId = 1L, code = "MDI", name = "HMP Moorland", enabled = true, notes = null),
   )
 
-  private val roomAttributes = RoomAttributes(
+  private val roomSchedules = listOf(
+    RoomSchedule(
+      scheduleId = 1L,
+      startDayOfWeek = DayOfWeek.MONDAY,
+      endDayOfWeek = DayOfWeek.TUESDAY,
+      startTime = LocalTime.of(10, 0),
+      endTime = LocalTime.of(11, 0),
+      locationUsage = LocationScheduleUsage.COURT,
+      allowedParties = listOf("ABERCV"),
+    ),
+    RoomSchedule(
+      scheduleId = 2L,
+      startDayOfWeek = DayOfWeek.WEDNESDAY,
+      endDayOfWeek = DayOfWeek.THURSDAY,
+      startTime = LocalTime.of(10, 0),
+      endTime = LocalTime.of(11, 0),
+      locationUsage = LocationScheduleUsage.PROBATION,
+      allowedParties = listOf("BARNET"),
+    ),
+  )
+
+  private val roomAttributes1 = RoomAttributes(
     attributeId = 1L,
     locationStatus = LocationStatus.ACTIVE,
-    locationUsage = LocationUsage.SHARED,
+    locationUsage = LocationUsage.SCHEDULE,
     prisonVideoUrl = "/video-link-url",
     allowedParties = emptyList(),
     notes = null,
     expectedActiveDate = null,
     statusMessage = null,
+    schedule = roomSchedules,
   )
 
+  private val roomAttributes2 = roomAttributes1.copy(attributeId = 2L)
+
   private val locationsAtMoorland = listOf(
-    Location(dpsLocationId = UUID.randomUUID(), key = "MDI-RM-1", prisonCode = "MDI", description = "Room 1", enabled = true, extraAttributes = roomAttributes),
+    Location(dpsLocationId = UUID.randomUUID(), key = "MDI-RM-1", prisonCode = "MDI", description = "Room 1", enabled = true, extraAttributes = roomAttributes1),
+    Location(dpsLocationId = UUID.randomUUID(), key = "MDI-RM-2", prisonCode = "MDI", description = "Room 2", enabled = true, extraAttributes = roomAttributes2),
   )
 }

--- a/src/test/resources/integration-test-data/seed-BMI-decorated-locations.sql
+++ b/src/test/resources/integration-test-data/seed-BMI-decorated-locations.sql
@@ -1,0 +1,11 @@
+-- Used in the prisons resource integration tests for decorated prison locations
+insert into location_attribute (location_attribute_id, dps_location_id, prison_id, location_status, location_usage, prison_video_url, notes, created_by, created_time)
+values
+    (1101, 'e58ed763-928c-4155-bee9-aaaaaaaaaaaa', 33, 'ACTIVE', 'COURT', '/link/1', '', 'test', current_timestamp),
+    (1102, 'e58ed763-928c-4155-bee9-bbbbbbbbbbbb', 33, 'ACTIVE', 'PROBATION', '/link/2', '', 'test', current_timestamp),
+    (1103, 'e58ed763-928c-4155-bee9-cccccccccccc', 33, 'ACTIVE', 'SCHEDULE', '/link/3', '', 'test', current_timestamp);
+
+insert into location_schedule(location_schedule_id, location_attribute_id, start_day_of_week, end_day_of_week, start_time, end_time, location_usage, created_by, created_time)
+values (1201, 1103, 1, 4, '09:00', '17:00', 'COURT', 'test', current_timestamp),
+       (1202, 1103, 5, 5, '09:00', '17:00', 'PROBATION', 'test', current_timestamp),
+       (1203, 1103, 6, 7, '09:00', '17:00', 'BLOCKED', 'test', current_timestamp);


### PR DESCRIPTION
This PR:
* Adds an endpoint which is called via the Admin tiles of the UI to get a CSV data download.
* Extracts all active prison VIDE locations and their room decoration data
* Formats the data (repeating schedule rows for each room set to type SCHEDULE)
* Formats the schedule data into one string which describes the rules.