### PR TITLE
BAVL-1294 fix the missing admin email configuration for preprod and production.

### DIFF
--- a/helm_deploy/hmpps-book-a-video-link-api/values.yaml
+++ b/helm_deploy/hmpps-book-a-video-link-api/values.yaml
@@ -71,6 +71,8 @@ generic-service:
     feature-toggles:
       FEATURE_PROBATION_ONLY_PRISONS: "FEATURE_PROBATION_ONLY_PRISONS?"
       FEATURE_COURT_ONLY_PRISONS: "FEATURE_COURT_ONLY_PRISONS?"
+    administration:
+      ADMINISTRATION_EMAILS: "ADMINISTRATION_EMAILS"
 
   allowlist:
     groups:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -21,10 +21,6 @@ generic-service:
     SPRINGDOC_API-DOCS_ENABLED: "true"
     SPRINGDOC_SWAGGER-UI_ENABLED: "true"
 
-  namespace_secrets:
-    administration:
-      ADMINISTRATION_EMAILS: "ADMINISTRATION_EMAILS"
-
   allowlist:
     groups:
       - internal


### PR DESCRIPTION
This one had managed to slip through the net 🤦 

I noticed a log statement saying there was no admin email config for preprod and prod during a deployment.