### PR TITLE
BAVL-1023 adds the probation officer name and email address where present to the probation CSV extracts.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingEvent.kt
@@ -72,4 +72,8 @@ data class VideoBookingEvent(
   val user: String,
 
   val cvpLink: String? = null,
+
+  val probationOfficerName: String? = null,
+
+  val probationOfficerEmail: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CsvDataExtractionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CsvDataExtractionService.kt
@@ -308,6 +308,8 @@ data class CourtBookingEvent(
   "postLocationName",
   "meetingType",
   "user",
+  "probationOfficerName",
+  "probationOfficerEmail",
 )
 data class ProbationBookingEvent(
   val eventId: Long,
@@ -329,6 +331,8 @@ data class ProbationBookingEvent(
   val postLocationName: String?,
   val meetingType: String,
   val user: String,
+  val probationOfficerName: String?,
+  val probationOfficerEmail: String?,
 ) {
   constructor(vbe: VideoBookingEvent, locations: Set<Location>) : this(
     vbe.eventId,
@@ -363,6 +367,8 @@ data class ProbationBookingEvent(
     null,
     vbe.type,
     vbe.user,
+    vbe.probationOfficerName ?: "Not known",
+    vbe.probationOfficerEmail ?: "Not known",
   )
 }
 

--- a/src/main/resources/migrations/common/R__v_video_booking_event.sql
+++ b/src/main/resources/migrations/common/R__v_video_booking_event.sql
@@ -29,7 +29,9 @@ select
   true as court_booking,
   rc.description as type,
   bh.created_by as "user",
-  coalesce(vlb.hmcts_number, vlb.video_url) as cvp_link
+  coalesce(vlb.hmcts_number, vlb.video_url) as cvp_link,
+  null as probation_officer_name,
+  null as probation_officer_email
 from video_booking vlb
   join booking_history bh on bh.video_booking_id = vlb.video_booking_id
   join booking_history_appointment bha_main on bha_main.booking_history_id = bh.booking_history_id and bha_main.appointment_type = 'VLB_COURT_MAIN'
@@ -66,10 +68,13 @@ select
     false as court_booking,
     rc.description as type,
     bh.created_by as "user",
-    null as cvp_link
+    null as cvp_link,
+    abd.contact_name as probation_officer_name,
+    abd.contact_email as probation_officer_email
 from video_booking vlb
   join booking_history bh on bh.video_booking_id = vlb.video_booking_id
   join booking_history_appointment bha_main on bha_main.booking_history_id = bh.booking_history_id and bha_main.appointment_type = 'VLB_PROBATION'
   join probation_team p on p.probation_team_id = vlb.probation_team_id
   join reference_code rc on rc.group_code = 'PROBATION_MEETING_TYPE' and rc.code = bh.probation_meeting_type
+  left join additional_booking_detail abd on abd.video_booking_id = vlb.video_booking_id
 where vlb.probation_team_id is not null;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CsvDataExtractionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CsvDataExtractionIntegrationTest.kt
@@ -54,8 +54,8 @@ class CsvDataExtractionIntegrationTest : IntegrationTestBase() {
     val probationResponse = webTestClient.downloadProbationDataByBookingDate(LocalDate.of(2024, 1, 1), 2)
 
     probationResponse contains "video-links-by-probation-booking-date-from-2024-01-01-for-2-days.csv"
-    probationResponse contains "eventId,timestamp,videoLinkBookingId,eventType,agencyId,probationTeam,probationTeamId,madeByProbation,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,meetingType,user\n"
-    probationResponse contains "-3000,2024-01-01T01:00:00,-3000,CREATE,PVI,\"Blackpool Magistrates - Probation\",BLKPPP,true,2099-01-24T16:00:00,2099-01-24T17:00:00,,,,,\"Pentonville room 3\",,,\"Pre-sentence report\",probation_user"
+    probationResponse contains "eventId,timestamp,videoLinkBookingId,eventType,agencyId,probationTeam,probationTeamId,madeByProbation,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,meetingType,user,probationOfficerName,probationOfficerEmail\n"
+    probationResponse contains "-3000,2024-01-01T01:00:00,-3000,CREATE,PVI,\"Blackpool Magistrates - Probation\",BLKPPP,true,2099-01-24T16:00:00,2099-01-24T17:00:00,,,,,\"Pentonville room 3\",,,\"Pre-sentence report\",probation_user,\"Not known\",\"Not known\""
   }
 
   @Sql("classpath:integration-test-data/seed-probation-events-by-meeting-date-data.sql")
@@ -64,9 +64,9 @@ class CsvDataExtractionIntegrationTest : IntegrationTestBase() {
     val probationResponse = webTestClient.downloadProbationDataByMeetingDate(LocalDate.of(2099, 1, 25), 365)
 
     probationResponse contains "video-links-by-probation-meeting-date-from-2099-01-25-for-365-days.csv"
-    probationResponse contains "eventId,timestamp,videoLinkBookingId,eventType,agencyId,probationTeam,probationTeamId,madeByProbation,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,meetingType,user\n"
-    probationResponse contains "-4100,2024-01-01T01:00:00,-4100,CREATE,PVI,\"Free text probation team name\",UNKNOWN,true,2099-01-25T16:00:00,2099-01-25T17:00:00,,,,,\"Pentonville room 3\",,,\"Pre-sentence report\",probation_user\n"
-    probationResponse contains "-4000,2024-01-01T01:00:00,-4000,CREATE,PVI,\"Blackpool Magistrates - Probation\",BLKPPP,true,2099-01-25T16:00:00,2099-01-25T17:00:00,,,,,\"Pentonville room 3\",,,\"Pre-sentence report\",probation_user\n"
+    probationResponse contains "eventId,timestamp,videoLinkBookingId,eventType,agencyId,probationTeam,probationTeamId,madeByProbation,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,meetingType,user,probationOfficerName,probationOfficerEmail\n"
+    probationResponse contains "-4100,2024-01-01T01:00:00,-4100,CREATE,PVI,\"Free text probation team name\",UNKNOWN,true,2099-01-25T16:00:00,2099-01-25T17:00:00,,,,,\"Pentonville room 3\",,,\"Pre-sentence report\",probation_user,\"Not known\",\"Not known\"\n"
+    probationResponse contains "-4000,2024-01-01T01:00:00,-4000,CREATE,PVI,\"Blackpool Magistrates - Probation\",BLKPPP,true,2099-01-25T16:00:00,2099-01-25T17:00:00,,,,,\"Pentonville room 3\",,,\"Pre-sentence report\",probation_user,\"officer name\",officer@email.com\n"
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CsvDataExtractionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CsvDataExtractionServiceTest.kt
@@ -88,13 +88,13 @@ class CsvDataExtractionServiceTest {
   )
   private val wandsworthCancelCourtBookingEvent = wandsworthCreateCourtBookingEvent.copy(eventType = "CANCEL")
   private val wandsworthAmendCourtBookingEvent = wandsworthCreateCourtBookingEvent.copy(eventType = "AMEND")
-  private val wandsworthCreateProbationBookingEvent = wandsworthCreateCourtBookingEvent.copy(courtDescription = null, courtCode = null, probationTeamCode = "probation code", probationTeamDescription = "probation team description", courtBooking = false, type = "Pre-sentence report", user = "probation_user")
+  private val wandsworthCreateProbationBookingEvent = wandsworthCreateCourtBookingEvent.copy(courtDescription = null, courtCode = null, probationTeamCode = "probation code", probationTeamDescription = "probation team description", courtBooking = false, type = "Pre-sentence report", user = "probation_user", probationOfficerName = "wandsworth officer name", probationOfficerEmail = "wandsworth_officer@email.com")
   private val wandsworthCancelProbationBooking = wandsworthCreateProbationBookingEvent.copy(eventType = "CANCEL")
   private val wandsworthAmendProbationBooking = wandsworthCreateProbationBookingEvent.copy(eventType = "AMEND")
   private val wandsworthPrisonCourtBooking = wandsworthCreateCourtBookingEvent.copy(createdByPrison = true)
   private val risleyCourtBooking = wandsworthCreateCourtBookingEvent.copy(prisonCode = RISLEY, eventType = "CANCEL", mainLocationId = risleyLocation.id, preLocationId = risleyLocation.id, postLocationId = risleyLocation.id)
   private val risleyPrisonCourtBooking = risleyCourtBooking.copy(createdByPrison = true, courtBooking = false)
-  private val risleyProbationBooking = wandsworthCreateProbationBookingEvent.copy(prisonCode = RISLEY, createdByPrison = false, mainLocationId = risleyLocation.id, preLocationId = risleyLocation.id, postLocationId = risleyLocation.id)
+  private val risleyProbationBooking = wandsworthCreateProbationBookingEvent.copy(prisonCode = RISLEY, createdByPrison = false, mainLocationId = risleyLocation.id, probationOfficerName = "risley officer name", probationOfficerEmail = "risley_officer@email.com")
 
   @BeforeEach
   fun before() {
@@ -223,8 +223,8 @@ class CsvDataExtractionServiceTest {
     verify(videoBookingEventRepository, never()).findByDateOfBookingBetween(any(), any(), any())
 
     csvOutputStream.toString() isEqualTo
-      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,probationTeam,probationTeamId,madeByProbation,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,meetingType,user\n" +
-      "1,2024-07-01T09:00:00,1,CREATE,$WANDSWORTH,\"probation team description\",\"probation code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,,,,,\"${wandsworthLocation.localName}\",,,\"Pre-sentence report\",probation_user\n"
+      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,probationTeam,probationTeamId,madeByProbation,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,meetingType,user,probationOfficerName,probationOfficerEmail\n" +
+      "1,2024-07-01T09:00:00,1,CREATE,$WANDSWORTH,\"probation team description\",\"probation code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,,,,,\"${wandsworthLocation.localName}\",,,\"Pre-sentence report\",probation_user,\"wandsworth officer name\",\"wandsworth_officer@email.com\"\n"
   }
 
   @Test
@@ -237,8 +237,8 @@ class CsvDataExtractionServiceTest {
     verify(videoBookingEventRepository, never()).findByDateOfBookingBetween(any(), any(), any())
 
     csvOutputStream.toString() isEqualTo
-      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,probationTeam,probationTeamId,madeByProbation,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,meetingType,user\n" +
-      "1,2024-07-01T09:00:00,1,DELETE,$WANDSWORTH,\"probation team description\",\"probation code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,,,,,\"${wandsworthLocation.localName}\",,,\"Pre-sentence report\",probation_user\n"
+      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,probationTeam,probationTeamId,madeByProbation,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,meetingType,user,probationOfficerName,probationOfficerEmail\n" +
+      "1,2024-07-01T09:00:00,1,DELETE,$WANDSWORTH,\"probation team description\",\"probation code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,,,,,\"${wandsworthLocation.localName}\",,,\"Pre-sentence report\",probation_user,\"wandsworth officer name\",\"wandsworth_officer@email.com\"\n"
   }
 
   @Test
@@ -251,8 +251,8 @@ class CsvDataExtractionServiceTest {
     verify(videoBookingEventRepository, never()).findByDateOfBookingBetween(any(), any(), any())
 
     csvOutputStream.toString() isEqualTo
-      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,probationTeam,probationTeamId,madeByProbation,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,meetingType,user\n" +
-      "1,2024-07-01T09:00:00,1,UPDATE,$WANDSWORTH,\"probation team description\",\"probation code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,,,,,\"${wandsworthLocation.localName}\",,,\"Pre-sentence report\",probation_user\n"
+      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,probationTeam,probationTeamId,madeByProbation,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,meetingType,user,probationOfficerName,probationOfficerEmail\n" +
+      "1,2024-07-01T09:00:00,1,UPDATE,$WANDSWORTH,\"probation team description\",\"probation code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,,,,,\"${wandsworthLocation.localName}\",,,\"Pre-sentence report\",probation_user,\"wandsworth officer name\",\"wandsworth_officer@email.com\"\n"
   }
 
   @Test
@@ -265,8 +265,8 @@ class CsvDataExtractionServiceTest {
     verify(videoBookingEventRepository, never()).findByMainDateBetween(any(), any(), any())
 
     csvOutputStream.toString() isEqualTo
-      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,probationTeam,probationTeamId,madeByProbation,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,meetingType,user\n" +
-      "1,2024-07-01T09:00:00,1,CREATE,$RISLEY,\"probation team description\",\"probation code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,,,,,\"${risleyLocation.localName}\",,,\"Pre-sentence report\",probation_user\n"
+      "eventId,timestamp,videoLinkBookingId,eventType,agencyId,probationTeam,probationTeamId,madeByProbation,mainStartTime,mainEndTime,preStartTime,preEndTime,postStartTime,postEndTime,mainLocationName,preLocationName,postLocationName,meetingType,user,probationOfficerName,probationOfficerEmail\n" +
+      "1,2024-07-01T09:00:00,1,CREATE,$RISLEY,\"probation team description\",\"probation code\",true,2024-07-10T10:00:00,2024-07-10T11:00:00,,,,,\"${risleyLocation.localName}\",,,\"Pre-sentence report\",probation_user,\"risley officer name\",risley_officer@email.com\n"
   }
 
   @Test

--- a/src/test/resources/integration-test-data/seed-probation-events-by-meeting-date-data.sql
+++ b/src/test/resources/integration-test-data/seed-probation-events-by-meeting-date-data.sql
@@ -11,6 +11,9 @@ values (-4000, -4000, 'CREATE', 1, 'PSR','comments about the meeting', 'probatio
 insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)
 values (-4000, 'PVI', 'ABCDEF', '2099-01-25', 'VLB_PROBATION', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '16:00', '17:00');
 
+insert into additional_booking_detail(additional_booking_detail_id, video_booking_id, contact_name, contact_email)
+values (-4000, -4000, 'officer name', 'officer@email.com');
+
 insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time, migrated_description)
 values (-4100, 'PROBATION', 'ACTIVE', 28, 'PSR', 'comments about the meeting', 'probation_user', '2024-01-01T01:00:00', 'Free text probation team name');
 


### PR DESCRIPTION
This changes adds the probation officer name and email to the probation CSV extracts when present.

When not present for a booking then "Not known" will be shown instead.