### PR TITLE
BAVL-1292: Adding 8 new Greater Manchester probation teams

### DIFF
--- a/src/main/resources/migrations/common/V2026.04.28__greater_manchester_probation_teams.sql
+++ b/src/main/resources/migrations/common/V2026.04.28__greater_manchester_probation_teams.sql
@@ -1,0 +1,12 @@
+-- New probation teams
+insert into probation_team (code, description, enabled, read_only, notes, created_by, created_time, court_team)
+values
+    ('BLTNCC', 'Bolton Crown - Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('BLTNMC', 'Bolton Magistrates - Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('MNCSCC', 'Manchester Crown (Crown Square) - Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('MNMSCC', 'Manchester Crown (Minshull Street) - Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('MNPRMC', 'Manchester Magistrates - Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('STKPMC', 'Stockport Magistrates - Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('TAMEMC', 'Tameside Magistrates - Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('WIGNMC', 'Wigan Magistrates - Probation', true, false, null, 'TIM', current_timestamp, true);
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationTeamsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationTeamsResourceIntegrationTest.kt
@@ -34,17 +34,17 @@ class ProbationTeamsResourceIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:integration-test-data/seed-enabled-probation-team-data.sql")
   @Test
   fun `should return filtered and unfiltered probation teams`() {
-    probationTeamRepository.findAll() hasSize 189 // Including enabled, read ony, and not enabled
+    probationTeamRepository.findAll() hasSize 197 // Including enabled, read ony, and not enabled
 
     val enabledOnlyTeams = webTestClient.getProbationTeams(true)
-    enabledOnlyTeams hasSize 183
+    enabledOnlyTeams hasSize 191
     enabledOnlyTeams.all { it.enabled } isBool true
 
     val allTeams = webTestClient.getProbationTeams(false)
-    allTeams hasSize 185
-    allTeams.count { it.enabled } isEqualTo 183
+    allTeams hasSize 193
+    allTeams.count { it.enabled } isEqualTo 191
     allTeams.count { !it.enabled } isEqualTo 2
-    allTeams.none { it.courtTeam } isBool true
+    allTeams.count { it.courtTeam } isEqualTo 8
     allTeams.none { it.sentenceManagementTeam } isBool true
   }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -45,7 +45,7 @@ hmpps:
   sar:
     tests:
       attachments-expected: false
-      expected-flyway-schema-version: 2026.03.30
+      expected-flyway-schema-version: 2026.04.28
       expected-jpa-entity-schema:
         path: /sar/entity-schema.json
       expected-api-response:


### PR DESCRIPTION
These are the basic team details - all set to probation "court" teams. 
The contacts are added separately (manually) from a generated script.