### PR TITLE
BAVL-1024 tidy up validation errors for UI purposes when reporting.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/HmppsBookAVideoLinkApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/HmppsBookAVideoLinkApiExceptionHandler.kt
@@ -28,7 +28,7 @@ class HmppsBookAVideoLinkApiExceptionHandler : ResponseEntityExceptionHandler() 
     .body(
       ErrorResponse(
         status = BAD_REQUEST,
-        userMessage = "Validation failure: ${e.message}",
+        userMessage = e.message,
         developerMessage = e.message,
       ),
     ).also { log.info("Validation exception: {}", e.message) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -516,7 +516,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
 
     with(error) {
       status isEqualTo 400
-      userMessage isEqualTo "Validation failure: Prisoner 123456 not found at prison BMI"
+      userMessage isEqualTo "Prisoner 123456 not found at prison BMI"
       developerMessage isEqualTo "Prisoner 123456 not found at prison BMI"
     }
   }
@@ -725,7 +725,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
 
     with(error) {
       status isEqualTo 400
-      userMessage isEqualTo "Validation failure: Prisoner 789012 not found at prison WWI"
+      userMessage isEqualTo "Prisoner 789012 not found at prison WWI"
       developerMessage isEqualTo "Prisoner 789012 not found at prison WWI"
     }
   }


### PR DESCRIPTION
The UI shows the user error and in this situation it currently shows the following.  
<img width="1752" height="342" alt="image" src="https://github.com/user-attachments/assets/27507010-db11-4f38-a719-f2f6a98ce546" />

This change removes the `Validation failure` prefix.
