### PR TITLE
BAVL-1269 undecorated rooms are no longer available by default. Defaulting to out of use for CSV download.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/RoomAdministrationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/resource/RoomAdministrationController.kt
@@ -106,8 +106,7 @@ class RoomAdministrationController(
   @ResponseStatus(HttpStatus.CREATED)
   @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN')")
   fun createDecoratedRoom(
-    @Parameter(description = "The identifier of the DPS location for the scheduled row to be created.")
-    @PathVariable(name = "dpsLocationId", required = true)
+    @PathVariable(required = true) @Parameter(description = "The identifier of the DPS location for the scheduled row to be created.")
     dpsLocationId: UUID,
     @Valid
     @RequestBody
@@ -148,8 +147,7 @@ class RoomAdministrationController(
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN')")
   fun amendDecoratedRoom(
-    @Parameter(description = "The identifier of the DPS location for the scheduled row to be amended.")
-    @PathVariable(name = "dpsLocationId", required = true)
+    @PathVariable(required = true) @Parameter(description = "The identifier of the DPS location for the scheduled row to be amended.")
     dpsLocationId: UUID,
     @Valid
     @RequestBody
@@ -180,7 +178,7 @@ class RoomAdministrationController(
     ],
   )
   @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN')")
-  fun deleteDecoratedLocation(@PathVariable("dpsLocationId") dpsLocationId: UUID) {
+  fun deleteDecoratedLocation(@PathVariable dpsLocationId: UUID) {
     decoratedLocationsService.deleteDecoratedLocation(dpsLocationId)
   }
 
@@ -210,8 +208,7 @@ class RoomAdministrationController(
   @ResponseStatus(HttpStatus.CREATED)
   @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN')")
   fun createSchedule(
-    @Parameter(description = "The identifier of the DPS location for the scheduled row to be created.")
-    @PathVariable(name = "dpsLocationId", required = true)
+    @PathVariable(required = true) @Parameter(description = "The identifier of the DPS location for the scheduled row to be created.")
     dpsLocationId: UUID,
     @Valid
     @RequestBody
@@ -245,8 +242,8 @@ class RoomAdministrationController(
   )
   @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN')")
   fun deleteSchedule(
-    @PathVariable("dpsLocationId") dpsLocationId: UUID,
-    @PathVariable("scheduleId") scheduleId: Long,
+    @PathVariable dpsLocationId: UUID,
+    @PathVariable scheduleId: Long,
     httpRequest: HttpServletRequest,
   ) {
     decoratedLocationsService.deleteSchedule(dpsLocationId, scheduleId, httpRequest.getBvlsRequestContext().user as ExternalUser)
@@ -284,11 +281,9 @@ class RoomAdministrationController(
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN')")
   fun amendDecoratedRoom(
-    @Parameter(description = "The identifier of the DPS location for the room schedule to be amended.")
-    @PathVariable(name = "dpsLocationId", required = true)
+    @PathVariable(required = true) @Parameter(description = "The identifier of the DPS location for the room schedule to be amended.")
     dpsLocationId: UUID,
-    @Parameter(description = "The identifier of the room schedule to be amended.")
-    @PathVariable(name = "scheduleId", required = true)
+    @PathVariable(required = true) @Parameter(description = "The identifier of the room schedule to be amended.")
     scheduleId: Long,
     @Valid
     @RequestBody

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CsvDataExtractionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CsvDataExtractionService.kt
@@ -415,7 +415,7 @@ data class RoomItem(
         LocationStatus.INACTIVE -> "Out of use"
         LocationStatus.TEMPORARILY_BLOCKED -> "Blocked"
       }
-    } ?: "Active",
+    } ?: "Out of use",
     permission = location.extraAttributes?.locationUsage?.let {
       when (it) {
         LocationUsage.COURT -> "Court"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CsvDataExtractionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CsvDataExtractionIntegrationTest.kt
@@ -26,6 +26,7 @@ class CsvDataExtractionIntegrationTest : IntegrationTestBase() {
         LocationKeyValue("ROOM-1", UUID.fromString("e58ed763-928c-4155-bee9-aaaaaaaaaaaa")),
         LocationKeyValue("ROOM-2", UUID.fromString("e58ed763-928c-4155-bee9-bbbbbbbbbbbb")),
         LocationKeyValue("ROOM-3", UUID.fromString("e58ed763-928c-4155-bee9-cccccccccccc")),
+        LocationKeyValue("ROOM-4", UUID.fromString("e58ed763-928c-4155-bee9-dddddddddddd")),
       ),
       true,
       "BMI",
@@ -89,6 +90,7 @@ class CsvDataExtractionIntegrationTest : IntegrationTestBase() {
     roomData contains "BMI,\"Birmingham (HMP)\",ROOM-3,\"BMI ROOM-3\",/link/3,Customised,Active,Schedule,,\"Monday-Thursday 09:00-17:00 Court \"\n"
     roomData contains "BMI,\"Birmingham (HMP)\",ROOM-3,\"BMI ROOM-3\",/link/3,Customised,Active,Schedule,,\"Friday-Friday 09:00-17:00 Probation \"\n"
     roomData contains "BMI,\"Birmingham (HMP)\",ROOM-3,\"BMI ROOM-3\",/link/3,Customised,Active,Schedule,,\"Saturday-Sunday 09:00-17:00 Blocked \"\n"
+    roomData contains "BMI,\"Birmingham (HMP)\",ROOM-4,\"BMI ROOM-4\",,Default,\"Out of use\",Shared,,No"
   }
 
   private fun WebTestClient.badRequestWhenRequestTooManyDaysOfData() = this


### PR DESCRIPTION
This is part 2 on the back of this change to room availability for undecorated rooms [PR](https://github.com/ministryofjustice/hmpps-book-a-video-link-api/pull/638).

Rooms that are undecorated no longer default to shared availability.  Going forwards they are not available.  This change needs to be reflected this on the CSV download also by saying the room is 'Out of use' until the room is decorated.