### PR TITLE
BAVL-1316 missing overlapping checks for court or sentence team checks on availability and was falling through to SHARED.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttribute.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttribute.kt
@@ -172,6 +172,8 @@ class LocationAttribute private constructor(
     val freeForAnyProbationTeam = ProbationAnySpecification(onDate.dayOfWeek, startTime, endTime)
     val overlapsWithCourtSlot = OverlappingSpecification(LocationScheduleUsage.COURT, onDate.dayOfWeek, startTime, endTime)
     val overlapsWithOtherProbationTeamSlot = OverlappingRoomSpecification(LocationScheduleUsage.PROBATION, onDate.dayOfWeek, startTime, endTime)
+    val overlapsWithProbationSentenceSlot = OverlappingSpecification(LocationScheduleUsage.PROBATION_SENTENCE, onDate.dayOfWeek, startTime, endTime)
+    val overlapsWithProbationCourtSlot = OverlappingSpecification(LocationScheduleUsage.PROBATION_COURT, onDate.dayOfWeek, startTime, endTime)
 
     // The order in which the checks are carried out is important and must be maintained.
     return when {
@@ -186,6 +188,12 @@ class LocationAttribute private constructor(
 
       // If none of the above match, we need to make sure the requested probation slot date and times to not overlap any other probation team room schedules
       fallsWithin(overlapsWithOtherProbationTeamSlot) -> AvailabilityStatus.NONE
+
+      // If none of the above match, we need to make sure the requested court slot date and times to not overlap any probation sentence schedules
+      fallsWithin(overlapsWithProbationSentenceSlot) -> AvailabilityStatus.NONE
+
+      // If none of the above match, we need to make sure the requested court slot date and times to not overlap any probation court schedules
+      fallsWithin(overlapsWithProbationCourtSlot) -> AvailabilityStatus.NONE
 
       else -> AvailabilityStatus.SHARED
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttributesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttributesTest.kt
@@ -892,6 +892,48 @@ class LocationAttributesTest {
         LocalTime.of(12, 30),
       ) isEqualTo AvailabilityStatus.PROBATION_SENTENCE
     }
+
+    @Test
+    fun `should be NONE for any probation court schedule`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = PROBATION_USER,
+      ).apply { schedule(this, locationUsage = LocationScheduleUsage.PROBATION_COURT) }
+
+      roomAttributes.isAvailableFor(
+        probationTeam(isCourtTeam = false),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.NONE
+    }
+
+    @Test
+    fun `should be NONE for any probation sentence management schedule`() {
+      val roomAttributes = LocationAttribute.decoratedRoom(
+        dpsLocationId = UUID.randomUUID(),
+        prison = pentonvillePrison,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.SCHEDULE,
+        allowedParties = emptySet(),
+        prisonVideoUrl = null,
+        notes = null,
+        createdBy = PROBATION_USER,
+      ).apply { schedule(this, locationUsage = LocationScheduleUsage.PROBATION_SENTENCE) }
+
+      roomAttributes.isAvailableFor(
+        probationTeam(isSentenceManagementTeam = false),
+        today(),
+        LocalTime.of(12, 0),
+        LocalTime.of(12, 30),
+      ) isEqualTo AvailabilityStatus.NONE
+    }
   }
 
   @Nested


### PR DESCRIPTION
This fixes an issue whereby sentence teams and/or court teams could be offered due to missing some checks in the availability logic.  It was falling through to the default of SHARED as a result.
