### PR TITLE
BAVL-1058: Update gradle springboot plugin to v9.0.0 and GH workflows

### DIFF
--- a/.github/workflows/security_owasp.yml
+++ b/.github/workflows/security_owasp.yml
@@ -5,8 +5,13 @@ on:
     - cron: "52 4 * * MON-FRI" # Every weekday at 04:52 UTC
 jobs:
   security-kotlin-owasp-check:
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
     name: Kotlin security OWASP dependency check
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_owasp.yml@v2 # WORKFLOW_VERSION
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
+      nvd_feed_version: '2'
     secrets: inherit

--- a/.github/workflows/security_trivy.yml
+++ b/.github/workflows/security_trivy.yml
@@ -5,6 +5,10 @@ on:
     - cron: "52 4 * * MON-FRI" # Every weekday at 04:52 UTC
 jobs:
   security-kotlin-trivy-check:
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
     name: Project security trivy dependency check
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_trivy.yml@v2 # WORKFLOW_VERSION
     with:

--- a/.github/workflows/security_veracode_pipeline_scan.yml
+++ b/.github/workflows/security_veracode_pipeline_scan.yml
@@ -5,6 +5,10 @@ on:
     - cron: "52 4 * * MON-FRI" # Every weekday at 04:52 UTC
 jobs:
   security-veracode-pipeline-scan:
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
     name: Project security veracode pipeline scan
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_pipeline_scan.yml@v2 # WORKFLOW_VERSION
     with:

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -5,6 +5,10 @@ on:
     - cron: "2 4 * * 1" # Every Monday at 04:02 UTC
 jobs:
   security-veracode-policy-check:
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
     name: Project security veracode policy scan
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_policy_scan.yml@v2 # WORKFLOW_VERSION
     with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jlleitschuh.gradle.ktlint.tasks.KtLintFormatTask
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.7"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.0.0"
   id("org.openapi.generator") version "7.14.0"
   kotlin("plugin.spring") version "2.2.10"
   kotlin("plugin.jpa") version "2.2.10"


### PR DESCRIPTION
The aim is to get the overnight Github actions security scans working with the v2 NVD feed. 
The DEV CP namespace has had its GH terraform integrations updated from v5.39.0 to v6.6.0. 