### PR TITLE
BAVL-1279 add missing check for court bookings and probation sentence and probation court room schedules.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttribute.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttribute.kt
@@ -191,7 +191,7 @@ class LocationAttribute private constructor(
     }
   }
 
-  private fun checkCourt(court: Court, onDate: LocalDate, startTime: LocalTime, endTime: LocalTime): AvailabilityStatus {
+  private fun checkCourt(court: Court, onDate: LocalDate, startTime: LocalTime, endTime: LocalTime): AvailabilityStatus = run {
     return when (locationUsage) {
       LocationUsage.SHARED -> AvailabilityStatus.SHARED
       LocationUsage.COURT -> when {
@@ -201,7 +201,7 @@ class LocationAttribute private constructor(
       }
 
       LocationUsage.SCHEDULE -> getScheduleAvailability(court, onDate, startTime, endTime)
-      else -> return AvailabilityStatus.NONE
+      else -> AvailabilityStatus.NONE
     }
   }
 
@@ -213,6 +213,8 @@ class LocationAttribute private constructor(
     val freeForCourtRoom = CourtRoomSpecification(court, onDate.dayOfWeek, startTime, endTime)
     val freeForAnyCourtRoom = CourtAnySpecification(onDate.dayOfWeek, startTime, endTime)
     val overlapsWithProbationSlot = OverlappingSpecification(LocationScheduleUsage.PROBATION, onDate.dayOfWeek, startTime, endTime)
+    val overlapsWithProbationSentenceSlot = OverlappingSpecification(LocationScheduleUsage.PROBATION_SENTENCE, onDate.dayOfWeek, startTime, endTime)
+    val overlapsWithProbationCourtSlot = OverlappingSpecification(LocationScheduleUsage.PROBATION_COURT, onDate.dayOfWeek, startTime, endTime)
     val overlapsWithOtherCourtRoomSlot = OverlappingRoomSpecification(LocationScheduleUsage.COURT, onDate.dayOfWeek, startTime, endTime)
 
     // The order in which the checks are carried out is important and must be maintained.
@@ -223,6 +225,12 @@ class LocationAttribute private constructor(
 
       // If none of the above match, we need to make sure the requested court slot date and times to not overlap any probation schedules
       fallsWithin(overlapsWithProbationSlot) -> AvailabilityStatus.NONE
+
+      // If none of the above match, we need to make sure the requested court slot date and times to not overlap any probation sentence schedules
+      fallsWithin(overlapsWithProbationSentenceSlot) -> AvailabilityStatus.NONE
+
+      // If none of the above match, we need to make sure the requested court slot date and times to not overlap any probation court schedules
+      fallsWithin(overlapsWithProbationCourtSlot) -> AvailabilityStatus.NONE
 
       // If none of the above match, we need to make sure the requested court slot date and times to not overlap any other court room schedules
       fallsWithin(overlapsWithOtherCourtRoomSlot) -> AvailabilityStatus.NONE

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttributesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttributesTest.kt
@@ -1166,7 +1166,7 @@ class LocationAttributesTest {
     }
 
     @Test
-    fun `should be PROBATION ANY for any probation schedule`() {
+    fun `should be COURT_ANY for any court schedule`() {
       val roomAttributes = LocationAttribute.decoratedRoom(
         dpsLocationId = UUID.randomUUID(),
         prison = pentonvillePrison,
@@ -1187,7 +1187,7 @@ class LocationAttributesTest {
     }
 
     @Test
-    fun `should be PROBATION_TEAM for probation team schedule`() {
+    fun `should be COURT_ROOM for court team schedule`() {
       val roomAttributes = LocationAttribute.decoratedRoom(
         dpsLocationId = UUID.randomUUID(),
         prison = pentonvillePrison,
@@ -1291,6 +1291,48 @@ class LocationAttributesTest {
         notes = null,
         createdBy = COURT_USER,
       ).apply { schedule(this, locationUsage = LocationScheduleUsage.PROBATION) }
+
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.NONE
+    }
+
+    @Test
+    fun `should be NONE for probation sentence schedule`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply { schedule(this, locationUsage = LocationScheduleUsage.PROBATION_SENTENCE) }
+
+      roomAttributes.isAvailableFor(
+        court(),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.NONE
+    }
+
+    @Test
+    fun `should be NONE for probation court schedule`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = COURT_USER,
+      ).apply { schedule(this, locationUsage = LocationScheduleUsage.PROBATION_COURT) }
 
       roomAttributes.isAvailableFor(
         court(),


### PR DESCRIPTION
Testing in dev raised a bug whereby court bookings are offered probation sentence rooms and probation court rooms when they shouldn't be.

This change should prevent that from happening going forwards.