### PR TITLE
BAVL-1026 changing patch appointment call to A&A to use DPS location ID instead of the NOMIS location ID.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
@@ -120,7 +120,7 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
     startDate: LocalDate,
     startTime: LocalTime,
     endTime: LocalTime,
-    internalLocationId: Long,
+    dpsLocationId: UUID,
     comments: String?,
   ): AppointmentSeries? = activitiesAppointmentsApiWebClient.patch()
     .uri("/appointments/$appointmentId")
@@ -131,7 +131,7 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
         startDate = startDate,
         startTime = startTime.toHourMinuteStyle(),
         endTime = endTime.toHourMinuteStyle(),
-        internalLocationId = internalLocationId,
+        dpsLocationId = dpsLocationId,
         extraInformation = comments,
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ActivitiesAndAppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ActivitiesAndAppointmentsService.kt
@@ -51,7 +51,7 @@ class ActivitiesAndAppointmentsService(
       startDate = appointment.appointmentDate,
       startTime = appointment.startTime,
       endTime = appointment.endTime,
-      internalLocationId = nomisMappingService.getNomisLocationId(appointment.prisonLocationId)!!,
+      dpsLocationId = appointment.prisonLocationId,
       comments = appointment.notesForPrisoners,
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationBookingIntegrationTest.kt
@@ -306,7 +306,7 @@ class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
         startDate = tomorrow(),
         startTime = LocalTime.of(12, 0),
         endTime = LocalTime.of(13, 0),
-        internalLocationId = 1,
+        dpsLocationId = birminghamLocation.id,
         comments = null,
       )
     }
@@ -437,7 +437,7 @@ class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
         startDate = tomorrow(),
         startTime = LocalTime.of(14, 30),
         endTime = LocalTime.of(15, 30),
-        internalLocationId = 1,
+        dpsLocationId = birminghamLocation.id,
         comments = "other integration test probation prisoner notes amended",
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ActivitiesAndAppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/events/ActivitiesAndAppointmentsServiceTest.kt
@@ -82,6 +82,42 @@ class ActivitiesAndAppointmentsServiceTest {
         appointmentType = SupportedAppointmentTypes.Type.PROBATION,
       )
     }
+
+    @Test
+    fun `should patch a court appointment`() {
+      val courtBooking = courtBooking().withMainCourtPrisonAppointment()
+
+      service.patchAppointment(1, courtBooking.mainHearing()!!)
+
+      verifyNoInteractions(nomisMappingService)
+
+      verify(activitiesAppointmentsClient).patchAppointment(
+        1,
+        startDate = courtBooking.mainHearing()!!.appointmentDate,
+        startTime = courtBooking.mainHearing()!!.startTime,
+        endTime = courtBooking.mainHearing()!!.endTime,
+        dpsLocationId = courtBooking.mainHearing()!!.prisonLocationId,
+        comments = null,
+      )
+    }
+
+    @Test
+    fun `should patch a probation appointment`() {
+      val probationBooking = probationBooking().withProbationPrisonAppointment()
+
+      service.patchAppointment(1, probationBooking.probationMeeting()!!)
+
+      verifyNoInteractions(nomisMappingService)
+
+      verify(activitiesAppointmentsClient).patchAppointment(
+        1,
+        startDate = probationBooking.probationMeeting()!!.appointmentDate,
+        startTime = probationBooking.probationMeeting()!!.startTime,
+        endTime = probationBooking.probationMeeting()!!.endTime,
+        dpsLocationId = probationBooking.probationMeeting()!!.prisonLocationId,
+        comments = null,
+      )
+    }
   }
 
   @Nested


### PR DESCRIPTION
The purpose of this change is move towards using DPS location IDs instead of NOMIS locations IDs when patching appointments via the A&A API (now that A&A supports DPS location IDs).

This only changes the patch of appointments.  Search will be coming next.

