### PR TITLE
BAVL-1297 adding shell script to making change the Gov Notify email key simpler.

### DIFF
--- a/utility/add-gov-notify-key.sh
+++ b/utility/add-gov-notify-key.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Script to add (if not present) or replace the Gov Notify API email key
+#
+# Usage:  ./add-gov-notify-key.sh <env> <key>
+
+ENV=$1
+GOV_NOTIFY_KEY=$2
+
+# Temporarily disable any prod runs
+if [ "$ENV" = "prod" ]; then
+  echo "Prod is currently disabled."
+  return 1 2> /dev/null || exit 1
+fi
+
+while true; do
+
+echo
+read -r -p "You are about add the Gov Notify email key '$GOV_NOTIFY_KEY' to the BVLS service in '$ENV' environment. Do you want to proceed? (y/n) " yn
+
+case $yn in
+	[yY] ) echo ok, proceeding...;
+		break;;
+	[nN] ) echo exiting...;
+		exit;;
+	* ) echo invalid response;;
+esac
+done
+
+NAMESPACE="hmpps-book-a-video-link-$ENV"
+SECRETS_FILE="book-a-video-link-secrets-$ENV.yaml"
+
+# Create the secrets YAML file
+cat <<EOF > $SECRETS_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gov-notify
+  namespace: $NAMESPACE
+type: Opaque
+stringData:
+  notify_api_key: "$GOV_NOTIFY_KEY"
+EOF
+
+# Apply the secret
+kubectl apply -f ./$SECRETS_FILE
+echo
+echo "Applied secrets to $NAMESPACE"
+
+rm -f ./$SECRETS_FILE
+
+# Restart the deployment pods
+echo
+echo "Restarting BVLS API deployment in namespace $NAMESPACE"
+kubectl -n "$NAMESPACE" rollout restart deployments/hmpps-book-a-video-link-api


### PR DESCRIPTION
There was no script for doing this so added one as less likely to make errors.

This has been used for dev and preprod.