### PR TITLE
BAVL-1017: Adding 19 new probation teams

### DIFF
--- a/src/main/resources/migrations/common/V2025.08.22__new_probation_teams.sql
+++ b/src/main/resources/migrations/common/V2025.08.22__new_probation_teams.sql
@@ -1,0 +1,22 @@
+-- New probation teams
+insert into probation_team (code, description, enabled, read_only, notes, created_by, created_time)
+values
+ ( 'BEXLPM', 'Bexley Magistrates - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'BROMPM', 'Bromley Magistrates - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'CENTPC', 'Central Criminal Court - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'CITYPM', 'City of London Magistrates - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'EALIPM', 'Ealing Magistrates - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'HARRPC', 'Harrow Crown - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'UXBRPM', 'Uxbridge Magistrates - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'WILSPM', 'Willesden Magistrates - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'WOOLPC', 'Woolwich Crown - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'BASIPC', 'Basildon Crown - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'BASIPM', 'Basildon Magistrates - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'SOUTPC', 'Southend Crown - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'SOUTPM', 'Southend Magistrates - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'CHELPC', 'Chelmsford Crown - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'CHELPM', 'Chelmsford Magistrates - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'COLCPM', 'Colchester Magistrates - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'GUILPC', 'Guildford Crown - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'GUILPM', 'Guildford Magistrates - Probation', true, false, null, 'TIM', current_timestamp),
+ ( 'STAIPM', 'Staines Magistrates - Probation', true, false, null, 'TIM', current_timestamp);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationTeamsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationTeamsResourceIntegrationTest.kt
@@ -34,15 +34,15 @@ class ProbationTeamsResourceIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:integration-test-data/seed-enabled-probation-team-data.sql")
   @Test
   fun `should return filtered and unfiltered probation teams`() {
-    probationTeamRepository.findAll() hasSize 35 // Including 1 read-only team
+    probationTeamRepository.findAll() hasSize 54 // Including 1 read-only team
 
     val enabledOnlyTeams = webTestClient.getProbationTeams(true)
-    enabledOnlyTeams hasSize 32
+    enabledOnlyTeams hasSize 51
     enabledOnlyTeams.all { it.enabled } isBool true
 
     val allTeams = webTestClient.getProbationTeams(false)
-    allTeams hasSize 34
-    allTeams.count { it.enabled } isEqualTo 32
+    allTeams hasSize 53
+    allTeams.count { it.enabled } isEqualTo 51
     allTeams.count { !it.enabled } isEqualTo 2
   }
 


### PR DESCRIPTION
This adds 19 new probation teams, into all environments.
Once there I will also add the team contacts emails, but only in PREPROD and PROD - and this step is done manually to avoid any email addresses being checked-into GitHub. 