### PR TITLE
BAVL-1194 increase POD memory in prod to help alleviate out of memory issues.

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -29,6 +29,14 @@ generic-service:
         DB_PASS_PREPROD: "database_password"
         DB_HOST_PREPROD: "rds_instance_address"
 
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+    limits:
+      cpu: 2000m
+      memory: 2000Mi
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:


### PR DESCRIPTION
Increase pod memory to help with **out of memory** issues we are seeing in production.

Looking at the memory stats were were maxing out, advice from the SRE team was to double what we had.

**Note: we do have other stuff that would be released if this were to go out now.**