### PR TITLE
BAVL-1083 make the HTMCS clickable in emails.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactory.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingAction
 import java.util.UUID
 
+const val DEFAULT_COURT_URL_PREFIX = "https://join.meet.video.justice.gov.uk/#?conference="
 const val DEFAULT_COURT_URL_SUFFIX = "meet.video.justice.gov.uk"
 
 object CourtEmailFactory {
@@ -439,5 +440,5 @@ object CourtEmailFactory {
     require(isStatus(CANCELLED)) { "Booking ID $videoBookingId is not a cancelled" }
   }
 
-  private fun VideoBooking.fullCvpVideoUrl() = hmctsNumber?.let { "HMCTS$it@$DEFAULT_COURT_URL_SUFFIX" } ?: videoUrl
+  private fun VideoBooking.fullCvpVideoUrl() = hmctsNumber?.let { "${DEFAULT_COURT_URL_PREFIX}HMCTS$it@$DEFAULT_COURT_URL_SUFFIX" } ?: videoUrl
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmailFactoryTest.kt
@@ -196,7 +196,7 @@ class CourtEmailFactoryTest {
     email?.personalisation()!! containsEntry Pair("comments", "Court hearing staff notes")
 
     if (listOf(BookingAction.CREATE, BookingAction.CANCEL).contains(action)) {
-      email.personalisation() containsEntry Pair("courtHearingLink", "HMCTS54321@meet.video.justice.gov.uk")
+      email.personalisation() containsEntry Pair("courtHearingLink", "https://join.meet.video.justice.gov.uk/#?conference=HMCTS54321@meet.video.justice.gov.uk")
     }
   }
 


### PR DESCRIPTION
Adds the full HTPPS prefix to HMTCS numbers so they can be full clickable URL's in emails.