### PR TITLE
BAVL-1019 increase the field length for the prison video URL from 120 to 300 characters when decorating a room.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AmendDecoratedRoomRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AmendDecoratedRoomRequest.kt
@@ -19,7 +19,7 @@ data class AmendDecoratedRoomRequest(
   val allowedParties: Set<String>? = null,
 
   @Schema(description = "The prison video URL for the location, can be null", example = "HMPS123456", required = false)
-  @field:Size(max = 120, message = "Prison video URL should not exceed {max} characters")
+  @field:Size(max = 300, message = "Prison video URL should not exceed {max} characters")
   val prisonVideoUrl: String? = null,
 
   @field:Size(max = 400, message = "Comments should not exceed {max} characters")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateDecoratedRoomRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateDecoratedRoomRequest.kt
@@ -19,7 +19,7 @@ data class CreateDecoratedRoomRequest(
   val allowedParties: Set<String>? = null,
 
   @Schema(description = "The prison video URL for the location, can be null", example = "HMPS123456", required = false)
-  @field:Size(max = 120, message = "Prison video URL should not exceed {max} characters")
+  @field:Size(max = 300, message = "Prison video URL should not exceed {max} characters")
   val prisonVideoUrl: String? = null,
 
   @field:Size(max = 400, message = "Comments should not exceed {max} characters")

--- a/src/main/resources/migrations/common/V2025.07.31__alter_location_attribute.sql
+++ b/src/main/resources/migrations/common/V2025.07.31__alter_location_attribute.sql
@@ -1,0 +1,1 @@
+ALTER TABLE location_attribute ALTER COLUMN prison_video_url type VARCHAR(300);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/RoomAdministrationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/RoomAdministrationIntegrationTest.kt
@@ -158,7 +158,7 @@ class RoomAdministrationIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `should amend an existing decorated location`() {
+  fun `should create and amend an existing decorated location with a long prison video url`() {
     locationsInsidePrisonApi().stubGetLocationById(wandsworthLocation3)
 
     webTestClient.createDecoratedRoom(
@@ -166,7 +166,7 @@ class RoomAdministrationIntegrationTest : IntegrationTestBase() {
         locationUsage = ModelLocationUsage.PROBATION,
         locationStatus = ModelLocationStatus.INACTIVE,
         allowedParties = setOf("PROBATION"),
-        prisonVideoUrl = "shared-prison-video-url-3",
+        prisonVideoUrl = "x".repeat(300),
         comments = "some comments",
       ),
       wandsworthLocation3.toModel(),
@@ -178,7 +178,7 @@ class RoomAdministrationIntegrationTest : IntegrationTestBase() {
         locationUsage = ModelLocationUsage.COURT,
         locationStatus = ModelLocationStatus.ACTIVE,
         allowedParties = setOf("COURT"),
-        prisonVideoUrl = null,
+        prisonVideoUrl = "v".repeat(300),
         comments = "amended comments",
       ),
       wandsworthLocation3.toModel(),
@@ -189,7 +189,7 @@ class RoomAdministrationIntegrationTest : IntegrationTestBase() {
       locationUsage isEqualTo ModelLocationUsage.COURT
       locationStatus isEqualTo ModelLocationStatus.ACTIVE
       allowedParties containsExactlyInAnyOrder setOf("COURT")
-      prisonVideoUrl isEqualTo null
+      prisonVideoUrl isEqualTo "v".repeat(300)
       notes isEqualTo "amended comments"
     }
 
@@ -197,7 +197,7 @@ class RoomAdministrationIntegrationTest : IntegrationTestBase() {
       locationUsage isEqualTo EntityLocationUsage.COURT
       locationStatus isEqualTo EntityLocationStatus.ACTIVE
       allowedParties isEqualTo "COURT"
-      prisonVideoUrl isEqualTo null
+      prisonVideoUrl isEqualTo "v".repeat(300)
       notes isEqualTo "amended comments"
       amendedBy isEqualTo COURT_USER.username
       amendedTime isCloseTo LocalDateTime.now()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AmendDecoratedRoomRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AmendDecoratedRoomRequestTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationStatus
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationUsage
+
+class AmendDecoratedRoomRequestTest : ValidatorBase<AmendDecoratedRoomRequest>() {
+
+  private val amendRequest = AmendDecoratedRoomRequest(
+    locationUsage = LocationUsage.COURT,
+    locationStatus = LocationStatus.ACTIVE,
+    allowedParties = setOf("COURT"),
+    prisonVideoUrl = "v".repeat(300),
+    comments = "amended comments",
+  )
+
+  @Test
+  fun `should be no errors for valid request`() {
+    assertNoErrors(amendRequest)
+  }
+
+  @Test
+  fun `should fail when prison video url exceeds max allowed characters`() {
+    amendRequest.copy(prisonVideoUrl = "v".repeat(301)) failsWithSingle ModelError("prisonVideoUrl", "Prison video URL should not exceed 300 characters")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateDecoratedRoomRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateDecoratedRoomRequestTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationStatus
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationUsage
+
+class CreateDecoratedRoomRequestTest : ValidatorBase<CreateDecoratedRoomRequest>() {
+
+  private val createRequest = CreateDecoratedRoomRequest(
+    locationUsage = LocationUsage.COURT,
+    locationStatus = LocationStatus.ACTIVE,
+    allowedParties = setOf("COURT"),
+    prisonVideoUrl = "v".repeat(300),
+    comments = "amended comments",
+  )
+
+  @Test
+  fun `should be no errors for valid request`() {
+    assertNoErrors(createRequest)
+  }
+
+  @Test
+  fun `should fail when prison video url exceeds max allowed characters`() {
+    createRequest.copy(prisonVideoUrl = "v".repeat(301)) failsWithSingle ModelError("prisonVideoUrl", "Prison video URL should not exceed 300 characters")
+  }
+}


### PR DESCRIPTION
Increasing the length of the prison video URL to allow for long URL's needed at some prisons.