### PR TITLE
BAVL-1042 add endpoint for finding a prison by its code for use in the Daily Schedule

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/PrisonsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/PrisonsController.kt
@@ -84,4 +84,26 @@ class PrisonsController(
   } else {
     locationsService.getNonResidentialLocationsAtPrison(prisonCode, enabledOnly)
   }
+
+  @Operation(summary = "Endpoint to find a prison by its code")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Get a prison by its code",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = Prison::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  @GetMapping(value = ["/{prisonCode}"], produces = [MediaType.APPLICATION_JSON_VALUE])
+  @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN', 'BVLS_ACCESS__RW')")
+  fun getPrisonByCode(
+    @Parameter(description = "The code of the prison to be returned.")
+    @PathVariable("prisonCode", required = true) prisonCode: String,
+  ) = prisonsService.getPrison(prisonCode)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/PrisonsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/PrisonsService.kt
@@ -20,6 +20,9 @@ class PrisonsService(private val prisonRepository: PrisonRepository) {
     prisonRepository.findAllByEnabledIsTrue().toModel()
   }
 
+  fun getPrison(prisonCode: String) = prisonRepository.findByCode(prisonCode)?.toModel()
+    ?: throw EntityNotFoundException("Prison with code $prisonCode not found.")
+
   fun amend(prisonCode: String, request: AmendPrisonRequest): Prison {
     val prison = prisonRepository.findByCode(prisonCode)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/PrisonsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/PrisonsResourceIntegrationTest.kt
@@ -100,6 +100,21 @@ class PrisonsResourceIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should return a prisons by its code`() {
+    with(webTestClient.getPrison("RSI")!!) { name isEqualTo "Risley (HMP)" }
+  }
+
+  private fun WebTestClient.getPrison(prisonCode: String) = get()
+    .uri("/prisons/$prisonCode")
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(roles = listOf("ROLE_BOOK_A_VIDEO_LINK_ADMIN")))
+    .exchange()
+    .expectStatus().isOk
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody(Prison::class.java)
+    .returnResult().responseBody
+
+  @Test
   fun `should get all possible appointment locations`() {
     locationsInsidePrisonApi().stubNonResidentialAppointmentLocationsAtPrison(
       WANDSWORTH,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/PrisonsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/PrisonsServiceTest.kt
@@ -92,4 +92,20 @@ class PrisonsServiceTest {
 
     error.message isEqualTo "Prison with code UNKNOWN not found."
   }
+
+  @Test
+  fun `Should return a prison by its code`() {
+    whenever(prisonRepository.findByCode(RISLEY)) doReturn prisonEntity(1L, RISLEY, "Risley")
+
+    service.getPrison(RISLEY).name isEqualTo risleyPrison.name
+  }
+
+  @Test
+  fun `Should fail to get prison by code`() {
+    whenever(prisonRepository.findByCode("UNKNOWN")) doReturn null
+
+    val error = assertThrows<EntityNotFoundException> { service.getPrison("UNKNOWN") }
+
+    error.message isEqualTo "Prison with code UNKNOWN not found."
+  }
 }


### PR DESCRIPTION
Linked [Jira](https://dsdmoj.atlassian.net/browse/BAVL-1042) ticket.

Prior to this change the only way you could look a single prison was by looking all of them up.

As part of the the pick-up time work, the Daily Schedule will need to look an individual prison to check the state of a prisons pick-up times.