### PR TITLE
BAVL-1251 rescheduled court probation emails

### DIFF
--- a/helm_deploy/hmpps-book-a-video-link-api/values.yaml
+++ b/helm_deploy/hmpps-book-a-video-link-api/values.yaml
@@ -42,6 +42,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     DB_SSL_MODE: "verify-full"
     HMPPS_SQS_USE_WEB_TOKEN: true
+    FEATURE_SEND_RESCHEDULED_EMAILS: false
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,6 +20,7 @@ generic-service:
     BVLS_FRONTEND_URL: "https://book-a-video-link-dev.prison.service.justice.gov.uk"
     SPRINGDOC_API-DOCS_ENABLED: "true"
     SPRINGDOC_SWAGGER-UI_ENABLED: "true"
+    FEATURE_SEND_RESCHEDULED_EMAILS: true
 
   allowlist:
     groups:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailConfiguration.kt
@@ -26,6 +26,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.ReleasedCourtBookingCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.ReleasedCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.ReleasedCourtBookingPrisonNoCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtBookingCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtBookingPrisonCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtBookingPrisonNoCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.TransferredCourtBookingCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.TransferredCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.TransferredCourtBookingPrisonNoCourtEmail
@@ -48,6 +52,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probat
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ReleasedProbationBookingPrisonNoProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ReleasedProbationBookingPrisonProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ReleasedProbationBookingProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationBookingPrisonNoProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationBookingPrisonProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationBookingProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.TransferredProbationBookingPrisonNoProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.TransferredProbationBookingPrisonProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.TransferredProbationBookingProbationEmail
@@ -85,6 +93,10 @@ class EmailConfiguration(
   @Value("\${notify.templates.court.release-booking.court:}") private val releaseCourtBookingCourt: String,
   @Value("\${notify.templates.court.release-booking.prison-court-email:}") private val releaseCourtBookingPrisonCourtEmail: String,
   @Value("\${notify.templates.court.release-booking.prison-no-court-email:}") private val releaseCourtBookingPrisonNoCourtEmail: String,
+  @Value("\${notify.templates.court.rescheduled-booking.user:}") private val rescheduledCourtBookingUser: String,
+  @Value("\${notify.templates.court.rescheduled-booking.court:}") private val rescheduledCourtBookingCourtEmail: String,
+  @Value("\${notify.templates.court.rescheduled-booking.prison-court-email:}") private val rescheduledCourtBookingPrisonCourtEmail: String,
+  @Value("\${notify.templates.court.rescheduled-booking.prison-no-court-email:}") private val rescheduledCourtBookingPrisonNoCourtEmail: String,
   @Value("\${notify.templates.probation.booking-request.user:}") private val probationBookingRequestUser: String,
   @Value("\${notify.templates.probation.booking-request.prison-probation-team-email:}") private val probationBookingRequestPrisonProbationTeamEmail: String,
   @Value("\${notify.templates.probation.booking-request.prison-no-probation-team-email:}") private val probationBookingRequestPrisonNoProbationTeamEmail: String,
@@ -108,6 +120,10 @@ class EmailConfiguration(
   @Value("\${notify.templates.probation.transfer-booking.prison-no-probation-email:}") private val transferProbationBookingPrisonNoProbationEmail: String,
   @Value("\${notify.templates.court.hearing-link-reminder.court:}") private val courtHearingLinkReminderEmail: String,
   @Value("\${notify.templates.probation.probation-officer-details-reminder.probation:}") private val probationOfficerDetailsReminderEmail: String,
+  @Value("\${notify.templates.probation.rescheduled-booking.user:}") private val rescheduledProbationBookingUser: String,
+  @Value("\${notify.templates.probation.rescheduled-booking.prison-probation-email:}") private val rescheduledProbationBookingPrisonProbationEmail: String,
+  @Value("\${notify.templates.probation.rescheduled-booking.prison-no-probation-email:}") private val rescheduledProbationBookingPrisonNoProbationEmail: String,
+  @Value("\${notify.templates.probation.rescheduled-booking.probation:}") private val rescheduledProbationBookingProbationEmail: String,
   @Value("\${notify.templates.administration.new-video-room:}") private val administrationNewVideoRoom: String,
 ) {
 
@@ -146,6 +162,10 @@ class EmailConfiguration(
     releaseCourtBookingCourt = releaseCourtBookingCourt,
     releaseCourtBookingPrisonCourtEmail = releaseCourtBookingPrisonCourtEmail,
     releaseCourtBookingPrisonNoCourtEmail = releaseCourtBookingPrisonNoCourtEmail,
+    rescheduledCourtBookingUser = rescheduledCourtBookingUser,
+    rescheduledCourtBookingCourtEmail = rescheduledCourtBookingCourtEmail,
+    rescheduledCourtBookingPrisonCourtEmail = rescheduledCourtBookingPrisonCourtEmail,
+    rescheduledCourtBookingPrisonNoCourtEmail = rescheduledCourtBookingPrisonNoCourtEmail,
     newProbationBookingUser = newProbationBookingUser,
     newProbationBookingProbation = newProbationBookingProbation,
     newProbationBookingPrisonProbationEmail = newProbationBookingPrisonProbationEmail,
@@ -168,6 +188,10 @@ class EmailConfiguration(
     courtHearingLinkReminderEmail = courtHearingLinkReminderEmail,
     probationOfficerDetailsReminderEmail = probationOfficerDetailsReminderEmail,
     administrationNewVideoRoom = administrationNewVideoRoom,
+    rescheduledProbationBookingUser = rescheduledProbationBookingUser,
+    rescheduledProbationBookingPrisonProbationEmail = rescheduledProbationBookingPrisonProbationEmail,
+    rescheduledProbationBookingPrisonNoProbationEmail = rescheduledProbationBookingPrisonNoProbationEmail,
+    rescheduledProbationBookingProbationEmail = rescheduledProbationBookingProbationEmail,
   )
 }
 
@@ -231,6 +255,10 @@ data class EmailTemplates(
   val releaseCourtBookingCourt: String,
   val releaseCourtBookingPrisonCourtEmail: String,
   val releaseCourtBookingPrisonNoCourtEmail: String,
+  val rescheduledCourtBookingUser: String,
+  val rescheduledCourtBookingCourtEmail: String,
+  val rescheduledCourtBookingPrisonCourtEmail: String,
+  val rescheduledCourtBookingPrisonNoCourtEmail: String,
   val newProbationBookingUser: String,
   val newProbationBookingProbation: String,
   val newProbationBookingPrisonProbationEmail: String,
@@ -252,6 +280,10 @@ data class EmailTemplates(
   val courtHearingLinkReminderEmail: String,
   val probationOfficerDetailsReminderEmail: String,
   val administrationNewVideoRoom: String,
+  val rescheduledProbationBookingUser: String,
+  val rescheduledProbationBookingPrisonProbationEmail: String,
+  val rescheduledProbationBookingPrisonNoProbationEmail: String,
+  val rescheduledProbationBookingProbationEmail: String,
 ) {
 
   private val emailTemplateMappings = mapOf(
@@ -300,6 +332,14 @@ data class EmailTemplates(
     CourtHearingLinkReminderEmail::class.java to courtHearingLinkReminderEmail,
     ProbationOfficerDetailsReminderEmail::class.java to probationOfficerDetailsReminderEmail,
     AdministrationNewVideoRoomEmail::class.java to administrationNewVideoRoom,
+    RescheduledCourtBookingUserEmail::class.java to rescheduledCourtBookingUser,
+    RescheduledCourtBookingCourtEmail::class.java to rescheduledCourtBookingCourtEmail,
+    RescheduledCourtBookingPrisonCourtEmail::class.java to rescheduledCourtBookingPrisonCourtEmail,
+    RescheduledCourtBookingPrisonNoCourtEmail::class.java to rescheduledCourtBookingPrisonNoCourtEmail,
+    RescheduledProbationBookingUserEmail::class.java to rescheduledProbationBookingUser,
+    RescheduledProbationBookingPrisonProbationEmail::class.java to rescheduledProbationBookingPrisonProbationEmail,
+    RescheduledProbationBookingPrisonNoProbationEmail::class.java to rescheduledProbationBookingPrisonNoProbationEmail,
+    RescheduledProbationBookingProbationEmail::class.java to rescheduledProbationBookingProbationEmail,
   )
 
   init {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/FeatureSwitches.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/FeatureSwitches.kt
@@ -31,6 +31,7 @@ class FeatureSwitches(private val environment: Environment) {
 
 enum class BooleanFeature(val label: String) {
   FEATURE_PLACEHOLDER("feature.placeholder.example"),
+  FEATURE_SEND_RESCHEDULED_EMAILS("feature.send.rescheduled.emails"),
 }
 
 enum class StringFeature(val label: String) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/BookingFacade.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.facade
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.BooleanFeature
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType.COURT
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType.PROBATION
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.StatusCode
@@ -11,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AmendVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.RequestVideoBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.VideoLinkBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ChangeTrackingService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ChangeType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ExternalUser
@@ -40,6 +43,7 @@ class BookingFacade(
   private val availabilityService: AvailabilityService,
   private val changeTrackingService: ChangeTrackingService,
   private val emailFacade: EmailFacade,
+  private val featureSwitches: FeatureSwitches,
   private val rescheduleEmailsFacade: RescheduleEmailsFacade,
 ) {
   companion object {
@@ -77,20 +81,39 @@ class BookingFacade(
     val changeType = changeTrackingService.determineChangeType(videoBookingId, bookingRequest, amendedBy)
 
     // Amend regardless of changes (this is in-case new fields ever are introduced but not covered by the change check).
-    val (booking, prisoner) = videoBookingServiceDelegate.amend(videoBookingId, bookingRequest, amendedBy)
+    val (amendedBooking, prisoner) = videoBookingServiceDelegate.amend(videoBookingId, bookingRequest, amendedBy)
     outboundEventsService.send(DomainEventType.VIDEO_BOOKING_AMENDED, videoBookingId)
 
     // Only send emails on back of change check above.
     if (changeType != ChangeType.NONE) {
-      // TODO check if a reschedule is required here and use the appropriate facade.
-      emailFacade.sendEmails(BookingAction.AMEND, booking, prisoner, amendedBy, changeType)
+      if (featureSwitches.isEnabled(BooleanFeature.FEATURE_SEND_RESCHEDULED_EMAILS) && isRescheduled(originalBooking, amendedBooking)) {
+        rescheduleEmailsFacade.sendEmails(originalBooking, amendedBooking, changeType, prisoner, amendedBy)
+      } else {
+        emailFacade.sendEmails(BookingAction.AMEND, amendedBooking, prisoner, amendedBy, changeType)
+      }
     } else {
       log.info("No changes detected for video booking $videoBookingId, not sending email")
     }
 
-    trackTelemetry(BookingAction.AMEND, booking, amendedBy)
+    trackTelemetry(BookingAction.AMEND, amendedBooking, amendedBy)
 
     return videoBookingId
+  }
+
+  private fun isRescheduled(originalBooking: VideoLinkBooking, amendedBooking: VideoBooking) = run {
+    originalBooking.startDateTime() != amendedBooking.startDateTime()
+  }
+
+  private fun VideoBooking.startDateTime() = run {
+    val appointment = this.mainHearing() ?: this.probationMeeting()!!
+
+    appointment.appointmentDate.atTime(appointment.startTime)
+  }
+
+  private fun VideoLinkBooking.startDateTime() = run {
+    val appointment = prisonAppointments.singleOrNull { it.appointmentType == "VLB_COURT_MAIN" } ?: prisonAppointments.single { it.appointmentType == "VLB_PROBATION" }
+
+    appointment.appointmentDate.atTime(appointment.startTime)
   }
 
   fun cancel(videoBookingId: Long, cancelledBy: PrisonUser) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/BookingFacade.kt
@@ -40,6 +40,7 @@ class BookingFacade(
   private val availabilityService: AvailabilityService,
   private val changeTrackingService: ChangeTrackingService,
   private val emailFacade: EmailFacade,
+  private val rescheduleEmailsFacade: RescheduleEmailsFacade,
 ) {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -70,6 +71,8 @@ class BookingFacade(
       }
     }
 
+    val originalBooking = videoBookingServiceDelegate.getVideoBookingById(videoBookingId, amendedBy)
+
     // Need to check before amendment to see before picture.
     val changeType = changeTrackingService.determineChangeType(videoBookingId, bookingRequest, amendedBy)
 
@@ -79,6 +82,7 @@ class BookingFacade(
 
     // Only send emails on back of change check above.
     if (changeType != ChangeType.NONE) {
+      // TODO check if a reschedule is required here and use the appropriate facade.
       emailFacade.sendEmails(BookingAction.AMEND, booking, prisoner, amendedBy, changeType)
     } else {
       log.info("No changes detected for video booking $videoBookingId, not sending email")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/RescheduleEmailsFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/RescheduleEmailsFacade.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationEmailFactory
 
 @Component
-@Transactional(readOnly = true)
+@Transactional
 class RescheduleEmailsFacade(
   private val prisonRepository: PrisonRepository,
   private val contactsService: ContactsService,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/RescheduleEmailsFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/RescheduleEmailsFacade.kt
@@ -1,0 +1,116 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.facade
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.EmailService
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.VideoBookingEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingContact
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ContactType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Notification
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.VideoLinkBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.NotificationRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ChangeType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ContactsService
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ExternalUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.PrisonUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ServiceUser
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.User
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtEmailFactory
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationEmailFactory
+
+@Component
+@Transactional(readOnly = true)
+class RescheduleEmailsFacade(
+  private val prisonRepository: PrisonRepository,
+  private val contactsService: ContactsService,
+  private val rescheduledCourtEmailFactory: RescheduledCourtEmailFactory,
+  private val rescheduledProbationEmailFactory: RescheduledProbationEmailFactory,
+  private val emailService: EmailService,
+  private val notificationRepository: NotificationRepository,
+) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun sendEmails(
+    oldBooking: VideoLinkBooking,
+    amendedBooking: VideoBooking,
+    changeType: ChangeType,
+    prisoner: Prisoner,
+    user: User,
+  ) {
+    val prison = prisonRepository.findByCode(prisoner.prisonCode)!!
+    val contacts = contactsService.getBookingContacts(oldBooking.videoLinkBookingId, user).withAnEmailAddress()
+
+    when (amendedBooking.bookingType) {
+      BookingType.COURT -> sendCourtEmails(oldBooking, amendedBooking, changeType, prison, prisoner, contacts, user)
+      BookingType.PROBATION -> sendProbationEmails(oldBooking, amendedBooking, changeType, prison, prisoner, contacts, user)
+    }
+  }
+
+  private fun sendCourtEmails(
+    oldBooking: VideoLinkBooking,
+    amendedBooking: VideoBooking,
+    changeType: ChangeType,
+    prison: Prison,
+    prisoner: Prisoner,
+    contacts: Collection<BookingContact>,
+    user: User,
+  ) {
+    val emails = contacts.mapNotNull { contact ->
+      when (contact.contactType) {
+        ContactType.USER -> rescheduledCourtEmailFactory.user(oldBooking, amendedBooking, prison, prisoner, contact).takeIf { user is PrisonUser || user is ExternalUser }
+        ContactType.COURT -> rescheduledCourtEmailFactory.court(oldBooking, amendedBooking, prison, prisoner, contact).takeIf { (user is PrisonUser || user is ServiceUser) && changeType in setOf(ChangeType.GLOBAL) }
+        ContactType.PRISON -> rescheduledCourtEmailFactory.prison(oldBooking, amendedBooking, prison, prisoner, contact, contacts).takeIf { changeType in setOf(ChangeType.GLOBAL, ChangeType.PRISON) }
+        else -> null
+      }
+    }
+
+    emails.forEach { courtEmail -> sendEmailAndSaveNotification(courtEmail, amendedBooking) }
+  }
+
+  private fun sendProbationEmails(
+    oldBooking: VideoLinkBooking,
+    amendedBooking: VideoBooking,
+    changeType: ChangeType,
+    prison: Prison,
+    prisoner: Prisoner,
+    contacts: Collection<BookingContact>,
+    user: User,
+  ) {
+    val emails = contacts.mapNotNull { contact ->
+      when (contact.contactType) {
+        ContactType.USER -> rescheduledProbationEmailFactory.user(oldBooking, amendedBooking, contact, prisoner, prison).takeIf { user is PrisonUser || user is ExternalUser }
+        ContactType.PROBATION -> rescheduledProbationEmailFactory.probation(oldBooking, amendedBooking, contact, prisoner, prison).takeIf { (user is PrisonUser || user is ServiceUser) && changeType in setOf(ChangeType.GLOBAL) }
+        ContactType.PRISON -> rescheduledProbationEmailFactory.prison(oldBooking, amendedBooking, contact, prisoner, prison, contacts).takeIf { changeType in setOf(ChangeType.GLOBAL, ChangeType.PRISON) }
+        else -> null
+      }
+    }
+
+    emails.forEach { probationEmail -> sendEmailAndSaveNotification(probationEmail, amendedBooking) }
+  }
+
+  private fun Collection<BookingContact>.withAnEmailAddress() = filter { it.email != null }
+
+  private fun sendEmailAndSaveNotification(email: VideoBookingEmail, booking: VideoBooking) {
+    emailService.send(email).onSuccess { (govNotifyId, templateId) ->
+      notificationRepository.saveAndFlush(
+        Notification(
+          videoBooking = booking,
+          email = email.address,
+          govNotifyNotificationId = govNotifyId,
+          templateName = templateId,
+          reason = "RESCHEDULED",
+        ),
+      )
+    }.onFailure {
+      log.info("BOOKINGS: Failed to send RESCHEDULED email for video booking ID ${booking.videoBookingId}.")
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegate.kt
@@ -23,6 +23,7 @@ class VideoBookingServiceDelegate(
   private val amendProbationBookingService: AmendProbationBookingService,
   private val cancelVideoBookingService: CancelVideoBookingService,
   private val requestBookingService: RequestBookingService,
+  private val videoLinkBookingsService: VideoLinkBookingsService,
   @Value("\${applications.max-appointment-start-date-from-today:1000}") private val maxStartDateOffsetDays: Long,
 ) {
   companion object {
@@ -75,4 +76,7 @@ class VideoBookingServiceDelegate(
       throw ValidationException("Date must be within the next $maxStartDateOffsetDays days")
     }
   }
+
+  @Transactional(readOnly = true)
+  fun getVideoBookingById(bookingId: Long, user: User) = videoLinkBookingsService.getVideoLinkBookingById(bookingId, user)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/CourtEmails.kt
@@ -685,3 +685,163 @@ class CourtHearingLinkReminderEmail(
     addPersonalisation("bookingId", bookingId)
   }
 }
+
+class RescheduledCourtBookingUserEmail(
+  address: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  prisonerNumber: String,
+  appointmentDate: LocalDate,
+  userName: String,
+  court: String,
+  prison: String,
+  preAppointmentDetails: AppointmentDetails?,
+  mainAppointmentDetails: AppointmentDetails,
+  postAppointmentDetails: AppointmentDetails?,
+  comments: String?,
+  courtHearingLink: String?,
+  oldAppointmentDate: LocalDate,
+  oldPreAppointmentDetails: AppointmentDetails?,
+  oldMainAppointmentDetails: AppointmentDetails,
+  oldPostAppointmentDetails: AppointmentDetails?,
+) : CourtEmail(
+  address = address,
+  prisonerFirstName = prisonerFirstName,
+  prisonerLastName = prisonerLastName,
+  prisonerNumber = prisonerNumber,
+  appointmentDate = appointmentDate,
+  userName = userName,
+  court = court,
+  prison = prison,
+  preAppointmentDetails = preAppointmentDetails,
+  mainAppointmentDetails = mainAppointmentDetails,
+  postAppointmentDetails = postAppointmentDetails,
+  comments = comments,
+  courtHearingLink = courtHearingLink,
+) {
+  init {
+    addPersonalisation("oldAppointmentDate", oldAppointmentDate.toMediumFormatStyle())
+    addPersonalisation("oldPreAppointmentInfo", oldPreAppointmentDetails?.toString() ?: "Not required")
+    addPersonalisation("oldMainAppointmentInfo", oldMainAppointmentDetails.toString())
+    addPersonalisation("oldPostAppointmentInfo", oldPostAppointmentDetails?.toString() ?: "Not required")
+  }
+}
+
+class RescheduledCourtBookingCourtEmail(
+  address: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  prisonerNumber: String,
+  appointmentDate: LocalDate,
+  court: String,
+  prison: String,
+  preAppointmentDetails: AppointmentDetails?,
+  mainAppointmentDetails: AppointmentDetails,
+  postAppointmentDetails: AppointmentDetails?,
+  comments: String?,
+  courtHearingLink: String?,
+  oldAppointmentDate: LocalDate,
+  oldPreAppointmentDetails: AppointmentDetails?,
+  oldMainAppointmentDetails: AppointmentDetails,
+  oldPostAppointmentDetails: AppointmentDetails?,
+) : CourtEmail(
+  address = address,
+  prisonerFirstName = prisonerFirstName,
+  prisonerLastName = prisonerLastName,
+  prisonerNumber = prisonerNumber,
+  appointmentDate = appointmentDate,
+  court = court,
+  prison = prison,
+  preAppointmentDetails = preAppointmentDetails,
+  mainAppointmentDetails = mainAppointmentDetails,
+  postAppointmentDetails = postAppointmentDetails,
+  comments = comments,
+  courtHearingLink = courtHearingLink,
+) {
+  init {
+    addPersonalisation("oldAppointmentDate", oldAppointmentDate.toMediumFormatStyle())
+    addPersonalisation("oldPreAppointmentInfo", oldPreAppointmentDetails?.toString() ?: "Not required")
+    addPersonalisation("oldMainAppointmentInfo", oldMainAppointmentDetails.toString())
+    addPersonalisation("oldPostAppointmentInfo", oldPostAppointmentDetails?.toString() ?: "Not required")
+  }
+}
+
+class RescheduledCourtBookingPrisonCourtEmail(
+  address: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  prisonerNumber: String,
+  appointmentDate: LocalDate,
+  court: String,
+  courtEmailAddress: String,
+  prison: String,
+  preAppointmentDetails: AppointmentDetails?,
+  mainAppointmentDetails: AppointmentDetails,
+  postAppointmentDetails: AppointmentDetails?,
+  comments: String?,
+  courtHearingLink: String?,
+  oldAppointmentDate: LocalDate,
+  oldPreAppointmentDetails: AppointmentDetails?,
+  oldMainAppointmentDetails: AppointmentDetails,
+  oldPostAppointmentDetails: AppointmentDetails?,
+) : CourtEmail(
+  address = address,
+  prisonerFirstName = prisonerFirstName,
+  prisonerLastName = prisonerLastName,
+  prisonerNumber = prisonerNumber,
+  appointmentDate = appointmentDate,
+  court = court,
+  courtEmailAddress = courtEmailAddress,
+  prison = prison,
+  preAppointmentDetails = preAppointmentDetails,
+  mainAppointmentDetails = mainAppointmentDetails,
+  postAppointmentDetails = postAppointmentDetails,
+  comments = comments,
+  courtHearingLink = courtHearingLink,
+) {
+  init {
+    addPersonalisation("oldAppointmentDate", oldAppointmentDate.toMediumFormatStyle())
+    addPersonalisation("oldPreAppointmentInfo", oldPreAppointmentDetails?.toString() ?: "Not required")
+    addPersonalisation("oldMainAppointmentInfo", oldMainAppointmentDetails.toString())
+    addPersonalisation("oldPostAppointmentInfo", oldPostAppointmentDetails?.toString() ?: "Not required")
+  }
+}
+
+class RescheduledCourtBookingPrisonNoCourtEmail(
+  address: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  prisonerNumber: String,
+  appointmentDate: LocalDate,
+  court: String,
+  prison: String,
+  preAppointmentDetails: AppointmentDetails?,
+  mainAppointmentDetails: AppointmentDetails,
+  postAppointmentDetails: AppointmentDetails?,
+  comments: String?,
+  courtHearingLink: String?,
+  oldAppointmentDate: LocalDate,
+  oldPreAppointmentDetails: AppointmentDetails?,
+  oldMainAppointmentDetails: AppointmentDetails,
+  oldPostAppointmentDetails: AppointmentDetails?,
+) : CourtEmail(
+  address = address,
+  prisonerFirstName = prisonerFirstName,
+  prisonerLastName = prisonerLastName,
+  prisonerNumber = prisonerNumber,
+  appointmentDate = appointmentDate,
+  court = court,
+  prison = prison,
+  preAppointmentDetails = preAppointmentDetails,
+  mainAppointmentDetails = mainAppointmentDetails,
+  postAppointmentDetails = postAppointmentDetails,
+  comments = comments,
+  courtHearingLink = courtHearingLink,
+) {
+  init {
+    addPersonalisation("oldAppointmentDate", oldAppointmentDate.toMediumFormatStyle())
+    addPersonalisation("oldPreAppointmentInfo", oldPreAppointmentDetails?.toString() ?: "Not required")
+    addPersonalisation("oldMainAppointmentInfo", oldMainAppointmentDetails.toString())
+    addPersonalisation("oldPostAppointmentInfo", oldPostAppointmentDetails?.toString() ?: "Not required")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/RescheduledCourtEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/RescheduledCourtEmailFactory.kt
@@ -1,0 +1,162 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.VideoBookingEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingContact
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType.COURT
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ContactType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.VideoLinkBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.LocationsService
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.PrisonAppointment as ModelPrisonAppointment
+
+@Component
+class RescheduledCourtEmailFactory(private val locationService: LocationsService) {
+  fun user(
+    oldBooking: VideoLinkBooking,
+    amendedBooking: VideoBooking,
+    prison: Prison,
+    prisoner: Prisoner,
+    userContact: BookingContact,
+  ): VideoBookingEmail? {
+    require(userContact.contactType == ContactType.USER) {
+      "Incorrect contact type ${userContact.contactType} for court user email"
+    }
+
+    val (pre, main, post) = Triple(amendedBooking.preHearing(), amendedBooking.mainHearing()!!, amendedBooking.postHearing())
+    val (oldPre, oldMain, oldPost) = Triple(oldBooking.preHearing(), oldBooking.mainHearing(), oldBooking.postHearing())
+
+    return RescheduledCourtBookingUserEmail(
+      address = userContact.email!!,
+      userName = userContact.name ?: "Book Video",
+      prisonerFirstName = prisoner.firstName,
+      prisonerLastName = prisoner.lastName,
+      prisonerNumber = prisoner.prisonerNumber,
+      court = amendedBooking.court!!.description,
+      prison = prison.name,
+      appointmentDate = main.appointmentDate,
+      preAppointmentDetails = pre?.appointmentDetails(locationService.getLocationById(pre.prisonLocationId)!!),
+      mainAppointmentDetails = main.appointmentDetails(locationService.getLocationById(main.prisonLocationId)!!),
+      postAppointmentDetails = post?.appointmentDetails(locationService.getLocationById(post.prisonLocationId)!!),
+      comments = amendedBooking.notesForStaff,
+      courtHearingLink = amendedBooking.fullCvpVideoUrl(),
+      oldAppointmentDate = oldMain.appointmentDate,
+      oldPreAppointmentDetails = oldPre?.appointmentDetails(locationService.getLocationByKey(oldPre.prisonLocKey)!!),
+      oldMainAppointmentDetails = oldMain.appointmentDetails(locationService.getLocationByKey(oldMain.prisonLocKey)!!),
+      oldPostAppointmentDetails = oldPost?.appointmentDetails(locationService.getLocationByKey(oldPost.prisonLocKey)!!),
+    )
+  }
+
+  fun court(
+    oldBooking: VideoLinkBooking,
+    amendedBooking: VideoBooking,
+    prison: Prison,
+    prisoner: Prisoner,
+    courtContact: BookingContact,
+  ): VideoBookingEmail? {
+    require(courtContact.contactType == ContactType.COURT) {
+      "Incorrect contact type ${courtContact.contactType} for court court email"
+    }
+
+    val (pre, main, post) = Triple(amendedBooking.preHearing(), amendedBooking.mainHearing()!!, amendedBooking.postHearing())
+    val (oldPre, oldMain, oldPost) = Triple(oldBooking.preHearing(), oldBooking.mainHearing(), oldBooking.postHearing())
+
+    return RescheduledCourtBookingCourtEmail(
+      address = courtContact.email!!,
+      prisonerFirstName = prisoner.firstName,
+      prisonerLastName = prisoner.lastName,
+      prisonerNumber = prisoner.prisonerNumber,
+      appointmentDate = main.appointmentDate,
+      court = amendedBooking.court!!.description,
+      prison = prison.name,
+      preAppointmentDetails = pre?.appointmentDetails(locationService.getLocationById(pre.prisonLocationId)!!),
+      mainAppointmentDetails = main.appointmentDetails(locationService.getLocationById(main.prisonLocationId)!!),
+      postAppointmentDetails = post?.appointmentDetails(locationService.getLocationById(post.prisonLocationId)!!),
+      comments = amendedBooking.notesForStaff,
+      courtHearingLink = amendedBooking.fullCvpVideoUrl(),
+      oldAppointmentDate = oldMain.appointmentDate,
+      oldPreAppointmentDetails = oldPre?.appointmentDetails(locationService.getLocationByKey(oldPre.prisonLocKey)!!),
+      oldMainAppointmentDetails = oldMain.appointmentDetails(locationService.getLocationByKey(oldMain.prisonLocKey)!!),
+      oldPostAppointmentDetails = oldPost?.appointmentDetails(locationService.getLocationByKey(oldPost.prisonLocKey)!!),
+    )
+  }
+
+  fun prison(
+    oldBooking: VideoLinkBooking,
+    amendedBooking: VideoBooking,
+    prison: Prison,
+    prisoner: Prisoner,
+    prisonContact: BookingContact,
+    contacts: Collection<BookingContact>,
+  ): VideoBookingEmail? {
+    require(prisonContact.contactType == ContactType.PRISON) {
+      "Incorrect contact type ${prisonContact.contactType} for court prison email"
+    }
+
+    val (pre, main, post) = Triple(amendedBooking.preHearing(), amendedBooking.mainHearing()!!, amendedBooking.postHearing())
+    val (oldPre, oldMain, oldPost) = Triple(oldBooking.preHearing(), oldBooking.mainHearing(), oldBooking.postHearing())
+
+    return contacts.primaryCourtContact()?.let { primaryCourtContact ->
+      RescheduledCourtBookingPrisonCourtEmail(
+        address = prisonContact.email!!,
+        prisonerFirstName = prisoner.firstName,
+        prisonerLastName = prisoner.lastName,
+        prisonerNumber = prisoner.prisonerNumber,
+        court = amendedBooking.court!!.description,
+        courtEmailAddress = primaryCourtContact.email!!,
+        prison = prison.name,
+        appointmentDate = main.appointmentDate,
+        preAppointmentDetails = pre?.appointmentDetails(locationService.getLocationById(pre.prisonLocationId)!!),
+        mainAppointmentDetails = main.appointmentDetails(locationService.getLocationById(main.prisonLocationId)!!),
+        postAppointmentDetails = post?.appointmentDetails(locationService.getLocationById(post.prisonLocationId)!!),
+        comments = amendedBooking.notesForStaff,
+        courtHearingLink = amendedBooking.fullCvpVideoUrl(),
+        oldAppointmentDate = oldMain.appointmentDate,
+        oldPreAppointmentDetails = oldPre?.appointmentDetails(locationService.getLocationByKey(oldPre.prisonLocKey)!!),
+        oldMainAppointmentDetails = oldMain.appointmentDetails(locationService.getLocationByKey(oldMain.prisonLocKey)!!),
+        oldPostAppointmentDetails = oldPost?.appointmentDetails(locationService.getLocationByKey(oldPost.prisonLocKey)!!),
+      )
+    } ?: RescheduledCourtBookingPrisonNoCourtEmail(
+      address = prisonContact.email!!,
+      prisonerFirstName = prisoner.firstName,
+      prisonerLastName = prisoner.lastName,
+      prisonerNumber = prisoner.prisonerNumber,
+      court = amendedBooking.court!!.description,
+      prison = prison.name,
+      appointmentDate = main.appointmentDate,
+      preAppointmentDetails = pre?.appointmentDetails(locationService.getLocationById(pre.prisonLocationId)!!),
+      mainAppointmentDetails = main.appointmentDetails(locationService.getLocationById(main.prisonLocationId)!!),
+      postAppointmentDetails = post?.appointmentDetails(locationService.getLocationById(post.prisonLocationId)!!),
+      comments = amendedBooking.notesForStaff,
+      courtHearingLink = amendedBooking.fullCvpVideoUrl(),
+      oldAppointmentDate = oldMain.appointmentDate,
+      oldPreAppointmentDetails = oldPre?.appointmentDetails(locationService.getLocationByKey(oldPre.prisonLocKey)!!),
+      oldMainAppointmentDetails = oldMain.appointmentDetails(locationService.getLocationByKey(oldMain.prisonLocKey)!!),
+      oldPostAppointmentDetails = oldPost?.appointmentDetails(locationService.getLocationByKey(oldPost.prisonLocKey)!!),
+    )
+  }
+
+  private fun PrisonAppointment.appointmentDetails(location: Location) = AppointmentDetails(location.description ?: "", startTime, endTime, location.prisonVideoUrl(this))
+
+  private fun Location.prisonVideoUrl(pa: PrisonAppointment) = this.extraAttributes?.prisonVideoUrl
+
+  private fun Collection<BookingContact>.primaryCourtContact() = singleOrNull { it.contactType == ContactType.COURT && it.primaryContact }
+
+  private fun VideoBooking.requireIsCourtBooking() {
+    require(isBookingType(COURT)) { "Booking ID $videoBookingId is not a court booking" }
+  }
+
+  private fun VideoBooking.fullCvpVideoUrl() = hmctsNumber?.let { "${DEFAULT_COURT_URL_PREFIX}HMCTS$it@$DEFAULT_COURT_URL_SUFFIX" } ?: videoUrl
+
+  private fun VideoLinkBooking.preHearing() = prisonAppointments.singleOrNull { it.appointmentType == "VLB_COURT_PRE" }
+
+  private fun VideoLinkBooking.mainHearing() = prisonAppointments.single { it.appointmentType == "VLB_COURT_MAIN" }
+
+  private fun VideoLinkBooking.postHearing() = prisonAppointments.singleOrNull { it.appointmentType == "VLB_COURT_POST" }
+
+  private fun ModelPrisonAppointment.appointmentDetails(location: Location) = AppointmentDetails(location.description ?: "", startTime, endTime, null)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/ProbationEmails.kt
@@ -732,3 +732,155 @@ class ProbationOfficerDetailsReminderEmail(
     addPersonalisation("bookingId", bookingId)
   }
 }
+
+class RescheduledProbationBookingUserEmail(
+  address: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  prisonerNumber: String,
+  userName: String,
+  appointmentDate: LocalDate,
+  probationTeam: String,
+  prison: String,
+  appointmentInfo: String,
+  prisonVideoUrl: String?,
+  probationOfficerName: String?,
+  probationOfficerEmailAddress: String?,
+  probationOfficerContactNumber: String?,
+  comments: String?,
+  oldAppointmentDate: LocalDate,
+  oldAppointmentInfo: String,
+) : ProbationEmail(
+  address = address,
+  prisonerNumber = prisonerNumber,
+  prisonerFirstName = prisonerFirstName,
+  prisonerLastName = prisonerLastName,
+  appointmentInfo = appointmentInfo,
+  appointmentDate = appointmentDate,
+  probationTeam = probationTeam,
+  prison = prison,
+  prisonVideoUrl = prisonVideoUrl ?: "Not yet known",
+  probationOfficerName = probationOfficerName ?: "Not yet known",
+  probationOfficerEmailAddress = probationOfficerEmailAddress ?: "Not yet known",
+  probationOfficerContactNumber = probationOfficerContactNumber ?: "Not yet known",
+  comments = comments,
+  userName = userName,
+) {
+  init {
+    addPersonalisation("oldAppointmentDate", oldAppointmentDate.toMediumFormatStyle())
+    addPersonalisation("oldAppointmentInfo", oldAppointmentInfo)
+  }
+}
+
+class RescheduledProbationBookingProbationEmail(
+  address: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  prisonerNumber: String,
+  probationTeam: String,
+  prison: String,
+  appointmentDate: LocalDate,
+  appointmentInfo: String,
+  prisonVideoUrl: String?,
+  probationOfficerName: String?,
+  probationOfficerEmailAddress: String?,
+  probationOfficerContactNumber: String?,
+  comments: String?,
+  oldAppointmentDate: LocalDate,
+  oldAppointmentInfo: String,
+) : ProbationEmail(
+  address = address,
+  prisonerNumber = prisonerNumber,
+  prisonerFirstName = prisonerFirstName,
+  prisonerLastName = prisonerLastName,
+  appointmentInfo = appointmentInfo,
+  appointmentDate = appointmentDate,
+  probationTeam = probationTeam,
+  prison = prison,
+  prisonVideoUrl = prisonVideoUrl ?: "Not yet known",
+  probationOfficerName = probationOfficerName ?: "Not yet known",
+  probationOfficerEmailAddress = probationOfficerEmailAddress ?: "Not yet known",
+  probationOfficerContactNumber = probationOfficerContactNumber ?: "Not yet known",
+  comments = comments,
+) {
+  init {
+    addPersonalisation("oldAppointmentDate", oldAppointmentDate.toMediumFormatStyle())
+    addPersonalisation("oldAppointmentInfo", oldAppointmentInfo)
+  }
+}
+
+class RescheduledProbationBookingPrisonProbationEmail(
+  address: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  prisonerNumber: String,
+  probationTeam: String,
+  probationEmailAddress: String,
+  prison: String,
+  appointmentDate: LocalDate,
+  appointmentInfo: String,
+  prisonVideoUrl: String?,
+  probationOfficerName: String?,
+  probationOfficerEmailAddress: String?,
+  probationOfficerContactNumber: String?,
+  comments: String?,
+  oldAppointmentDate: LocalDate,
+  oldAppointmentInfo: String,
+) : ProbationEmail(
+  address = address,
+  prisonerNumber = prisonerNumber,
+  prisonerFirstName = prisonerFirstName,
+  prisonerLastName = prisonerLastName,
+  appointmentInfo = appointmentInfo,
+  appointmentDate = appointmentDate,
+  probationTeam = probationTeam,
+  prison = prison,
+  comments = comments,
+  probationEmailAddress = probationEmailAddress,
+  prisonVideoUrl = prisonVideoUrl ?: "Not yet known",
+  probationOfficerName = probationOfficerName ?: "Not yet known",
+  probationOfficerEmailAddress = probationOfficerEmailAddress ?: "Not yet known",
+  probationOfficerContactNumber = probationOfficerContactNumber ?: "Not yet known",
+) {
+  init {
+    addPersonalisation("oldAppointmentDate", oldAppointmentDate.toMediumFormatStyle())
+    addPersonalisation("oldAppointmentInfo", oldAppointmentInfo)
+  }
+}
+
+class RescheduledProbationBookingPrisonNoProbationEmail(
+  address: String,
+  prisonerFirstName: String,
+  prisonerLastName: String,
+  prisonerNumber: String,
+  probationTeam: String,
+  prison: String,
+  appointmentDate: LocalDate,
+  appointmentInfo: String,
+  prisonVideoUrl: String?,
+  probationOfficerName: String?,
+  probationOfficerEmailAddress: String?,
+  probationOfficerContactNumber: String?,
+  comments: String?,
+  oldAppointmentDate: LocalDate,
+  oldAppointmentInfo: String,
+) : ProbationEmail(
+  address = address,
+  prisonerNumber = prisonerNumber,
+  prisonerFirstName = prisonerFirstName,
+  prisonerLastName = prisonerLastName,
+  appointmentInfo = appointmentInfo,
+  appointmentDate = appointmentDate,
+  probationTeam = probationTeam,
+  prison = prison,
+  prisonVideoUrl = prisonVideoUrl ?: "Not yet known",
+  probationOfficerName = probationOfficerName ?: "Not yet known",
+  probationOfficerEmailAddress = probationOfficerEmailAddress ?: "Not yet known",
+  probationOfficerContactNumber = probationOfficerContactNumber ?: "Not yet known",
+  comments = comments,
+) {
+  init {
+    addPersonalisation("oldAppointmentDate", oldAppointmentDate.toMediumFormatStyle())
+    addPersonalisation("oldAppointmentInfo", oldAppointmentInfo)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/RescheduledProbationEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/RescheduledProbationEmailFactory.kt
@@ -1,0 +1,162 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toHourMinuteStyle
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.VideoBookingEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingContact
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType.PROBATION
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ContactType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.VideoLinkBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.AdditionalBookingDetailRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.LocationsService
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.PrisonAppointment as ModelPrisonAppointment
+
+@Component
+class RescheduledProbationEmailFactory(
+  private val locationService: LocationsService,
+  private val additionalBookingDetailRepository: AdditionalBookingDetailRepository,
+) {
+  fun user(
+    oldBooking: VideoLinkBooking,
+    amendedBooking: VideoBooking,
+    contact: BookingContact,
+    prisoner: Prisoner,
+    prison: Prison,
+  ): VideoBookingEmail {
+    amendedBooking.requireIsProbationBooking()
+
+    require(contact.contactType == ContactType.USER) {
+      "Incorrect contact type ${contact.contactType} for probation user email"
+    }
+
+    val meeting = amendedBooking.probationMeeting()!!
+    val meetingLocation = locationService.getLocationById(meeting.prisonLocationId)!!
+    val additionalBookingDetail = additionalBookingDetailRepository.findByVideoBooking(amendedBooking)
+
+    return RescheduledProbationBookingUserEmail(
+      address = contact.email!!,
+      prisonerNumber = prisoner.prisonerNumber,
+      userName = contact.name ?: "Book Video",
+      probationTeam = amendedBooking.probationTeam!!.description,
+      appointmentDate = meeting.appointmentDate,
+      appointmentInfo = meeting.appointmentInformation(meetingLocation),
+      comments = amendedBooking.notesForStaff,
+      prisonerFirstName = prisoner.firstName,
+      prisonerLastName = prisoner.lastName,
+      prison = prison.name,
+      prisonVideoUrl = meetingLocation.extraAttributes?.prisonVideoUrl,
+      probationOfficerName = additionalBookingDetail?.contactName,
+      probationOfficerEmailAddress = additionalBookingDetail?.contactEmail,
+      probationOfficerContactNumber = additionalBookingDetail?.contactNumber,
+      oldAppointmentDate = oldBooking.prisonAppointments.single().appointmentDate,
+      oldAppointmentInfo = oldBooking.prisonAppointments.single().let { it.appointmentInformation(locationService.getLocationByKey(it.prisonLocKey)!!) },
+    )
+  }
+
+  fun probation(
+    oldBooking: VideoLinkBooking,
+    amendedBooking: VideoBooking,
+    contact: BookingContact,
+    prisoner: Prisoner,
+    prison: Prison,
+  ): VideoBookingEmail {
+    amendedBooking.requireIsProbationBooking()
+
+    require(contact.contactType == ContactType.PROBATION) {
+      "Incorrect contact type ${contact.contactType} for probation probation email"
+    }
+
+    val meeting = amendedBooking.probationMeeting()!!
+    val meetingLocation = locationService.getLocationById(meeting.prisonLocationId)!!
+    val additionalBookingDetail = additionalBookingDetailRepository.findByVideoBooking(amendedBooking)
+
+    return RescheduledProbationBookingProbationEmail(
+      address = contact.email!!,
+      prisonerNumber = prisoner.prisonerNumber,
+      prisonerFirstName = prisoner.firstName,
+      prisonerLastName = prisoner.lastName,
+      appointmentDate = meeting.appointmentDate,
+      probationTeam = amendedBooking.probationTeam!!.description,
+      comments = amendedBooking.notesForStaff,
+      appointmentInfo = meeting.appointmentInformation(meetingLocation),
+      prison = prison.name,
+      prisonVideoUrl = meetingLocation.extraAttributes?.prisonVideoUrl,
+      probationOfficerName = additionalBookingDetail?.contactName,
+      probationOfficerEmailAddress = additionalBookingDetail?.contactEmail,
+      probationOfficerContactNumber = additionalBookingDetail?.contactNumber,
+      oldAppointmentDate = oldBooking.prisonAppointments.single().appointmentDate,
+      oldAppointmentInfo = oldBooking.prisonAppointments.single().let { it.appointmentInformation(locationService.getLocationByKey(it.prisonLocKey)!!) },
+    )
+  }
+
+  fun prison(
+    oldBooking: VideoLinkBooking,
+    amendedBooking: VideoBooking,
+    contact: BookingContact,
+    prisoner: Prisoner,
+    prison: Prison,
+    contacts: Collection<BookingContact>,
+  ): VideoBookingEmail {
+    amendedBooking.requireIsProbationBooking()
+
+    require(contact.contactType == ContactType.PRISON) {
+      "Incorrect contact type ${contact.contactType} for prison probation email"
+    }
+
+    val meeting = amendedBooking.probationMeeting()!!
+    val meetingLocation = locationService.getLocationById(meeting.prisonLocationId)!!
+    val additionalBookingDetail = additionalBookingDetailRepository.findByVideoBooking(amendedBooking)
+
+    return contacts.primaryProbationContact()?.let { primaryProbationContact ->
+      RescheduledProbationBookingPrisonProbationEmail(
+        address = contact.email!!,
+        prisonerNumber = prisoner.prisonerNumber,
+        probationTeam = amendedBooking.probationTeam!!.description,
+        appointmentDate = meeting.appointmentDate,
+        appointmentInfo = meeting.appointmentInformation(meetingLocation),
+        comments = amendedBooking.notesForStaff,
+        prisonerFirstName = prisoner.firstName,
+        prisonerLastName = prisoner.lastName,
+        prison = prison.name,
+        probationEmailAddress = primaryProbationContact.email!!,
+        prisonVideoUrl = meetingLocation.extraAttributes?.prisonVideoUrl,
+        probationOfficerName = additionalBookingDetail?.contactName,
+        probationOfficerEmailAddress = additionalBookingDetail?.contactEmail,
+        probationOfficerContactNumber = additionalBookingDetail?.contactNumber,
+        oldAppointmentDate = oldBooking.prisonAppointments.single().appointmentDate,
+        oldAppointmentInfo = oldBooking.prisonAppointments.single().let { it.appointmentInformation(locationService.getLocationByKey(it.prisonLocKey)!!) },
+      )
+    } ?: RescheduledProbationBookingPrisonNoProbationEmail(
+      address = contact.email!!,
+      prisonerNumber = prisoner.prisonerNumber,
+      probationTeam = amendedBooking.probationTeam!!.description,
+      appointmentDate = meeting.appointmentDate,
+      appointmentInfo = meeting.appointmentInformation(meetingLocation),
+      comments = amendedBooking.notesForStaff,
+      prisonerFirstName = prisoner.firstName,
+      prisonerLastName = prisoner.lastName,
+      prison = prison.name,
+      prisonVideoUrl = meetingLocation.extraAttributes?.prisonVideoUrl,
+      probationOfficerName = additionalBookingDetail?.contactName,
+      probationOfficerEmailAddress = additionalBookingDetail?.contactEmail,
+      probationOfficerContactNumber = additionalBookingDetail?.contactNumber,
+      oldAppointmentDate = oldBooking.prisonAppointments.single().appointmentDate,
+      oldAppointmentInfo = oldBooking.prisonAppointments.single().let { it.appointmentInformation(locationService.getLocationByKey(it.prisonLocKey)!!) },
+    )
+  }
+
+  private fun VideoBooking.requireIsProbationBooking() {
+    require(isBookingType(PROBATION)) { "Booking ID $videoBookingId is not a probation booking" }
+  }
+
+  private fun PrisonAppointment.appointmentInformation(location: Location) = "${location.description} - ${startTime.toHourMinuteStyle()} to ${endTime.toHourMinuteStyle()}"
+
+  private fun Collection<BookingContact>.primaryProbationContact() = singleOrNull { it.contactType == ContactType.PROBATION && it.primaryContact }
+
+  private fun ModelPrisonAppointment.appointmentInformation(location: Location) = "${location.description} - ${startTime.toHourMinuteStyle()} to ${endTime.toHourMinuteStyle()}"
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -152,6 +152,11 @@ notify:
         prison-no-court-email: "da59e795-aef6-4cb9-be68-54435df8c8b1"
       hearing-link-reminder:
         court: "2a067470-bc6b-4169-8c94-4733ed28a203"
+      rescheduled-booking:
+        user: "84454dd9-6816-4d65-9f0a-ba2d711688ac"
+        court: "387f2593-3041-4cfd-b378-7f6fcee63ccb"
+        prison-court-email: "ac5a9fbe-6fdd-470e-b74b-b92f7ae9f5e3"
+        prison-no-court-email: "7a1b743b-29ea-422c-8896-b8ef14b43935"
     probation:
       booking-request:
         user: "4fcd9f4a-00d3-43e7-ac84-7eb3a19b2773"
@@ -182,6 +187,11 @@ notify:
         prison-no-probation-email: "816437b5-4d4b-4245-87db-91f3297c78a9"
       probation-officer-details-reminder:
         probation: "459a1bff-466f-42ed-bf6d-ad7206342fbb"
+      rescheduled-booking:
+        user: "cd7a1305-6eda-40e0-a816-32e733fd163c"
+        probation: "0d7ba32b-1a4e-4a07-a146-cf4cc85de153"
+        prison-probation-email: "462767ff-de71-474d-8559-27f2d579663b"
+        prison-no-probation-email: "126949ed-cc62-4ca8-8bc3-95ef13c015ba"
 
 springdoc:
   swagger-ui:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailTemplatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/config/EmailTemplatesTest.kt
@@ -23,6 +23,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.ReleasedCourtBookingCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.ReleasedCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.ReleasedCourtBookingPrisonNoCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtBookingCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtBookingPrisonCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtBookingPrisonNoCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.TransferredCourtBookingCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.TransferredCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.TransferredCourtBookingPrisonNoCourtEmail
@@ -45,6 +49,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probat
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ReleasedProbationBookingPrisonNoProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ReleasedProbationBookingPrisonProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ReleasedProbationBookingProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationBookingPrisonNoProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationBookingPrisonProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationBookingProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.TransferredProbationBookingPrisonNoProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.TransferredProbationBookingPrisonProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.TransferredProbationBookingProbationEmail
@@ -97,6 +105,14 @@ class EmailTemplatesTest {
     CourtHearingLinkReminderEmail::class.java to "courtHearingLinkReminderEmail",
     ProbationOfficerDetailsReminderEmail::class.java to "probationOfficerDetailsReminderEmail",
     AdministrationNewVideoRoomEmail::class.java to "administrationNewVideoRoom",
+    RescheduledCourtBookingUserEmail::class.java to "rescheduledCourtBookingUser",
+    RescheduledCourtBookingCourtEmail::class.java to "rescheduledCourtBookingCourtEmail",
+    RescheduledCourtBookingPrisonCourtEmail::class.java to "rescheduledCourtBookingPrisonCourtEmail",
+    RescheduledCourtBookingPrisonNoCourtEmail::class.java to "rescheduledCourtBookingPrisonNoCourtEmail",
+    RescheduledProbationBookingUserEmail::class.java to "rescheduledProbationBookingUser",
+    RescheduledProbationBookingPrisonProbationEmail::class.java to "rescheduledProbationBookingPrisonProbationEmail",
+    RescheduledProbationBookingPrisonNoProbationEmail::class.java to "rescheduledProbationBookingPrisonNoProbationEmail",
+    RescheduledProbationBookingProbationEmail::class.java to "rescheduledProbationBookingProbationEmail",
   )
 
   private val templates = EmailTemplates(
@@ -145,6 +161,14 @@ class EmailTemplatesTest {
     courtHearingLinkReminderEmail = "courtHearingLinkReminderEmail",
     probationOfficerDetailsReminderEmail = "probationOfficerDetailsReminderEmail",
     administrationNewVideoRoom = "administrationNewVideoRoom",
+    rescheduledCourtBookingUser = "rescheduledCourtBookingUser",
+    rescheduledCourtBookingCourtEmail = "rescheduledCourtBookingCourtEmail",
+    rescheduledCourtBookingPrisonCourtEmail = "rescheduledCourtBookingPrisonCourtEmail",
+    rescheduledCourtBookingPrisonNoCourtEmail = "rescheduledCourtBookingPrisonNoCourtEmail",
+    rescheduledProbationBookingUser = "rescheduledProbationBookingUser",
+    rescheduledProbationBookingPrisonProbationEmail = "rescheduledProbationBookingPrisonProbationEmail",
+    rescheduledProbationBookingPrisonNoProbationEmail = "rescheduledProbationBookingPrisonNoProbationEmail",
+    rescheduledProbationBookingProbationEmail = "rescheduledProbationBookingProbationEmail",
   )
 
   @Test
@@ -201,9 +225,17 @@ class EmailTemplatesTest {
       "13",
       "14",
       "15",
-      courtHearingLinkReminderEmail = "16",
-      probationOfficerDetailsReminderEmail = "17",
-      administrationNewVideoRoom = "18",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
     )
 
     val error = assertThrows<IllegalArgumentException> {
@@ -250,9 +282,17 @@ class EmailTemplatesTest {
         "13",
         "duplicate",
         "duplicate",
-        courtHearingLinkReminderEmail = "14",
-        probationOfficerDetailsReminderEmail = "15",
-        administrationNewVideoRoom = "16",
+        "14",
+        "15",
+        "16",
+        "17",
+        "18",
+        "19",
+        "20",
+        "21",
+        "22",
+        "23",
+        "24",
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/BookingFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/BookingFacadeTest.kt
@@ -68,6 +68,7 @@ class BookingFacadeTest {
   private val availabilityService: AvailabilityService = mock()
   private val changeTrackingService: ChangeTrackingService = mock()
   private val emailFacade: EmailFacade = mock()
+  private val rescheduleEmailsFacade: RescheduleEmailsFacade = mock()
   private val facade = BookingFacade(
     videoBookingServiceDelegate,
     outboundEventsService,
@@ -76,6 +77,7 @@ class BookingFacadeTest {
     availabilityService,
     changeTrackingService,
     emailFacade,
+    rescheduleEmailsFacade,
   )
   private val courtBooking = courtBooking(notesForStaff = "court notes for staff")
     .addAppointment(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/BookingFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/BookingFacadeTest.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_BIRMINGHAM
@@ -68,6 +69,7 @@ class BookingFacadeTest {
   private val availabilityService: AvailabilityService = mock()
   private val changeTrackingService: ChangeTrackingService = mock()
   private val emailFacade: EmailFacade = mock()
+  private val featureSwitches: FeatureSwitches = mock()
   private val rescheduleEmailsFacade: RescheduleEmailsFacade = mock()
   private val facade = BookingFacade(
     videoBookingServiceDelegate,
@@ -77,6 +79,7 @@ class BookingFacadeTest {
     availabilityService,
     changeTrackingService,
     emailFacade,
+    featureSwitches,
     rescheduleEmailsFacade,
   )
   private val courtBooking = courtBooking(notesForStaff = "court notes for staff")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/config/FeatureSwitchesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/config/FeatureSwitchesTest.kt
@@ -31,6 +31,7 @@ class FeatureSwitchesTest : IntegrationTestBase() {
       "feature.public.private.comments.sync=true",
       "feature.court.only.prisons=PVI",
       "feature.probation.only.prisons=MDI",
+      "feature.send.rescheduled.emails=true",
     ],
   )
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import org.springframework.test.context.jdbc.Sql
@@ -97,11 +98,15 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.NewCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.NewCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.NewCourtBookingUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtBookingPrisonCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.AmendedProbationBookingPrisonProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.AmendedProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationBookingRequestPrisonNoProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationBookingRequestPrisonProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationBookingRequestUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationBookingPrisonProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.AppointmentCreatedEvent
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.AppointmentInformation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.events.DomainEvent
@@ -117,6 +122,7 @@ import java.util.UUID
 import kotlin.reflect.KClass
 
 @ContextConfiguration(classes = [TestEmailConfiguration::class])
+@TestPropertySource(properties = ["feature.send.rescheduled.emails=true"])
 class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
 
   @MockitoSpyBean
@@ -968,7 +974,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
   }
 
   @Test
-  fun `should amend a Derby court booking and emails sent to Pentonville prison`() {
+  fun `should reschedule a Derby court booking and emails sent to Pentonville prison`() {
     videoBookingRepository.findAll() hasSize 0
     notificationRepository.findAll() hasSize 0
 
@@ -1025,9 +1031,9 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     // There should be 3 notifications, 1 user email and 2 prison emails
     val notifications = notificationRepository.findAll().also { it hasSize 3 }
 
-    notifications.isPresent("p@p.com", AmendedCourtBookingPrisonCourtEmail::class, persistedBooking)
-    notifications.isPresent("g@g.com", AmendedCourtBookingPrisonCourtEmail::class, persistedBooking)
-    notifications.isPresent(COURT_USER.email!!, AmendedCourtBookingUserEmail::class, persistedBooking)
+    notifications.isPresent("p@p.com", RescheduledCourtBookingPrisonCourtEmail::class, persistedBooking)
+    notifications.isPresent("g@g.com", RescheduledCourtBookingPrisonCourtEmail::class, persistedBooking)
+    notifications.isPresent(COURT_USER.email!!, RescheduledCourtBookingUserEmail::class, persistedBooking)
   }
 
   @Test
@@ -1053,8 +1059,8 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
       prisonerNumber = "123456",
       prisonCode = BIRMINGHAM,
       location = birminghamLocation,
-      startTime = LocalTime.of(13, 0),
-      endTime = LocalTime.of(14, 30),
+      startTime = LocalTime.of(12, 0),
+      endTime = LocalTime.of(12, 30),
       notesForStaff = "amended integration test court booking staff note",
     )
 
@@ -1082,8 +1088,8 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
       appointmentType isEqualTo AppointmentType.VLB_COURT_MAIN.name
       appointmentDate isEqualTo tomorrow()
       prisonLocationId isEqualTo birminghamLocation.id
-      startTime isEqualTo LocalTime.of(13, 0)
-      endTime isEqualTo LocalTime.of(14, 30)
+      startTime isEqualTo LocalTime.of(12, 0)
+      endTime isEqualTo LocalTime.of(12, 30)
       notesForStaff isEqualTo "amended integration test court booking staff note"
     }
 
@@ -1375,7 +1381,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
   }
 
   @Test
-  fun `should amend a probation booking when prisoner has been transferred to a different prison`() {
+  fun `should amend a probation booking when prisoner has when meeting type is changed`() {
     videoBookingRepository.findAll() hasSize 0
 
     prisonSearchApi().stubGetPrisoner("123456", BIRMINGHAM)
@@ -1393,7 +1399,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
 
     val videoBookingId = webTestClient.createBooking(probationBookingRequest, PROBATION_USER)
 
-    prisonSearchApi().stubGetPrisoner("123456", WANDSWORTH)
+    prisonSearchApi().stubGetPrisoner("123456", BIRMINGHAM)
 
     val amendBookingRequest = amendProbationBookingRequest(
       probationMeetingType = ProbationMeetingType.OTHER,
@@ -1414,6 +1420,48 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
     val notifications = notificationRepository.findAll().also { it hasSize 2 }
     notifications.isPresent("a@a.com", AmendedProbationBookingPrisonProbationEmail::class, persistedBooking)
     notifications.isPresent(PROBATION_USER.email!!, AmendedProbationBookingUserEmail::class, persistedBooking)
+  }
+
+  @Test
+  fun `should reschedule a probation booking when prisoner has when time changed`() {
+    videoBookingRepository.findAll() hasSize 0
+
+    prisonSearchApi().stubGetPrisoner("123456", BIRMINGHAM)
+
+    val probationBookingRequest = probationBookingRequest(
+      probationTeamCode = BLACKPOOL_MC_PPOC,
+      probationMeetingType = ProbationMeetingType.PSR,
+      prisonCode = BIRMINGHAM,
+      prisonerNumber = "123456",
+      startTime = LocalTime.of(9, 0),
+      endTime = LocalTime.of(9, 30),
+      appointmentType = AppointmentType.VLB_PROBATION,
+      location = birminghamLocation,
+    )
+
+    val videoBookingId = webTestClient.createBooking(probationBookingRequest, PROBATION_USER)
+
+    prisonSearchApi().stubGetPrisoner("123456", BIRMINGHAM)
+
+    val amendBookingRequest = amendProbationBookingRequest(
+      probationMeetingType = ProbationMeetingType.PSR,
+      prisonCode = BIRMINGHAM,
+      prisonerNumber = "123456",
+      startTime = LocalTime.of(9, 30),
+      endTime = LocalTime.of(10, 0),
+      appointmentType = AppointmentType.VLB_PROBATION,
+      location = birminghamLocation,
+    )
+
+    notificationRepository.deleteAll()
+    webTestClient.amendBooking(videoBookingId, amendBookingRequest, PROBATION_USER)
+
+    val persistedBooking = videoBookingRepository.findById(videoBookingId).orElseThrow()
+
+    // There should be a user email
+    val notifications = notificationRepository.findAll().also { it hasSize 2 }
+    notifications.isPresent("a@a.com", RescheduledProbationBookingPrisonProbationEmail::class, persistedBooking)
+    notifications.isPresent(PROBATION_USER.email!!, RescheduledProbationBookingUserEmail::class, persistedBooking)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoBookingServiceDelegateTest.kt
@@ -24,6 +24,7 @@ class VideoBookingServiceDelegateTest {
   private val amendProbationBookingService: AmendProbationBookingService = mock()
   private val cancelVideoBookingService: CancelVideoBookingService = mock()
   private val requestBookingService: RequestBookingService = mock()
+  private val videoLinkBookingsService: VideoLinkBookingsService = mock()
   private val maxDaysIntoFuture = 100L
 
   private val delegate =
@@ -34,6 +35,7 @@ class VideoBookingServiceDelegateTest {
       amendProbationBookingService,
       cancelVideoBookingService,
       requestBookingService,
+      videoLinkBookingsService,
       maxDaysIntoFuture,
     )
 
@@ -51,7 +53,8 @@ class VideoBookingServiceDelegateTest {
     delegate.create(probationBookingRequest, PROBATION_USER)
     verify(createProbationBookingService).create(probationBookingRequest, PROBATION_USER)
 
-    verifyNoMoreInteractions(createCourtBookingService)
+    verifyNoMoreInteractions(createCourtBookingService, createProbationBookingService)
+    verifyNoInteractions(amendProbationBookingService, cancelVideoBookingService, requestBookingService, videoLinkBookingsService)
   }
 
   @Test
@@ -62,7 +65,7 @@ class VideoBookingServiceDelegateTest {
     delegate.amend(2, amendProbationBookingRequest, PROBATION_USER)
     verify(amendProbationBookingService).amend(2, amendProbationBookingRequest, PROBATION_USER)
 
-    verifyNoInteractions(createCourtBookingService, createProbationBookingService)
+    verifyNoInteractions(createCourtBookingService, createProbationBookingService, cancelVideoBookingService, requestBookingService, videoLinkBookingsService)
   }
 
   @Test
@@ -70,7 +73,7 @@ class VideoBookingServiceDelegateTest {
     delegate.cancel(1, COURT_USER)
     verify(cancelVideoBookingService).cancel(1, COURT_USER)
 
-    verifyNoInteractions(createCourtBookingService, createProbationBookingService, amendCourtBookingService)
+    verifyNoInteractions(createCourtBookingService, createProbationBookingService, amendCourtBookingService, requestBookingService, videoLinkBookingsService)
   }
 
   @Test
@@ -79,7 +82,16 @@ class VideoBookingServiceDelegateTest {
 
     verify(requestBookingService).request(requestVideoBookingRequest, COURT_USER)
 
-    verifyNoInteractions(createCourtBookingService, createProbationBookingService, amendCourtBookingService, cancelVideoBookingService)
+    verifyNoInteractions(createCourtBookingService, createProbationBookingService, amendCourtBookingService, cancelVideoBookingService, videoLinkBookingsService)
+  }
+
+  @Test
+  fun `should delegate to video link booking service service`() {
+    delegate.getVideoBookingById(1, COURT_USER)
+
+    verify(videoLinkBookingsService).getVideoLinkBookingById(1, COURT_USER)
+
+    verifyNoInteractions(createCourtBookingService, createProbationBookingService, amendCourtBookingService, cancelVideoBookingService, requestBookingService)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/GovNotifyEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/GovNotifyEmailServiceTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.EmailTemplates
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.VideoBookingEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.administration.AdministrationNewVideoRoomEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.AmendedCourtBookingPrisonNoCourtEmail
@@ -28,6 +29,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.NewCourtBookingPrisonCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.NewCourtBookingPrisonNoCourtEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.NewCourtBookingUserEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtBookingCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtBookingPrisonCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtBookingPrisonNoCourtEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtBookingUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.AmendedProbationBookingPrisonNoProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.AmendedProbationBookingPrisonProbationEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.AmendedProbationBookingProbationEmail
@@ -39,6 +44,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probat
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationBookingRequestPrisonProbationTeamEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationBookingRequestUserEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.ProbationOfficerDetailsReminderEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationBookingPrisonNoProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationBookingPrisonProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationBookingProbationEmail
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationBookingUserEmail
 import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.NotificationClientException
 import uk.gov.service.notify.SendEmailResponse
@@ -76,6 +85,10 @@ class GovNotifyEmailServiceTest {
     releaseCourtBookingCourt = "releaseCourtBookingCourt",
     releaseCourtBookingPrisonCourtEmail = "releaseCourtBookingPrisonCourtEmail",
     releaseCourtBookingPrisonNoCourtEmail = "releaseCourtBookingPrisonNoCourtEmail",
+    rescheduledCourtBookingUser = "rescheduledCourtBookingUser",
+    rescheduledCourtBookingCourtEmail = "rescheduledCourtBookingCourtEmail",
+    rescheduledCourtBookingPrisonCourtEmail = "rescheduledCourtBookingPrisonCourtEmail",
+    rescheduledCourtBookingPrisonNoCourtEmail = "rescheduledCourtBookingPrisonNoCourtEmail",
     newProbationBookingUser = "newProbationBookingUser",
     newProbationBookingProbation = "newProbationBookingProbation",
     newProbationBookingPrisonProbationEmail = "newProbationBookingPrisonProbationEmail",
@@ -97,6 +110,10 @@ class GovNotifyEmailServiceTest {
     courtHearingLinkReminderEmail = "courtHearingLinkReminderEmail",
     probationOfficerDetailsReminderEmail = "probationOfficerDetailsReminderEmail",
     administrationNewVideoRoom = "administrationNewVideoRoomEmail",
+    rescheduledProbationBookingUser = "rescheduledProbationBookingUser",
+    rescheduledProbationBookingPrisonProbationEmail = "rescheduledProbationBookingPrisonProbationEmail",
+    rescheduledProbationBookingPrisonNoProbationEmail = "rescheduledProbationBookingPrisonNoProbationEmail",
+    rescheduledProbationBookingProbationEmail = "rescheduledProbationBookingProbationEmail",
   )
 
   private val service = GovNotifyEmailService(client, emailTemplates, "http://localhost:3000")
@@ -1260,6 +1277,409 @@ class GovNotifyEmailServiceTest {
       "administrationNewVideoRoomEmail",
       "recipient@emailaddress.com",
       mapOf("prisonsAndRooms" to "Moorland\nRoom 1\nRoom 2\nRoom 3\n\nRisley\nRoom 10\nRoom 12\nRoom 18\n\n", "frontendDomain" to "http://localhost:3000"),
+      null,
+    )
+  }
+
+  @Test
+  fun `should send court rescheduled booking user email and return a notification ID`() {
+    val result = service.send(
+      RescheduledCourtBookingUserEmail(
+        address = "recipient@emailaddress.com",
+        prisonerFirstName = "builder",
+        prisonerLastName = "bob",
+        prisonerNumber = "123456",
+        userName = "username",
+        appointmentDate = today,
+        comments = "comments for bob",
+        preAppointmentDetails = AppointmentDetails("pre", LocalTime.of(11, 0), LocalTime.of(11, 15), "pre-link"),
+        mainAppointmentDetails = AppointmentDetails("main", LocalTime.of(11, 15), LocalTime.of(11, 30), "main-link"),
+        postAppointmentDetails = AppointmentDetails("post", LocalTime.of(11, 30), LocalTime.of(11, 45), "post-link"),
+        court = "the court",
+        prison = "the prison",
+        courtHearingLink = "https://video.link.com",
+        oldAppointmentDate = tomorrow(),
+        oldPreAppointmentDetails = AppointmentDetails("pre", LocalTime.of(11, 0), LocalTime.of(11, 15), "pre-link"),
+        oldMainAppointmentDetails = AppointmentDetails("main", LocalTime.of(11, 15), LocalTime.of(11, 30), "main-link"),
+        oldPostAppointmentDetails = AppointmentDetails("post", LocalTime.of(11, 30), LocalTime.of(11, 45), "post-link"),
+      ),
+    )
+
+    result.getOrThrow() isEqualTo Pair(notificationId, "rescheduledCourtBookingUser")
+
+    verify(client).sendEmail(
+      "rescheduledCourtBookingUser",
+      "recipient@emailaddress.com",
+      mapOf(
+        "date" to today.toMediumFormatStyle(),
+        "prisonerName" to "builder bob",
+        "offenderNo" to "123456",
+        "comments" to "comments for bob",
+        "userName" to "username",
+        "court" to "the court",
+        "prison" to "the prison",
+        "preAppointmentInfo" to "pre - 11:00 to 11:15",
+        "mainAppointmentInfo" to "main - 11:15 to 11:30",
+        "postAppointmentInfo" to "post - 11:30 to 11:45",
+        "courtHearingLink" to "https://video.link.com",
+        "frontendDomain" to "http://localhost:3000",
+        "prePrisonVideoUrl" to "Pre-court hearing link (PVL): pre-link",
+        "postPrisonVideoUrl" to "Post-court hearing link (PVL): post-link",
+        "oldAppointmentDate" to tomorrow().toMediumFormatStyle(),
+        "oldPreAppointmentInfo" to "pre - 11:00 to 11:15",
+        "oldMainAppointmentInfo" to "main - 11:15 to 11:30",
+        "oldPostAppointmentInfo" to "post - 11:30 to 11:45",
+      ),
+      null,
+    )
+  }
+
+  @Test
+  fun `should send court rescheduled booking court email and return a notification ID`() {
+    val result = service.send(
+      RescheduledCourtBookingCourtEmail(
+        address = "recipient@emailaddress.com",
+        prisonerFirstName = "builder",
+        prisonerLastName = "bob",
+        prisonerNumber = "123456",
+        appointmentDate = today,
+        comments = "comments for bob",
+        preAppointmentDetails = AppointmentDetails("pre", LocalTime.of(11, 0), LocalTime.of(11, 15), "pre-link"),
+        mainAppointmentDetails = AppointmentDetails("main", LocalTime.of(11, 15), LocalTime.of(11, 30), "main-link"),
+        postAppointmentDetails = AppointmentDetails("post", LocalTime.of(11, 30), LocalTime.of(11, 45), "post-link"),
+        court = "the court",
+        prison = "the prison",
+        courtHearingLink = "https://video.link.com",
+        oldAppointmentDate = tomorrow(),
+        oldPreAppointmentDetails = AppointmentDetails("pre", LocalTime.of(11, 0), LocalTime.of(11, 15), "pre-link"),
+        oldMainAppointmentDetails = AppointmentDetails("main", LocalTime.of(11, 15), LocalTime.of(11, 30), "main-link"),
+        oldPostAppointmentDetails = AppointmentDetails("post", LocalTime.of(11, 30), LocalTime.of(11, 45), "post-link"),
+      ),
+    )
+
+    result.getOrThrow() isEqualTo Pair(notificationId, "rescheduledCourtBookingCourtEmail")
+
+    verify(client).sendEmail(
+      "rescheduledCourtBookingCourtEmail",
+      "recipient@emailaddress.com",
+      mapOf(
+        "date" to today.toMediumFormatStyle(),
+        "prisonerName" to "builder bob",
+        "offenderNo" to "123456",
+        "comments" to "comments for bob",
+        "court" to "the court",
+        "prison" to "the prison",
+        "preAppointmentInfo" to "pre - 11:00 to 11:15",
+        "mainAppointmentInfo" to "main - 11:15 to 11:30",
+        "postAppointmentInfo" to "post - 11:30 to 11:45",
+        "courtHearingLink" to "https://video.link.com",
+        "frontendDomain" to "http://localhost:3000",
+        "prePrisonVideoUrl" to "Pre-court hearing link (PVL): pre-link",
+        "postPrisonVideoUrl" to "Post-court hearing link (PVL): post-link",
+        "oldAppointmentDate" to tomorrow().toMediumFormatStyle(),
+        "oldPreAppointmentInfo" to "pre - 11:00 to 11:15",
+        "oldMainAppointmentInfo" to "main - 11:15 to 11:30",
+        "oldPostAppointmentInfo" to "post - 11:30 to 11:45",
+      ),
+      null,
+    )
+  }
+
+  @Test
+  fun `should send prison rescheduled booking from court with email and return a notification ID`() {
+    val result = service.send(
+      RescheduledCourtBookingPrisonCourtEmail(
+        address = "recipient@emailaddress.com",
+        prisonerFirstName = "builder",
+        prisonerLastName = "bob",
+        prisonerNumber = "123456",
+        appointmentDate = today,
+        comments = "comments for bob",
+        preAppointmentDetails = AppointmentDetails("pre", LocalTime.of(11, 0), LocalTime.of(11, 15), "pre-link"),
+        mainAppointmentDetails = AppointmentDetails("main", LocalTime.of(11, 15), LocalTime.of(11, 30), "main-link"),
+        postAppointmentDetails = AppointmentDetails("post", LocalTime.of(11, 30), LocalTime.of(11, 45), "post-link"),
+        court = "the court",
+        courtEmailAddress = "court@emailaddress.com",
+        prison = "the prison",
+        courtHearingLink = "https://video.link.com",
+        oldAppointmentDate = tomorrow(),
+        oldPreAppointmentDetails = AppointmentDetails("pre", LocalTime.of(11, 0), LocalTime.of(11, 15), "pre-link"),
+        oldMainAppointmentDetails = AppointmentDetails("main", LocalTime.of(11, 15), LocalTime.of(11, 30), "main-link"),
+        oldPostAppointmentDetails = AppointmentDetails("post", LocalTime.of(11, 30), LocalTime.of(11, 45), "post-link"),
+      ),
+    )
+
+    result.getOrThrow() isEqualTo Pair(notificationId, "rescheduledCourtBookingPrisonCourtEmail")
+
+    verify(client).sendEmail(
+      "rescheduledCourtBookingPrisonCourtEmail",
+      "recipient@emailaddress.com",
+      mapOf(
+        "date" to today.toMediumFormatStyle(),
+        "prisonerName" to "builder bob",
+        "offenderNo" to "123456",
+        "comments" to "comments for bob",
+        "court" to "the court",
+        "courtEmailAddress" to "court@emailaddress.com",
+        "prison" to "the prison",
+        "preAppointmentInfo" to "pre - 11:00 to 11:15",
+        "mainAppointmentInfo" to "main - 11:15 to 11:30",
+        "postAppointmentInfo" to "post - 11:30 to 11:45",
+        "courtHearingLink" to "https://video.link.com",
+        "frontendDomain" to "http://localhost:3000",
+        "prePrisonVideoUrl" to "Pre-court hearing link (PVL): pre-link",
+        "postPrisonVideoUrl" to "Post-court hearing link (PVL): post-link",
+        "oldAppointmentDate" to tomorrow().toMediumFormatStyle(),
+        "oldPreAppointmentInfo" to "pre - 11:00 to 11:15",
+        "oldMainAppointmentInfo" to "main - 11:15 to 11:30",
+        "oldPostAppointmentInfo" to "post - 11:30 to 11:45",
+      ),
+      null,
+    )
+  }
+
+  @Test
+  fun `should send prison rescheduled booking from court with no email and return a notification ID`() {
+    val result = service.send(
+      RescheduledCourtBookingPrisonNoCourtEmail(
+        address = "recipient@emailaddress.com",
+        prisonerFirstName = "builder",
+        prisonerLastName = "bob",
+        prisonerNumber = "123456",
+        appointmentDate = today,
+        comments = "comments for bob",
+        preAppointmentDetails = AppointmentDetails("pre", LocalTime.of(11, 0), LocalTime.of(11, 15), "pre-link"),
+        mainAppointmentDetails = AppointmentDetails("main", LocalTime.of(11, 15), LocalTime.of(11, 30), "main-link"),
+        postAppointmentDetails = AppointmentDetails("post", LocalTime.of(11, 30), LocalTime.of(11, 45), "post-link"),
+        court = "the court",
+        prison = "the prison",
+        courtHearingLink = "https://video.link.com",
+        oldAppointmentDate = tomorrow(),
+        oldPreAppointmentDetails = AppointmentDetails("pre", LocalTime.of(11, 0), LocalTime.of(11, 15), "pre-link"),
+        oldMainAppointmentDetails = AppointmentDetails("main", LocalTime.of(11, 15), LocalTime.of(11, 30), "main-link"),
+        oldPostAppointmentDetails = AppointmentDetails("post", LocalTime.of(11, 30), LocalTime.of(11, 45), "post-link"),
+      ),
+    )
+
+    result.getOrThrow() isEqualTo Pair(notificationId, "rescheduledCourtBookingPrisonNoCourtEmail")
+
+    verify(client).sendEmail(
+      "rescheduledCourtBookingPrisonNoCourtEmail",
+      "recipient@emailaddress.com",
+      mapOf(
+        "date" to today.toMediumFormatStyle(),
+        "prisonerName" to "builder bob",
+        "offenderNo" to "123456",
+        "comments" to "comments for bob",
+        "court" to "the court",
+        "prison" to "the prison",
+        "preAppointmentInfo" to "pre - 11:00 to 11:15",
+        "mainAppointmentInfo" to "main - 11:15 to 11:30",
+        "postAppointmentInfo" to "post - 11:30 to 11:45",
+        "courtHearingLink" to "https://video.link.com",
+        "frontendDomain" to "http://localhost:3000",
+        "prePrisonVideoUrl" to "Pre-court hearing link (PVL): pre-link",
+        "postPrisonVideoUrl" to "Post-court hearing link (PVL): post-link",
+        "oldAppointmentDate" to tomorrow().toMediumFormatStyle(),
+        "oldPreAppointmentInfo" to "pre - 11:00 to 11:15",
+        "oldMainAppointmentInfo" to "main - 11:15 to 11:30",
+        "oldPostAppointmentInfo" to "post - 11:30 to 11:45",
+      ),
+      null,
+    )
+  }
+
+  @Test
+  fun `should send rescheduled probation user amend booking email and return a notification ID`() {
+    val result = service.send(
+      RescheduledProbationBookingUserEmail(
+        address = "recipient@emailaddress.com",
+        prisonerFirstName = "builder",
+        prisonerLastName = "bob",
+        prisonerNumber = "123456",
+        appointmentDate = today,
+        userName = "username",
+        comments = "comments for bob",
+        appointmentInfo = "bobs appointment info",
+        probationTeam = "the probation team",
+        prison = "the prison",
+        prisonVideoUrl = "prison-video-url",
+        probationOfficerName = "probation officer name",
+        probationOfficerEmailAddress = "probation.officer@email.address",
+        probationOfficerContactNumber = "123456",
+        oldAppointmentDate = tomorrow(),
+        oldAppointmentInfo = "bobs appointment info",
+      ),
+    )
+
+    result.getOrThrow() isEqualTo Pair(notificationId, "rescheduledProbationBookingUser")
+
+    verify(client).sendEmail(
+      "rescheduledProbationBookingUser",
+      "recipient@emailaddress.com",
+      mapOf(
+        "date" to today.toMediumFormatStyle(),
+        "prisonerName" to "builder bob",
+        "comments" to "comments for bob",
+        "offenderNo" to "123456",
+        "userName" to "username",
+        "probationTeam" to "the probation team",
+        "prison" to "the prison",
+        "appointmentInfo" to "bobs appointment info",
+        "frontendDomain" to "http://localhost:3000",
+        "prisonVideoUrl" to "prison-video-url",
+        "probationOfficerName" to "probation officer name",
+        "probationOfficerEmailAddress" to "probation.officer@email.address",
+        "probationOfficerContactNumber" to "123456",
+        "oldAppointmentDate" to tomorrow().toMediumFormatStyle(),
+        "oldAppointmentInfo" to "bobs appointment info",
+      ),
+      null,
+    )
+  }
+
+  @Test
+  fun `should send rescheduled probation booking email and return a notification ID`() {
+    val result = service.send(
+      RescheduledProbationBookingProbationEmail(
+        address = "recipient@emailaddress.com",
+        prisonerFirstName = "builder",
+        prisonerLastName = "bob",
+        prisonerNumber = "123456",
+        appointmentDate = today,
+        comments = "comments for bob",
+        appointmentInfo = "bobs appointment info",
+        probationTeam = "the probation team",
+        prison = "the prison",
+        prisonVideoUrl = "prison-video-url",
+        probationOfficerName = "probation officer name",
+        probationOfficerEmailAddress = "probation.officer@email.address",
+        probationOfficerContactNumber = "123456",
+        oldAppointmentDate = tomorrow(),
+        oldAppointmentInfo = "bobs appointment info",
+      ),
+    )
+
+    result.getOrThrow() isEqualTo Pair(notificationId, "rescheduledProbationBookingProbationEmail")
+
+    verify(client).sendEmail(
+      "rescheduledProbationBookingProbationEmail",
+      "recipient@emailaddress.com",
+      mapOf(
+        "date" to today.toMediumFormatStyle(),
+        "prisonerName" to "builder bob",
+        "comments" to "comments for bob",
+        "offenderNo" to "123456",
+        "probationTeam" to "the probation team",
+        "prison" to "the prison",
+        "appointmentInfo" to "bobs appointment info",
+        "frontendDomain" to "http://localhost:3000",
+        "prisonVideoUrl" to "prison-video-url",
+        "probationOfficerName" to "probation officer name",
+        "probationOfficerEmailAddress" to "probation.officer@email.address",
+        "probationOfficerContactNumber" to "123456",
+        "prisonVideoUrl" to "prison-video-url",
+        "oldAppointmentDate" to tomorrow().toMediumFormatStyle(),
+        "oldAppointmentInfo" to "bobs appointment info",
+      ),
+      null,
+    )
+  }
+
+  @Test
+  fun `should send rescheduled probation booking prison probation email and return a notification ID`() {
+    val result = service.send(
+      RescheduledProbationBookingPrisonProbationEmail(
+        address = "recipient@emailaddress.com",
+        prisonerFirstName = "builder",
+        prisonerLastName = "bob",
+        prisonerNumber = "123456",
+        appointmentDate = today,
+        comments = "comments for bob",
+        appointmentInfo = "bobs appointment info",
+        probationTeam = "the probation team",
+        prison = "the prison",
+        probationEmailAddress = "probation.team@email.address",
+        prisonVideoUrl = "prison-video-url",
+        probationOfficerName = "probation officer name",
+        probationOfficerEmailAddress = "probation.officer@email.address",
+        probationOfficerContactNumber = "123456",
+        oldAppointmentDate = tomorrow(),
+        oldAppointmentInfo = "bobs appointment info",
+      ),
+    )
+
+    result.getOrThrow() isEqualTo Pair(notificationId, "rescheduledProbationBookingPrisonProbationEmail")
+
+    verify(client).sendEmail(
+      "rescheduledProbationBookingPrisonProbationEmail",
+      "recipient@emailaddress.com",
+      mapOf(
+        "date" to today.toMediumFormatStyle(),
+        "prisonerName" to "builder bob",
+        "comments" to "comments for bob",
+        "offenderNo" to "123456",
+        "probationTeam" to "the probation team",
+        "prison" to "the prison",
+        "probationEmailAddress" to "probation.team@email.address",
+        "appointmentInfo" to "bobs appointment info",
+        "frontendDomain" to "http://localhost:3000",
+        "prisonVideoUrl" to "prison-video-url",
+        "probationOfficerName" to "probation officer name",
+        "probationOfficerEmailAddress" to "probation.officer@email.address",
+        "probationOfficerContactNumber" to "123456",
+        "prisonVideoUrl" to "prison-video-url",
+        "oldAppointmentDate" to tomorrow().toMediumFormatStyle(),
+        "oldAppointmentInfo" to "bobs appointment info",
+      ),
+      null,
+    )
+  }
+
+  @Test
+  fun `should send rescheduled probation booking prison no probation email and return a notification ID`() {
+    val result = service.send(
+      RescheduledProbationBookingPrisonNoProbationEmail(
+        address = "recipient@emailaddress.com",
+        prisonerFirstName = "builder",
+        prisonerLastName = "bob",
+        prisonerNumber = "123456",
+        appointmentDate = today,
+        comments = "comments for bob",
+        appointmentInfo = "bobs appointment info",
+        probationTeam = "the probation team",
+        prison = "the prison",
+        prisonVideoUrl = "prison-video-url",
+        probationOfficerName = "probation officer name",
+        probationOfficerEmailAddress = "probation.officer@email.address",
+        probationOfficerContactNumber = "123456",
+        oldAppointmentDate = tomorrow(),
+        oldAppointmentInfo = "bobs appointment info",
+      ),
+    )
+
+    result.getOrThrow() isEqualTo Pair(notificationId, "rescheduledProbationBookingPrisonNoProbationEmail")
+
+    verify(client).sendEmail(
+      "rescheduledProbationBookingPrisonNoProbationEmail",
+      "recipient@emailaddress.com",
+      mapOf(
+        "date" to today.toMediumFormatStyle(),
+        "prisonerName" to "builder bob",
+        "comments" to "comments for bob",
+        "offenderNo" to "123456",
+        "probationTeam" to "the probation team",
+        "prison" to "the prison",
+        "appointmentInfo" to "bobs appointment info",
+        "frontendDomain" to "http://localhost:3000",
+        "prisonVideoUrl" to "prison-video-url",
+        "probationOfficerName" to "probation officer name",
+        "probationOfficerEmailAddress" to "probation.officer@email.address",
+        "probationOfficerContactNumber" to "123456",
+        "prisonVideoUrl" to "prison-video-url",
+        "oldAppointmentDate" to tomorrow().toMediumFormatStyle(),
+        "oldAppointmentInfo" to "bobs appointment info",
+      ),
       null,
     )
   }


### PR DESCRIPTION
This PR introduces a feature toggled change which when turned on will send the relevant rescheduled emails when the date and/or start time is changed on a court or probation booking.

I have kept the code as separate as possible from the existing email logic, in part due to the size of the change but also so as not to affect/break the existing code.

I have also tested most scenarios locally.  Some will need to be done on dev e.g. for court and probation contacts as this requires a prison user to change a booking (via A&A).