### PR TITLE
BAVL-1251 changeds to factor in changes to pre/post meetings. If they change then considered rescheduled.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/StringExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/common/StringExt.kt
@@ -20,3 +20,6 @@ fun String.isUkPhoneNumber(): Boolean = runCatching {
       phoneNumberUtil.isValidNumber(it)
   }
 }.getOrElse { false }
+
+// Crude, this will title case every word in the given string.
+fun String.toTitleCase() = lowercase().split(" ").joinToString(separator = " ") { word -> word.replaceFirstChar { it.titlecase(Locale.getDefault()) } }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBooking.kt
@@ -193,6 +193,30 @@ class VideoBooking private constructor(
 
   fun probationMeeting(): PrisonAppointment? = appointments().singleOrNull { it.appointmentType == "VLB_PROBATION" }
 
+  /**
+   * Will be null if no appointments on the booking, also bear in mind appointments are lazily loaded.
+   */
+  fun startDateTime(): LocalDateTime? = run {
+    when {
+      preHearing() != null -> preHearing()!!.appointmentDate.atTime(preHearing()!!.startTime)
+      mainHearing() != null -> mainHearing()!!.appointmentDate.atTime(mainHearing()!!.startTime)
+      probationMeeting() != null -> probationMeeting()!!.appointmentDate.atTime(probationMeeting()!!.startTime)
+      else -> null
+    }
+  }
+
+  /**
+   * Will be null if no appointments on the booking, also bear in mind appointments are lazily loaded.
+   */
+  fun endDateTime(): LocalDateTime? = run {
+    when {
+      postHearing() != null -> postHearing()!!.appointmentDate.atTime(postHearing()!!.endTime)
+      mainHearing() != null -> mainHearing()!!.appointmentDate.atTime(mainHearing()!!.endTime)
+      probationMeeting() != null -> probationMeeting()!!.appointmentDate.atTime(probationMeeting()!!.endTime)
+      else -> null
+    }
+  }
+
   companion object {
 
     fun newCourtBooking(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/BookingFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/BookingFacade.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AmendVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.RequestVideoBookingRequest
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.VideoLinkBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ChangeTrackingService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ChangeType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ExternalUser
@@ -86,7 +85,7 @@ class BookingFacade(
 
     // Only send emails on back of change check above.
     if (changeType != ChangeType.NONE) {
-      if (featureSwitches.isEnabled(BooleanFeature.FEATURE_SEND_RESCHEDULED_EMAILS) && isRescheduled(originalBooking, amendedBooking)) {
+      if (featureSwitches.isEnabled(BooleanFeature.FEATURE_SEND_RESCHEDULED_EMAILS) && rescheduleEmailsFacade.isConsideredRescheduled(originalBooking, amendedBooking)) {
         rescheduleEmailsFacade.sendEmails(originalBooking, amendedBooking, changeType, prisoner, amendedBy)
       } else {
         emailFacade.sendEmails(BookingAction.AMEND, amendedBooking, prisoner, amendedBy, changeType)
@@ -98,22 +97,6 @@ class BookingFacade(
     trackTelemetry(BookingAction.AMEND, amendedBooking, amendedBy)
 
     return videoBookingId
-  }
-
-  private fun isRescheduled(originalBooking: VideoLinkBooking, amendedBooking: VideoBooking) = run {
-    originalBooking.startDateTime() != amendedBooking.startDateTime()
-  }
-
-  private fun VideoBooking.startDateTime() = run {
-    val appointment = this.mainHearing() ?: this.probationMeeting()!!
-
-    appointment.appointmentDate.atTime(appointment.startTime)
-  }
-
-  private fun VideoLinkBooking.startDateTime() = run {
-    val appointment = prisonAppointments.singleOrNull { it.appointmentType == "VLB_COURT_MAIN" } ?: prisonAppointments.single { it.appointmentType == "VLB_PROBATION" }
-
-    appointment.appointmentDate.atTime(appointment.startTime)
   }
 
   fun cancel(videoBookingId: Long, cancelledBy: PrisonUser) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/RescheduleEmailsFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/RescheduleEmailsFacade.kt
@@ -25,7 +25,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationEmailFactory
 
 @Component
-@Transactional
 class RescheduleEmailsFacade(
   private val prisonRepository: PrisonRepository,
   private val contactsService: ContactsService,
@@ -38,6 +37,18 @@ class RescheduleEmailsFacade(
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
+  /**
+   * Will throw a runtime exception if the booking IDs do not match.
+   */
+  fun isConsideredRescheduled(originalBooking: VideoLinkBooking, amendedBooking: VideoBooking) = run {
+    require(originalBooking.videoLinkBookingId == amendedBooking.videoBookingId) {
+      "Original and amended bookings must have the same video booking ID"
+    }
+
+    originalBooking.startDateTime() != amendedBooking.startDateTime() || originalBooking.endDateTime() != amendedBooking.endDateTime()
+  }
+
+  @Transactional
   fun sendEmails(
     oldBooking: VideoLinkBooking,
     amendedBooking: VideoBooking,
@@ -45,6 +56,8 @@ class RescheduleEmailsFacade(
     prisoner: Prisoner,
     user: User,
   ) {
+    require(isConsideredRescheduled(oldBooking, amendedBooking)) { "Booking with ID ${oldBooking.videoLinkBookingId} is not rescheduled" }
+
     val prison = prisonRepository.findByCode(prisoner.prisonCode)!!
     val contacts = contactsService.getBookingContacts(oldBooking.videoLinkBookingId, user).withAnEmailAddress()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/PrisonAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/PrisonAppointment.kt
@@ -20,7 +20,7 @@ data class PrisonAppointment(
   @Schema(description = "The prisoner number for the person attending this appointment", example = "AA1234A")
   val prisonerNumber: String,
 
-  @Schema(description = "The appointment type", example = "VLB")
+  @Schema(description = "The appointment type", example = "VLB_COURT_MAIN")
   val appointmentType: String,
 
   @Schema(description = "The location of the appointment at the prison", example = "VCC-ROOM-1")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/VideoLinkBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/VideoLinkBooking.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import dev.zacsweers.redacted.annotations.Redacted
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
@@ -88,7 +89,27 @@ data class VideoLinkBooking(
   )
   @Redacted
   val notesForPrisoners: String?,
-)
+) {
+  @JsonIgnore
+  fun startDateTime(): LocalDateTime = run {
+    val courtAppointment = prisonAppointments.singleOrNull { it.appointmentType == "VLB_COURT_PRE" } ?: prisonAppointments.singleOrNull { it.appointmentType == "VLB_COURT_MAIN" }
+    val probationAppointment = prisonAppointments.singleOrNull { it.appointmentType == "VLB_PROBATION" }
+
+    val appointment = courtAppointment ?: probationAppointment!!
+
+    appointment.appointmentDate.atTime(appointment.startTime)
+  }
+
+  @JsonIgnore
+  fun endDateTime(): LocalDateTime = run {
+    val courtAppointment = prisonAppointments.singleOrNull { it.appointmentType == "VLB_COURT_POST" } ?: prisonAppointments.singleOrNull { it.appointmentType == "VLB_COURT_MAIN" }
+    val probationAppointment = prisonAppointments.singleOrNull { it.appointmentType == "VLB_PROBATION" }
+
+    val appointment = courtAppointment ?: probationAppointment!!
+
+    appointment.appointmentDate.atTime(appointment.endTime)
+  }
+}
 
 enum class BookingStatus {
   ACTIVE,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/RescheduledCourtEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/RescheduledCourtEmailFactory.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court
 
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toTitleCase
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.VideoBookingEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingContact
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType.COURT
@@ -22,7 +23,7 @@ class RescheduledCourtEmailFactory(private val locationService: LocationsService
     prison: Prison,
     prisoner: Prisoner,
     userContact: BookingContact,
-  ): VideoBookingEmail? {
+  ): VideoBookingEmail {
     require(userContact.contactType == ContactType.USER) {
       "Incorrect contact type ${userContact.contactType} for court user email"
     }
@@ -57,7 +58,7 @@ class RescheduledCourtEmailFactory(private val locationService: LocationsService
     prison: Prison,
     prisoner: Prisoner,
     courtContact: BookingContact,
-  ): VideoBookingEmail? {
+  ): VideoBookingEmail {
     require(courtContact.contactType == ContactType.COURT) {
       "Incorrect contact type ${courtContact.contactType} for court court email"
     }
@@ -92,7 +93,7 @@ class RescheduledCourtEmailFactory(private val locationService: LocationsService
     prisoner: Prisoner,
     prisonContact: BookingContact,
     contacts: Collection<BookingContact>,
-  ): VideoBookingEmail? {
+  ): VideoBookingEmail {
     require(prisonContact.contactType == ContactType.PRISON) {
       "Incorrect contact type ${prisonContact.contactType} for court prison email"
     }
@@ -158,5 +159,6 @@ class RescheduledCourtEmailFactory(private val locationService: LocationsService
 
   private fun VideoLinkBooking.postHearing() = prisonAppointments.singleOrNull { it.appointmentType == "VLB_COURT_POST" }
 
-  private fun ModelPrisonAppointment.appointmentDetails(location: Location) = AppointmentDetails(location.description ?: "", startTime, endTime, null)
+  // Not ideal, but toTitleCase is used here because the locations API is returning all CAPS for the description when looking up location by key
+  private fun ModelPrisonAppointment.appointmentDetails(location: Location) = AppointmentDetails(location.description?.toTitleCase() ?: "", startTime, endTime, null)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/RescheduledProbationEmailFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/RescheduledProbationEmailFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.proba
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toHourMinuteStyle
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toTitleCase
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.VideoBookingEmail
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingContact
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.BookingType.PROBATION
@@ -158,5 +159,6 @@ class RescheduledProbationEmailFactory(
 
   private fun Collection<BookingContact>.primaryProbationContact() = singleOrNull { it.contactType == ContactType.PROBATION && it.primaryContact }
 
-  private fun ModelPrisonAppointment.appointmentInformation(location: Location) = "${location.description} - ${startTime.toHourMinuteStyle()} to ${endTime.toHourMinuteStyle()}"
+  // Not ideal, but toTitleCase is used here because the locations API is returning all CAPS for the description when looking up location by key
+  private fun ModelPrisonAppointment.appointmentInformation(location: Location) = "${location.description?.toTitleCase()} - ${startTime.toHourMinuteStyle()} to ${endTime.toHourMinuteStyle()}"
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/VideoBookingTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity
 
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -23,7 +24,7 @@ import java.util.UUID
 
 class VideoBookingTest {
 
-  private val booking = courtBooking().also {
+  private val courtBooking = courtBooking().also {
     it.isBookingType(BookingType.COURT) isBool true
     it.isBookingType(BookingType.PROBATION) isBool false
     it.statusCode isEqualTo StatusCode.ACTIVE
@@ -31,485 +32,629 @@ class VideoBookingTest {
     it.amendedTime isEqualTo null
   }
 
-  @Test
-  fun `should be court booking with CVP video URL created by prison user`() {
-    val courtBooking = VideoBooking.newCourtBooking(
-      court(code = "COURT_CODE"),
-      hearingType = "TRIBUNAL",
-      cvpLinkDetails = CvpLinkDetails.url("prison-user-video-url"),
-      createdBy = PRISON_USER_BIRMINGHAM,
-      guestPin = "123456",
-      notesForStaff = "Some private staff notes",
-      notesForPrisoners = "Some public prisoners notes",
-    )
+  @Nested
+  inner class CourtBookings {
+    @Test
+    fun `should be court booking with CVP video URL created by prison user`() {
+      val courtBooking = VideoBooking.newCourtBooking(
+        court(code = "COURT_CODE"),
+        hearingType = "TRIBUNAL",
+        cvpLinkDetails = CvpLinkDetails.url("prison-user-video-url"),
+        createdBy = PRISON_USER_BIRMINGHAM,
+        guestPin = "123456",
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Some public prisoners notes",
+      )
 
-    with(courtBooking) {
-      court isEqualTo court(code = "COURT_CODE")
-      isBookingType(BookingType.COURT) isBool true
-      hearingType isEqualTo "TRIBUNAL"
-      videoUrl isEqualTo "prison-user-video-url"
-      hmctsNumber isEqualTo null
-      guestPin isEqualTo "123456"
-      createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
-      createdTime isCloseTo now()
-      createdByPrison isBool true
-      statusCode isEqualTo StatusCode.ACTIVE
-      notesForStaff isEqualTo "Some private staff notes"
-      notesForPrisoners isEqualTo "Some public prisoners notes"
+      with(courtBooking) {
+        court isEqualTo court(code = "COURT_CODE")
+        isBookingType(BookingType.COURT) isBool true
+        hearingType isEqualTo "TRIBUNAL"
+        videoUrl isEqualTo "prison-user-video-url"
+        hmctsNumber isEqualTo null
+        guestPin isEqualTo "123456"
+        createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
+        createdTime isCloseTo now()
+        createdByPrison isBool true
+        statusCode isEqualTo StatusCode.ACTIVE
+        notesForStaff isEqualTo "Some private staff notes"
+        notesForPrisoners isEqualTo "Some public prisoners notes"
+      }
+    }
+
+    @Test
+    fun `should be court booking with CVP HMCTS number created by prison user`() {
+      val courtBooking = VideoBooking.newCourtBooking(
+        court(code = "COURT_CODE"),
+        hearingType = "TRIBUNAL",
+        cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS123"),
+        createdBy = PRISON_USER_BIRMINGHAM,
+        guestPin = "123456",
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Some public prisoners notes",
+      )
+
+      with(courtBooking) {
+        court isEqualTo court(code = "COURT_CODE")
+        isBookingType(BookingType.COURT) isBool true
+        hearingType isEqualTo "TRIBUNAL"
+        videoUrl isEqualTo null
+        hmctsNumber isEqualTo "HMCTS123"
+        guestPin isEqualTo "123456"
+        createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
+        createdTime isCloseTo now()
+        createdByPrison isBool true
+        statusCode isEqualTo StatusCode.ACTIVE
+        notesForStaff isEqualTo "Some private staff notes"
+        notesForPrisoners isEqualTo "Some public prisoners notes"
+      }
+    }
+
+    @Test
+    fun `should amend prison created court booking with CVP video URL created by court user`() {
+      val courtBooking = VideoBooking.newCourtBooking(
+        court(code = "COURT_CODE"),
+        hearingType = "TRIBUNAL",
+        cvpLinkDetails = CvpLinkDetails.url("prison-user-video-url"),
+        guestPin = "123456",
+        createdBy = PRISON_USER_BIRMINGHAM,
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Some public prisoners notes",
+      )
+
+      with(courtBooking) {
+        court isEqualTo court(code = "COURT_CODE")
+        isBookingType(BookingType.COURT) isBool true
+        hearingType isEqualTo "TRIBUNAL"
+        videoUrl isEqualTo "prison-user-video-url"
+        hmctsNumber isEqualTo null
+        guestPin isEqualTo "123456"
+        createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
+        createdTime isCloseTo now()
+        createdByPrison isBool true
+        statusCode isEqualTo StatusCode.ACTIVE
+        notesForStaff isEqualTo "Some private staff notes"
+        notesForPrisoners isEqualTo "Some public prisoners notes"
+      }
+
+      courtBooking.amendCourtBooking(
+        hearingType = "APPEAL",
+        notesForStaff = "Amended staff notes",
+        notesForPrisoners = "Amended prisoners notes",
+        cvpLinkDetails = CvpLinkDetails.url("amended-prison-user-video-url"),
+        guestPin = "654321",
+        COURT_USER,
+      )
+
+      with(courtBooking) {
+        hearingType isEqualTo "APPEAL"
+        notesForStaff isEqualTo "Amended staff notes"
+        notesForPrisoners isEqualTo "Some public prisoners notes"
+        videoUrl isEqualTo "amended-prison-user-video-url"
+        hmctsNumber isEqualTo null
+        guestPin isEqualTo "654321"
+        amendedBy isEqualTo COURT_USER.username
+        amendedTime isCloseTo now()
+      }
+    }
+
+    @Test
+    fun `should amend prison created court booking with CVP HMCTS number created by court user`() {
+      val courtBooking = VideoBooking.newCourtBooking(
+        court(code = "COURT_CODE"),
+        hearingType = "TRIBUNAL",
+        cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS123"),
+        guestPin = "123456",
+        createdBy = PRISON_USER_BIRMINGHAM,
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Some public prisoners notes",
+      )
+
+      with(courtBooking) {
+        court isEqualTo court(code = "COURT_CODE")
+        isBookingType(BookingType.COURT) isBool true
+        hearingType isEqualTo "TRIBUNAL"
+        videoUrl isEqualTo null
+        hmctsNumber isEqualTo "HMCTS123"
+        guestPin isEqualTo "123456"
+        createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
+        createdTime isCloseTo now()
+        createdByPrison isBool true
+        statusCode isEqualTo StatusCode.ACTIVE
+        notesForStaff isEqualTo "Some private staff notes"
+        notesForPrisoners isEqualTo "Some public prisoners notes"
+      }
+
+      courtBooking.amendCourtBooking(
+        hearingType = "APPEAL",
+        notesForStaff = "Amended staff notes",
+        notesForPrisoners = "Amended prisoners notes",
+        cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS321"),
+        guestPin = "654321",
+        COURT_USER,
+      )
+
+      with(courtBooking) {
+        hearingType isEqualTo "APPEAL"
+        notesForStaff isEqualTo "Amended staff notes"
+        notesForPrisoners isEqualTo "Some public prisoners notes"
+        videoUrl isEqualTo null
+        hmctsNumber isEqualTo "HMCTS321"
+        guestPin isEqualTo "654321"
+        amendedBy isEqualTo COURT_USER.username
+        amendedTime isCloseTo now()
+      }
+    }
+
+    @Test
+    fun `should amend prison created court booking created by prison user`() {
+      val courtBooking = VideoBooking.newCourtBooking(
+        court(code = "COURT_CODE"),
+        hearingType = "TRIBUNAL",
+        cvpLinkDetails = CvpLinkDetails.url("prison-user-video-url"),
+        guestPin = "123456",
+        createdBy = PRISON_USER_BIRMINGHAM,
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Some public prisoners notes",
+      )
+
+      with(courtBooking) {
+        court isEqualTo court(code = "COURT_CODE")
+        isBookingType(BookingType.COURT) isBool true
+        hearingType isEqualTo "TRIBUNAL"
+        videoUrl isEqualTo "prison-user-video-url"
+        hmctsNumber isEqualTo null
+        guestPin isEqualTo "123456"
+        createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
+        createdTime isCloseTo now()
+        createdByPrison isBool true
+        statusCode isEqualTo StatusCode.ACTIVE
+        notesForStaff isEqualTo "Some private staff notes"
+        notesForPrisoners isEqualTo "Some public prisoners notes"
+      }
+
+      courtBooking.amendCourtBooking(
+        hearingType = "APPEAL",
+        notesForStaff = "Amended staff notes",
+        notesForPrisoners = "Amended prisoners notes",
+        cvpLinkDetails = CvpLinkDetails.url("amended-prison-user-video-url"),
+        guestPin = "654321",
+        PRISON_USER_BIRMINGHAM,
+      )
+
+      with(courtBooking) {
+        hearingType isEqualTo "APPEAL"
+        notesForStaff isEqualTo "Amended staff notes"
+        notesForPrisoners isEqualTo "Amended prisoners notes"
+        videoUrl isEqualTo "amended-prison-user-video-url"
+        guestPin isEqualTo "654321"
+        amendedBy isEqualTo PRISON_USER_BIRMINGHAM.username
+        amendedTime isCloseTo now()
+      }
+    }
+
+    @Test
+    fun `should be court booking created by court user`() {
+      val courtBooking = VideoBooking.newCourtBooking(
+        court(code = "COURT_CODE"),
+        hearingType = "APPEAL",
+        cvpLinkDetails = CvpLinkDetails.url("court-user-video-url"),
+        guestPin = "123456",
+        createdBy = COURT_USER,
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Should be ignored for external user",
+      )
+
+      with(courtBooking) {
+        court isEqualTo court(code = "COURT_CODE")
+        isBookingType(BookingType.COURT) isBool true
+        hearingType isEqualTo "APPEAL"
+        videoUrl isEqualTo "court-user-video-url"
+        guestPin isEqualTo "123456"
+        createdBy isEqualTo COURT_USER.username
+        createdByPrison isBool false
+        statusCode isEqualTo StatusCode.ACTIVE
+        notesForStaff isEqualTo "Some private staff notes"
+        notesForPrisoners isEqualTo null
+      }
+    }
+
+    @Test
+    fun `should amend court created court booking by court user`() {
+      val courtBooking = VideoBooking.newCourtBooking(
+        court(code = "COURT_CODE"),
+        hearingType = "APPEAL",
+        cvpLinkDetails = CvpLinkDetails.url("court-user-video-url"),
+        guestPin = "123456",
+        createdBy = COURT_USER,
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Should be ignored for external user",
+      )
+
+      with(courtBooking) {
+        court isEqualTo court(code = "COURT_CODE")
+        isBookingType(BookingType.COURT) isBool true
+        hearingType isEqualTo "APPEAL"
+        videoUrl isEqualTo "court-user-video-url"
+        guestPin isEqualTo "123456"
+        createdBy isEqualTo COURT_USER.username
+        createdByPrison isBool false
+        statusCode isEqualTo StatusCode.ACTIVE
+        notesForStaff isEqualTo "Some private staff notes"
+        notesForPrisoners isEqualTo null
+      }
+
+      courtBooking.amendCourtBooking(
+        hearingType = "APPEAL",
+        notesForStaff = "Amended staff notes",
+        notesForPrisoners = "Amended prisoners notes",
+        cvpLinkDetails = CvpLinkDetails.url("amended-court-user-video-url"),
+        guestPin = "654321",
+        COURT_USER,
+      )
+
+      with(courtBooking) {
+        hearingType isEqualTo "APPEAL"
+        notesForStaff isEqualTo "Amended staff notes"
+        notesForPrisoners isEqualTo null
+        videoUrl isEqualTo "amended-court-user-video-url"
+        guestPin isEqualTo "654321"
+        amendedBy isEqualTo COURT_USER.username
+        amendedTime isCloseTo now()
+      }
+    }
+
+    @Test
+    fun `should amend court created court booking by prison user`() {
+      val courtBooking = VideoBooking.newCourtBooking(
+        court(code = "COURT_CODE"),
+        hearingType = "APPEAL",
+        cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS123"),
+        guestPin = "123456",
+        createdBy = COURT_USER,
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Should be ignored for external user",
+      )
+
+      with(courtBooking) {
+        court isEqualTo court(code = "COURT_CODE")
+        isBookingType(BookingType.COURT) isBool true
+        hearingType isEqualTo "APPEAL"
+        videoUrl isEqualTo null
+        hmctsNumber isEqualTo "HMCTS123"
+        guestPin isEqualTo "123456"
+        createdBy isEqualTo COURT_USER.username
+        createdByPrison isBool false
+        statusCode isEqualTo StatusCode.ACTIVE
+        notesForStaff isEqualTo "Some private staff notes"
+        notesForPrisoners isEqualTo null
+      }
+
+      courtBooking.amendCourtBooking(
+        hearingType = "APPEAL",
+        notesForStaff = "Amended staff notes",
+        notesForPrisoners = "Amended prisoners notes",
+        cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS321"),
+        guestPin = "654321",
+        PRISON_USER_BIRMINGHAM,
+      )
+
+      with(courtBooking) {
+        hearingType isEqualTo "APPEAL"
+        notesForStaff isEqualTo "Amended staff notes"
+        notesForPrisoners isEqualTo "Amended prisoners notes"
+        hmctsNumber isEqualTo "HMCTS321"
+        guestPin isEqualTo "654321"
+        videoUrl isEqualTo null
+        amendedBy isEqualTo PRISON_USER_BIRMINGHAM.username
+        amendedTime isCloseTo now()
+      }
+    }
+
+    @Test
+    fun `should be no start or end time when no appointments`() {
+      courtBooking.startDateTime() isEqualTo null
+      courtBooking.endDateTime() isEqualTo null
+    }
+
+    @Test
+    fun `should be start and end time when main hearing only`() {
+      courtBooking.addAppointment(
+        prison = prison(prisonCode = BIRMINGHAM),
+        prisonerNumber = "ABC123",
+        appointmentType = "VLB_COURT_MAIN",
+        date = tomorrow(),
+        startTime = LocalTime.of(12, 0),
+        endTime = LocalTime.of(12, 45),
+        locationId = UUID.randomUUID(),
+      )
+
+      courtBooking.startDateTime() isEqualTo tomorrow().atTime(12, 0)
+      courtBooking.endDateTime() isEqualTo tomorrow().atTime(12, 45)
+    }
+
+    @Test
+    fun `should be start and end time when pre and main hearing`() {
+      courtBooking.addAppointment(
+        prison = prison(prisonCode = BIRMINGHAM),
+        prisonerNumber = "ABC123",
+        appointmentType = "VLB_COURT_PRE",
+        date = tomorrow(),
+        startTime = LocalTime.of(11, 45),
+        endTime = LocalTime.of(12, 0),
+        locationId = UUID.randomUUID(),
+      ).addAppointment(
+        prison = prison(prisonCode = BIRMINGHAM),
+        prisonerNumber = "ABC123",
+        appointmentType = "VLB_COURT_MAIN",
+        date = tomorrow(),
+        startTime = LocalTime.of(12, 0),
+        endTime = LocalTime.of(12, 45),
+        locationId = UUID.randomUUID(),
+      )
+
+      courtBooking.startDateTime() isEqualTo tomorrow().atTime(11, 45)
+      courtBooking.endDateTime() isEqualTo tomorrow().atTime(12, 45)
+    }
+
+    @Test
+    fun `should be start and end time when main hearing and post meeting`() {
+      courtBooking.addAppointment(
+        prison = prison(prisonCode = BIRMINGHAM),
+        prisonerNumber = "ABC123",
+        appointmentType = "VLB_COURT_MAIN",
+        date = tomorrow(),
+        startTime = LocalTime.of(12, 0),
+        endTime = LocalTime.of(12, 45),
+        locationId = UUID.randomUUID(),
+      ).addAppointment(
+        prison = prison(prisonCode = BIRMINGHAM),
+        prisonerNumber = "ABC123",
+        appointmentType = "VLB_COURT_POST",
+        date = tomorrow(),
+        startTime = LocalTime.of(12, 45),
+        endTime = LocalTime.of(13, 0),
+        locationId = UUID.randomUUID(),
+      )
+
+      courtBooking.startDateTime() isEqualTo tomorrow().atTime(12, 0)
+      courtBooking.endDateTime() isEqualTo tomorrow().atTime(13, 0)
+    }
+
+    @Test
+    fun `should be start and end time when pre, main and post meeting`() {
+      courtBooking.addAppointment(
+        prison = prison(prisonCode = BIRMINGHAM),
+        prisonerNumber = "ABC123",
+        appointmentType = "VLB_COURT_PRE",
+        date = tomorrow(),
+        startTime = LocalTime.of(11, 45),
+        endTime = LocalTime.of(12, 0),
+        locationId = UUID.randomUUID(),
+      ).addAppointment(
+        prison = prison(prisonCode = BIRMINGHAM),
+        prisonerNumber = "ABC123",
+        appointmentType = "VLB_COURT_MAIN",
+        date = tomorrow(),
+        startTime = LocalTime.of(12, 0),
+        endTime = LocalTime.of(12, 45),
+        locationId = UUID.randomUUID(),
+      ).addAppointment(
+        prison = prison(prisonCode = BIRMINGHAM),
+        prisonerNumber = "ABC123",
+        appointmentType = "VLB_COURT_POST",
+        date = tomorrow(),
+        startTime = LocalTime.of(12, 45),
+        endTime = LocalTime.of(13, 0),
+        locationId = UUID.randomUUID(),
+      )
+
+      courtBooking.startDateTime() isEqualTo tomorrow().atTime(11, 45)
+      courtBooking.endDateTime() isEqualTo tomorrow().atTime(13, 0)
     }
   }
 
-  @Test
-  fun `should be court booking with CVP HMCTS number created by prison user`() {
-    val courtBooking = VideoBooking.newCourtBooking(
-      court(code = "COURT_CODE"),
-      hearingType = "TRIBUNAL",
-      cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS123"),
-      createdBy = PRISON_USER_BIRMINGHAM,
-      guestPin = "123456",
-      notesForStaff = "Some private staff notes",
-      notesForPrisoners = "Some public prisoners notes",
-    )
+  @Nested
+  inner class ProbationBookings {
+    @Test
+    fun `should be probation booking created by prison user`() {
+      val probationBooking = VideoBooking.newProbationBooking(
+        probationTeam(code = "TEAM_CODE"),
+        probationMeetingType = "OTHER",
+        createdBy = PRISON_USER_BIRMINGHAM,
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Some public prisoners notes",
+      )
 
-    with(courtBooking) {
-      court isEqualTo court(code = "COURT_CODE")
-      isBookingType(BookingType.COURT) isBool true
-      hearingType isEqualTo "TRIBUNAL"
-      videoUrl isEqualTo null
-      hmctsNumber isEqualTo "HMCTS123"
-      guestPin isEqualTo "123456"
-      createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
-      createdTime isCloseTo now()
-      createdByPrison isBool true
-      statusCode isEqualTo StatusCode.ACTIVE
-      notesForStaff isEqualTo "Some private staff notes"
-      notesForPrisoners isEqualTo "Some public prisoners notes"
-    }
-  }
-
-  @Test
-  fun `should amend prison created court booking with CVP video URL created by court user`() {
-    val courtBooking = VideoBooking.newCourtBooking(
-      court(code = "COURT_CODE"),
-      hearingType = "TRIBUNAL",
-      cvpLinkDetails = CvpLinkDetails.url("prison-user-video-url"),
-      guestPin = "123456",
-      createdBy = PRISON_USER_BIRMINGHAM,
-      notesForStaff = "Some private staff notes",
-      notesForPrisoners = "Some public prisoners notes",
-    )
-
-    with(courtBooking) {
-      court isEqualTo court(code = "COURT_CODE")
-      isBookingType(BookingType.COURT) isBool true
-      hearingType isEqualTo "TRIBUNAL"
-      videoUrl isEqualTo "prison-user-video-url"
-      hmctsNumber isEqualTo null
-      guestPin isEqualTo "123456"
-      createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
-      createdTime isCloseTo now()
-      createdByPrison isBool true
-      statusCode isEqualTo StatusCode.ACTIVE
-      notesForStaff isEqualTo "Some private staff notes"
-      notesForPrisoners isEqualTo "Some public prisoners notes"
+      with(probationBooking) {
+        probationTeam isEqualTo probationTeam(code = "TEAM_CODE")
+        isBookingType(BookingType.PROBATION) isBool true
+        probationMeetingType isEqualTo "OTHER"
+        createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
+        createdTime isCloseTo now()
+        createdByPrison isBool true
+        statusCode isEqualTo StatusCode.ACTIVE
+        notesForStaff isEqualTo "Some private staff notes"
+        notesForPrisoners isEqualTo "Some public prisoners notes"
+      }
     }
 
-    courtBooking.amendCourtBooking(
-      hearingType = "APPEAL",
-      notesForStaff = "Amended staff notes",
-      notesForPrisoners = "Amended prisoners notes",
-      cvpLinkDetails = CvpLinkDetails.url("amended-prison-user-video-url"),
-      guestPin = "654321",
-      COURT_USER,
-    )
+    @Test
+    fun `should amend prison created probation booking created by prison user`() {
+      val probationBooking = VideoBooking.newProbationBooking(
+        probationTeam(code = "TEAM_CODE"),
+        probationMeetingType = "OTHER",
+        createdBy = PRISON_USER_BIRMINGHAM,
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Some public prisoners notes",
+      )
 
-    with(courtBooking) {
-      hearingType isEqualTo "APPEAL"
-      notesForStaff isEqualTo "Amended staff notes"
-      notesForPrisoners isEqualTo "Some public prisoners notes"
-      videoUrl isEqualTo "amended-prison-user-video-url"
-      hmctsNumber isEqualTo null
-      guestPin isEqualTo "654321"
-      amendedBy isEqualTo COURT_USER.username
-      amendedTime isCloseTo now()
-    }
-  }
+      with(probationBooking) {
+        probationTeam isEqualTo probationTeam(code = "TEAM_CODE")
+        isBookingType(BookingType.PROBATION) isBool true
+        probationMeetingType isEqualTo "OTHER"
+        createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
+        createdTime isCloseTo now()
+        createdByPrison isBool true
+        statusCode isEqualTo StatusCode.ACTIVE
+        notesForStaff isEqualTo "Some private staff notes"
+        notesForPrisoners isEqualTo "Some public prisoners notes"
+      }
 
-  @Test
-  fun `should amend prison created court booking with CVP HMCTS number created by court user`() {
-    val courtBooking = VideoBooking.newCourtBooking(
-      court(code = "COURT_CODE"),
-      hearingType = "TRIBUNAL",
-      cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS123"),
-      guestPin = "123456",
-      createdBy = PRISON_USER_BIRMINGHAM,
-      notesForStaff = "Some private staff notes",
-      notesForPrisoners = "Some public prisoners notes",
-    )
+      probationBooking.amendProbationBooking(
+        probationMeetingType = "RR",
+        notesForStaff = "Amended staff notes",
+        notesForPrisoners = "Amended prisoners notes",
+        amendedBy = PRISON_USER_BIRMINGHAM,
+      )
 
-    with(courtBooking) {
-      court isEqualTo court(code = "COURT_CODE")
-      isBookingType(BookingType.COURT) isBool true
-      hearingType isEqualTo "TRIBUNAL"
-      videoUrl isEqualTo null
-      hmctsNumber isEqualTo "HMCTS123"
-      guestPin isEqualTo "123456"
-      createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
-      createdTime isCloseTo now()
-      createdByPrison isBool true
-      statusCode isEqualTo StatusCode.ACTIVE
-      notesForStaff isEqualTo "Some private staff notes"
-      notesForPrisoners isEqualTo "Some public prisoners notes"
+      with(probationBooking) {
+        probationMeetingType isEqualTo "RR"
+        notesForStaff isEqualTo "Amended staff notes"
+        notesForPrisoners isEqualTo "Amended prisoners notes"
+        amendedBy isEqualTo PRISON_USER_BIRMINGHAM.username
+        amendedTime isCloseTo now()
+      }
     }
 
-    courtBooking.amendCourtBooking(
-      hearingType = "APPEAL",
-      notesForStaff = "Amended staff notes",
-      notesForPrisoners = "Amended prisoners notes",
-      cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS321"),
-      guestPin = "654321",
-      COURT_USER,
-    )
+    @Test
+    fun `should amend prison created probation booking created by probation user`() {
+      val probationBooking = VideoBooking.newProbationBooking(
+        probationTeam(code = "TEAM_CODE"),
+        probationMeetingType = "OTHER",
+        createdBy = PRISON_USER_BIRMINGHAM,
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Some public prisoners notes",
+      )
 
-    with(courtBooking) {
-      hearingType isEqualTo "APPEAL"
-      notesForStaff isEqualTo "Amended staff notes"
-      notesForPrisoners isEqualTo "Some public prisoners notes"
-      videoUrl isEqualTo null
-      hmctsNumber isEqualTo "HMCTS321"
-      guestPin isEqualTo "654321"
-      amendedBy isEqualTo COURT_USER.username
-      amendedTime isCloseTo now()
-    }
-  }
+      with(probationBooking) {
+        probationTeam isEqualTo probationTeam(code = "TEAM_CODE")
+        isBookingType(BookingType.PROBATION) isBool true
+        probationMeetingType isEqualTo "OTHER"
+        createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
+        createdTime isCloseTo now()
+        createdByPrison isBool true
+        statusCode isEqualTo StatusCode.ACTIVE
+        notesForStaff isEqualTo "Some private staff notes"
+        notesForPrisoners isEqualTo "Some public prisoners notes"
+      }
 
-  @Test
-  fun `should amend prison created court booking created by prison user`() {
-    val courtBooking = VideoBooking.newCourtBooking(
-      court(code = "COURT_CODE"),
-      hearingType = "TRIBUNAL",
-      cvpLinkDetails = CvpLinkDetails.url("prison-user-video-url"),
-      guestPin = "123456",
-      createdBy = PRISON_USER_BIRMINGHAM,
-      notesForStaff = "Some private staff notes",
-      notesForPrisoners = "Some public prisoners notes",
-    )
+      probationBooking.amendProbationBooking(
+        probationMeetingType = "RR",
+        notesForStaff = "Amended staff notes",
+        notesForPrisoners = "Amended prisoners notes",
+        amendedBy = PROBATION_USER,
+      )
 
-    with(courtBooking) {
-      court isEqualTo court(code = "COURT_CODE")
-      isBookingType(BookingType.COURT) isBool true
-      hearingType isEqualTo "TRIBUNAL"
-      videoUrl isEqualTo "prison-user-video-url"
-      hmctsNumber isEqualTo null
-      guestPin isEqualTo "123456"
-      createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
-      createdTime isCloseTo now()
-      createdByPrison isBool true
-      statusCode isEqualTo StatusCode.ACTIVE
-      notesForStaff isEqualTo "Some private staff notes"
-      notesForPrisoners isEqualTo "Some public prisoners notes"
+      with(probationBooking) {
+        probationMeetingType isEqualTo "RR"
+        notesForStaff isEqualTo "Amended staff notes"
+        notesForPrisoners isEqualTo "Some public prisoners notes"
+        amendedBy isEqualTo PROBATION_USER.username
+        amendedTime isCloseTo now()
+      }
     }
 
-    courtBooking.amendCourtBooking(
-      hearingType = "APPEAL",
-      notesForStaff = "Amended staff notes",
-      notesForPrisoners = "Amended prisoners notes",
-      cvpLinkDetails = CvpLinkDetails.url("amended-prison-user-video-url"),
-      guestPin = "654321",
-      PRISON_USER_BIRMINGHAM,
-    )
+    @Test
+    fun `should amend probation created probation booking created by probation user`() {
+      val probationBooking = VideoBooking.newProbationBooking(
+        probationTeam(code = "TEAM_CODE"),
+        probationMeetingType = "OTHER",
+        createdBy = PROBATION_USER,
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Some public prisoners notes",
+      )
 
-    with(courtBooking) {
-      hearingType isEqualTo "APPEAL"
-      notesForStaff isEqualTo "Amended staff notes"
-      notesForPrisoners isEqualTo "Amended prisoners notes"
-      videoUrl isEqualTo "amended-prison-user-video-url"
-      guestPin isEqualTo "654321"
-      amendedBy isEqualTo PRISON_USER_BIRMINGHAM.username
-      amendedTime isCloseTo now()
-    }
-  }
+      with(probationBooking) {
+        probationTeam isEqualTo probationTeam(code = "TEAM_CODE")
+        isBookingType(BookingType.PROBATION) isBool true
+        probationMeetingType isEqualTo "OTHER"
+        createdBy isEqualTo PROBATION_USER.username
+        createdTime isCloseTo now()
+        createdByPrison isBool false
+        statusCode isEqualTo StatusCode.ACTIVE
+        notesForStaff isEqualTo "Some private staff notes"
+        notesForPrisoners isEqualTo null
+      }
 
-  @Test
-  fun `should be court booking created by court user`() {
-    val courtBooking = VideoBooking.newCourtBooking(
-      court(code = "COURT_CODE"),
-      hearingType = "APPEAL",
-      cvpLinkDetails = CvpLinkDetails.url("court-user-video-url"),
-      guestPin = "123456",
-      createdBy = COURT_USER,
-      notesForStaff = "Some private staff notes",
-      notesForPrisoners = "Should be ignored for external user",
-    )
+      probationBooking.amendProbationBooking(
+        probationMeetingType = "RR",
+        notesForStaff = "Amended staff notes",
+        notesForPrisoners = "Amended prisoners notes",
+        amendedBy = PROBATION_USER,
+      )
 
-    with(courtBooking) {
-      court isEqualTo court(code = "COURT_CODE")
-      isBookingType(BookingType.COURT) isBool true
-      hearingType isEqualTo "APPEAL"
-      videoUrl isEqualTo "court-user-video-url"
-      guestPin isEqualTo "123456"
-      createdBy isEqualTo COURT_USER.username
-      createdByPrison isBool false
-      statusCode isEqualTo StatusCode.ACTIVE
-      notesForStaff isEqualTo "Some private staff notes"
-      notesForPrisoners isEqualTo null
-    }
-  }
-
-  @Test
-  fun `should amend court created court booking by court user`() {
-    val courtBooking = VideoBooking.newCourtBooking(
-      court(code = "COURT_CODE"),
-      hearingType = "APPEAL",
-      cvpLinkDetails = CvpLinkDetails.url("court-user-video-url"),
-      guestPin = "123456",
-      createdBy = COURT_USER,
-      notesForStaff = "Some private staff notes",
-      notesForPrisoners = "Should be ignored for external user",
-    )
-
-    with(courtBooking) {
-      court isEqualTo court(code = "COURT_CODE")
-      isBookingType(BookingType.COURT) isBool true
-      hearingType isEqualTo "APPEAL"
-      videoUrl isEqualTo "court-user-video-url"
-      guestPin isEqualTo "123456"
-      createdBy isEqualTo COURT_USER.username
-      createdByPrison isBool false
-      statusCode isEqualTo StatusCode.ACTIVE
-      notesForStaff isEqualTo "Some private staff notes"
-      notesForPrisoners isEqualTo null
+      with(probationBooking) {
+        probationMeetingType isEqualTo "RR"
+        notesForStaff isEqualTo "Amended staff notes"
+        notesForPrisoners isEqualTo null
+        amendedBy isEqualTo PROBATION_USER.username
+        amendedTime isCloseTo now()
+      }
     }
 
-    courtBooking.amendCourtBooking(
-      hearingType = "APPEAL",
-      notesForStaff = "Amended staff notes",
-      notesForPrisoners = "Amended prisoners notes",
-      cvpLinkDetails = CvpLinkDetails.url("amended-court-user-video-url"),
-      guestPin = "654321",
-      COURT_USER,
-    )
+    @Test
+    fun `should be probation booking created by probation user`() {
+      val probationBooking = VideoBooking.newProbationBooking(
+        probationTeam(code = "TEAM_CODE"),
+        probationMeetingType = "PSR",
+        createdBy = PROBATION_USER,
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Should be ignored for external user",
+      )
 
-    with(courtBooking) {
-      hearingType isEqualTo "APPEAL"
-      notesForStaff isEqualTo "Amended staff notes"
-      notesForPrisoners isEqualTo null
-      videoUrl isEqualTo "amended-court-user-video-url"
-      guestPin isEqualTo "654321"
-      amendedBy isEqualTo COURT_USER.username
-      amendedTime isCloseTo now()
-    }
-  }
-
-  @Test
-  fun `should amend court created court booking by prison user`() {
-    val courtBooking = VideoBooking.newCourtBooking(
-      court(code = "COURT_CODE"),
-      hearingType = "APPEAL",
-      cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS123"),
-      guestPin = "123456",
-      createdBy = COURT_USER,
-      notesForStaff = "Some private staff notes",
-      notesForPrisoners = "Should be ignored for external user",
-    )
-
-    with(courtBooking) {
-      court isEqualTo court(code = "COURT_CODE")
-      isBookingType(BookingType.COURT) isBool true
-      hearingType isEqualTo "APPEAL"
-      videoUrl isEqualTo null
-      hmctsNumber isEqualTo "HMCTS123"
-      guestPin isEqualTo "123456"
-      createdBy isEqualTo COURT_USER.username
-      createdByPrison isBool false
-      statusCode isEqualTo StatusCode.ACTIVE
-      notesForStaff isEqualTo "Some private staff notes"
-      notesForPrisoners isEqualTo null
+      with(probationBooking) {
+        probationTeam isEqualTo probationTeam(code = "TEAM_CODE")
+        isBookingType(BookingType.PROBATION) isBool true
+        probationMeetingType isEqualTo "PSR"
+        createdBy isEqualTo PROBATION_USER.username
+        createdByPrison isBool false
+        statusCode isEqualTo StatusCode.ACTIVE
+        notesForStaff isEqualTo "Some private staff notes"
+        notesForPrisoners isEqualTo null
+      }
     }
 
-    courtBooking.amendCourtBooking(
-      hearingType = "APPEAL",
-      notesForStaff = "Amended staff notes",
-      notesForPrisoners = "Amended prisoners notes",
-      cvpLinkDetails = CvpLinkDetails.hmctsNumber("HMCTS321"),
-      guestPin = "654321",
-      PRISON_USER_BIRMINGHAM,
-    )
+    @Test
+    fun `should be no start or end time when no main meeting`() {
+      val probationBooking = VideoBooking.newProbationBooking(
+        probationTeam(code = "TEAM_CODE"),
+        probationMeetingType = "PSR",
+        createdBy = PROBATION_USER,
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Should be ignored for external user",
+      )
 
-    with(courtBooking) {
-      hearingType isEqualTo "APPEAL"
-      notesForStaff isEqualTo "Amended staff notes"
-      notesForPrisoners isEqualTo "Amended prisoners notes"
-      hmctsNumber isEqualTo "HMCTS321"
-      guestPin isEqualTo "654321"
-      videoUrl isEqualTo null
-      amendedBy isEqualTo PRISON_USER_BIRMINGHAM.username
-      amendedTime isCloseTo now()
-    }
-  }
-
-  @Test
-  fun `should be probation booking created by prison user`() {
-    val probationBooking = VideoBooking.newProbationBooking(
-      probationTeam(code = "TEAM_CODE"),
-      probationMeetingType = "OTHER",
-      createdBy = PRISON_USER_BIRMINGHAM,
-      notesForStaff = "Some private staff notes",
-      notesForPrisoners = "Some public prisoners notes",
-    )
-
-    with(probationBooking) {
-      probationTeam isEqualTo probationTeam(code = "TEAM_CODE")
-      isBookingType(BookingType.PROBATION) isBool true
-      probationMeetingType isEqualTo "OTHER"
-      createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
-      createdTime isCloseTo now()
-      createdByPrison isBool true
-      statusCode isEqualTo StatusCode.ACTIVE
-      notesForStaff isEqualTo "Some private staff notes"
-      notesForPrisoners isEqualTo "Some public prisoners notes"
-    }
-  }
-
-  @Test
-  fun `should amend prison created probation booking created by prison user`() {
-    val probationBooking = VideoBooking.newProbationBooking(
-      probationTeam(code = "TEAM_CODE"),
-      probationMeetingType = "OTHER",
-      createdBy = PRISON_USER_BIRMINGHAM,
-      notesForStaff = "Some private staff notes",
-      notesForPrisoners = "Some public prisoners notes",
-    )
-
-    with(probationBooking) {
-      probationTeam isEqualTo probationTeam(code = "TEAM_CODE")
-      isBookingType(BookingType.PROBATION) isBool true
-      probationMeetingType isEqualTo "OTHER"
-      createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
-      createdTime isCloseTo now()
-      createdByPrison isBool true
-      statusCode isEqualTo StatusCode.ACTIVE
-      notesForStaff isEqualTo "Some private staff notes"
-      notesForPrisoners isEqualTo "Some public prisoners notes"
+      probationBooking.startDateTime() isEqualTo null
+      probationBooking.endDateTime() isEqualTo null
     }
 
-    probationBooking.amendProbationBooking(
-      probationMeetingType = "RR",
-      notesForStaff = "Amended staff notes",
-      notesForPrisoners = "Amended prisoners notes",
-      amendedBy = PRISON_USER_BIRMINGHAM,
-    )
+    @Test
+    fun `should be start and end time when main meeting`() {
+      val probationBooking = VideoBooking.newProbationBooking(
+        probationTeam(code = "TEAM_CODE"),
+        probationMeetingType = "PSR",
+        createdBy = PROBATION_USER,
+        notesForStaff = "Some private staff notes",
+        notesForPrisoners = "Should be ignored for external user",
+      ).addAppointment(
+        prison = prison(prisonCode = BIRMINGHAM),
+        prisonerNumber = "ABC123",
+        appointmentType = "VLB_PROBATION",
+        date = tomorrow(),
+        startTime = LocalTime.of(13, 0),
+        endTime = LocalTime.of(15, 0),
+        locationId = UUID.randomUUID(),
+      )
 
-    with(probationBooking) {
-      probationMeetingType isEqualTo "RR"
-      notesForStaff isEqualTo "Amended staff notes"
-      notesForPrisoners isEqualTo "Amended prisoners notes"
-      amendedBy isEqualTo PRISON_USER_BIRMINGHAM.username
-      amendedTime isCloseTo now()
-    }
-  }
-
-  @Test
-  fun `should amend prison created probation booking created by probation user`() {
-    val probationBooking = VideoBooking.newProbationBooking(
-      probationTeam(code = "TEAM_CODE"),
-      probationMeetingType = "OTHER",
-      createdBy = PRISON_USER_BIRMINGHAM,
-      notesForStaff = "Some private staff notes",
-      notesForPrisoners = "Some public prisoners notes",
-    )
-
-    with(probationBooking) {
-      probationTeam isEqualTo probationTeam(code = "TEAM_CODE")
-      isBookingType(BookingType.PROBATION) isBool true
-      probationMeetingType isEqualTo "OTHER"
-      createdBy isEqualTo PRISON_USER_BIRMINGHAM.username
-      createdTime isCloseTo now()
-      createdByPrison isBool true
-      statusCode isEqualTo StatusCode.ACTIVE
-      notesForStaff isEqualTo "Some private staff notes"
-      notesForPrisoners isEqualTo "Some public prisoners notes"
-    }
-
-    probationBooking.amendProbationBooking(
-      probationMeetingType = "RR",
-      notesForStaff = "Amended staff notes",
-      notesForPrisoners = "Amended prisoners notes",
-      amendedBy = PROBATION_USER,
-    )
-
-    with(probationBooking) {
-      probationMeetingType isEqualTo "RR"
-      notesForStaff isEqualTo "Amended staff notes"
-      notesForPrisoners isEqualTo "Some public prisoners notes"
-      amendedBy isEqualTo PROBATION_USER.username
-      amendedTime isCloseTo now()
-    }
-  }
-
-  @Test
-  fun `should amend probation created probation booking created by probation user`() {
-    val probationBooking = VideoBooking.newProbationBooking(
-      probationTeam(code = "TEAM_CODE"),
-      probationMeetingType = "OTHER",
-      createdBy = PROBATION_USER,
-      notesForStaff = "Some private staff notes",
-      notesForPrisoners = "Some public prisoners notes",
-    )
-
-    with(probationBooking) {
-      probationTeam isEqualTo probationTeam(code = "TEAM_CODE")
-      isBookingType(BookingType.PROBATION) isBool true
-      probationMeetingType isEqualTo "OTHER"
-      createdBy isEqualTo PROBATION_USER.username
-      createdTime isCloseTo now()
-      createdByPrison isBool false
-      statusCode isEqualTo StatusCode.ACTIVE
-      notesForStaff isEqualTo "Some private staff notes"
-      notesForPrisoners isEqualTo null
-    }
-
-    probationBooking.amendProbationBooking(
-      probationMeetingType = "RR",
-      notesForStaff = "Amended staff notes",
-      notesForPrisoners = "Amended prisoners notes",
-      amendedBy = PROBATION_USER,
-    )
-
-    with(probationBooking) {
-      probationMeetingType isEqualTo "RR"
-      notesForStaff isEqualTo "Amended staff notes"
-      notesForPrisoners isEqualTo null
-      amendedBy isEqualTo PROBATION_USER.username
-      amendedTime isCloseTo now()
-    }
-  }
-
-  @Test
-  fun `should be probation booking created by probation user`() {
-    val probationBooking = VideoBooking.newProbationBooking(
-      probationTeam(code = "TEAM_CODE"),
-      probationMeetingType = "PSR",
-      createdBy = PROBATION_USER,
-      notesForStaff = "Some private staff notes",
-      notesForPrisoners = "Should be ignored for external user",
-    )
-
-    with(probationBooking) {
-      probationTeam isEqualTo probationTeam(code = "TEAM_CODE")
-      isBookingType(BookingType.PROBATION) isBool true
-      probationMeetingType isEqualTo "PSR"
-      createdBy isEqualTo PROBATION_USER.username
-      createdByPrison isBool false
-      statusCode isEqualTo StatusCode.ACTIVE
-      notesForStaff isEqualTo "Some private staff notes"
-      notesForPrisoners isEqualTo null
+      probationBooking.startDateTime() isEqualTo tomorrow().atTime(13, 0)
+      probationBooking.endDateTime() isEqualTo tomorrow().atTime(15, 0)
     }
   }
 
   @Test
   fun `should cancel booking when active`() {
-    booking.addAppointment(
+    courtBooking.addAppointment(
       prison = prison(prisonCode = BIRMINGHAM),
       prisonerNumber = "ABC123",
       appointmentType = "VLB_COURT_MAIN",
@@ -519,16 +664,16 @@ class VideoBookingTest {
       locationId = UUID.randomUUID(),
     )
 
-    booking.cancel(courtUser())
+    courtBooking.cancel(courtUser())
 
-    booking.statusCode isEqualTo StatusCode.CANCELLED
-    booking.amendedBy isEqualTo "user"
-    booking.amendedTime isCloseTo now()
+    courtBooking.statusCode isEqualTo StatusCode.CANCELLED
+    courtBooking.amendedBy isEqualTo "user"
+    courtBooking.amendedTime isCloseTo now()
   }
 
   @Test
   fun `should reject booking cancellation if already cancelled`() {
-    booking.addAppointment(
+    courtBooking.addAppointment(
       prison = prison(prisonCode = BIRMINGHAM),
       prisonerNumber = "ABC123",
       appointmentType = "VLB_COURT_MAIN",
@@ -538,18 +683,18 @@ class VideoBookingTest {
       locationId = UUID.randomUUID(),
     )
 
-    booking.cancel(courtUser())
+    courtBooking.cancel(courtUser())
 
     val exception = assertThrows<IllegalArgumentException> {
-      booking.cancel(courtUser())
+      courtBooking.cancel(courtUser())
     }
 
-    exception.message isEqualTo "Video booking ${booking.videoBookingId} is already cancelled"
+    exception.message isEqualTo "Video booking ${courtBooking.videoBookingId} is already cancelled"
   }
 
   @Test
   fun `should reject booking cancellation if appointments in past`() {
-    booking.addAppointment(
+    courtBooking.addAppointment(
       prison = prison(prisonCode = BIRMINGHAM),
       prisonerNumber = "ABC123",
       appointmentType = "VLB_COURT_MAIN",
@@ -560,15 +705,15 @@ class VideoBookingTest {
     )
 
     val exception = assertThrows<IllegalArgumentException> {
-      booking.cancel(courtUser())
+      courtBooking.cancel(courtUser())
     }
 
-    exception.message isEqualTo "Video booking ${booking.videoBookingId} cannot be cancelled"
+    exception.message isEqualTo "Video booking ${courtBooking.videoBookingId} cannot be cancelled"
   }
 
   @Test
   fun `should not be a migrated booking`() {
-    booking.isMigrated() isBool false
+    courtBooking.isMigrated() isBool false
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/RescheduleEmailsFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/facade/RescheduleEmailsFacadeTest.kt
@@ -1,0 +1,102 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.facade
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.EmailService
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withMainCourtPrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withPreMainCourtPrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.VideoLinkBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.NotificationRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ContactsService
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court.RescheduledCourtEmailFactory
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation.RescheduledProbationEmailFactory
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
+import java.time.LocalDate
+import java.time.LocalTime
+
+class RescheduleEmailsFacadeTest {
+  private val prisonRepository: PrisonRepository = mock()
+  private val contactsService: ContactsService = mock()
+  private val rescheduledCourtEmailFactory: RescheduledCourtEmailFactory = mock()
+  private val rescheduledProbationEmailFactory: RescheduledProbationEmailFactory = mock()
+  private val emailService: EmailService = mock()
+  private val notificationRepository: NotificationRepository = mock()
+  private val facade = RescheduleEmailsFacade(
+    prisonRepository,
+    contactsService,
+    rescheduledCourtEmailFactory,
+    rescheduledProbationEmailFactory,
+    emailService,
+    notificationRepository,
+  )
+  private val old = bookingWithPreAndMain(
+    date = tomorrow(),
+    startTime = LocalTime.of(10, 0),
+    endTime = LocalTime.of(11, 0),
+    birminghamLocation,
+  ).toModel(setOf(birminghamLocation.toModel()))
+
+  private val amended = bookingWithMainOnly(
+    date = tomorrow(),
+    startTime = LocalTime.of(10, 0),
+    endTime = LocalTime.of(11, 0),
+    birminghamLocation,
+  )
+
+  @Test
+  fun `should be considered rescheduled`() {
+    facade.isConsideredRescheduled(old, amended) isBool true
+  }
+
+  @Test
+  fun `should not be considered rescheduled`() {
+    facade.isConsideredRescheduled(amended.toModel(setOf(birminghamLocation.toModel())), amended) isBool false
+  }
+
+  @Test
+  fun `should fail rescheduled check if bookings are not the same`() {
+    val originalBooking: VideoLinkBooking = mock()
+    whenever { originalBooking.videoLinkBookingId } doReturn 1
+
+    val amendedBooking: VideoBooking = mock()
+    whenever { amendedBooking.videoBookingId } doReturn 2
+
+    assertThrows<IllegalArgumentException> {
+      facade.isConsideredRescheduled(originalBooking, amendedBooking)
+    }.message isEqualTo "Original and amended bookings must have the same video booking ID"
+  }
+
+  private fun bookingWithPreAndMain(date: LocalDate, startTime: LocalTime, endTime: LocalTime, location: Location) = run {
+    courtBooking().withPreMainCourtPrisonAppointment(
+      date = date,
+      startTime = startTime,
+      endTime = endTime,
+      location = location,
+      prisonCode = BIRMINGHAM,
+      prisonerNumber = "123456",
+    )
+  }
+
+  private fun bookingWithMainOnly(date: LocalDate, startTime: LocalTime, endTime: LocalTime, location: Location) = run {
+    courtBooking().withMainCourtPrisonAppointment(
+      date = date,
+      startTime = startTime,
+      endTime = endTime,
+      location = location,
+      prisonCode = BIRMINGHAM,
+      prisonerNumber = "123456",
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/IntegrationTestBase.kt
@@ -69,7 +69,7 @@ abstract class IntegrationTestBase {
   @BeforeEach
   fun clearAllCaches() {
     // Clear the caches so tests don't interfere with each other when stubbed API calls could overlap with another.
-    cacheManager.cacheNames.forEach { cacheManager.getCache(it)?.clear() }
+    cacheManager.resetCaches()
   }
 
   @BeforeEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -24,10 +24,12 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.LocationUsage
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Notification
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.StatusCode
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.AmendCourtBookingRequestBuilder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BLACKPOOL_MC_PPOC
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.CHESTERFIELD_JUSTICE_CENTRE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.CreateCourtBookingRequestBuilder
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.DERBY_JUSTICE_CENTRE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.HARROW
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.LocationKeyValue
@@ -63,6 +65,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isInstanceOf
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isNotEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.pentonvilleLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.pentonvillePrisoner
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.requestCourtVideoLinkRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.requestProbationVideoLinkRequest
@@ -974,7 +977,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
   }
 
   @Test
-  fun `should reschedule a Derby court booking and emails sent to Pentonville prison`() {
+  fun `should reschedule a Derby court booking and emails sent to Pentonville prison when main start time changed`() {
     videoBookingRepository.findAll() hasSize 0
     notificationRepository.findAll() hasSize 0
 
@@ -1026,6 +1029,147 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
       startTime isEqualTo LocalTime.of(13, 0)
       endTime isEqualTo LocalTime.of(14, 30)
       notesForStaff isEqualTo "amended court booking comments"
+    }
+
+    // There should be 3 notifications, 1 user email and 2 prison emails
+    val notifications = notificationRepository.findAll().also { it hasSize 3 }
+
+    notifications.isPresent("p@p.com", RescheduledCourtBookingPrisonCourtEmail::class, persistedBooking)
+    notifications.isPresent("g@g.com", RescheduledCourtBookingPrisonCourtEmail::class, persistedBooking)
+    notifications.isPresent(COURT_USER.email!!, RescheduledCourtBookingUserEmail::class, persistedBooking)
+  }
+
+  @Test
+  fun `should reschedule a Derby court booking and emails sent to Pentonville prison when pre is removed`() {
+    videoBookingRepository.findAll() hasSize 0
+    notificationRepository.findAll() hasSize 0
+
+    prisonSearchApi().stubGetPrisoner("123456", PENTONVILLE)
+
+    val courtBookingRequest = CreateCourtBookingRequestBuilder.builder {
+      court(DERBY_JUSTICE_CENTRE)
+      prisoner(pentonvillePrisoner)
+      pre(pentonvilleLocation)
+      main(pentonvilleLocation, tomorrow(), LocalTime.of(12, 0), LocalTime.of(12, 30))
+    }.build()
+
+    val bookingId = webTestClient.createBooking(courtBookingRequest, COURT_USER)
+
+    val amendBookingRequest = AmendCourtBookingRequestBuilder.builder {
+      prisoner(pentonvillePrisoner)
+      main(pentonvilleLocation, tomorrow(), LocalTime.of(12, 0), LocalTime.of(12, 30))
+    }.build()
+
+    notificationRepository.deleteAll()
+    webTestClient.amendBooking(bookingId, amendBookingRequest, COURT_USER)
+
+    val persistedBooking = videoBookingRepository.findById(bookingId).orElseThrow()
+
+    with(prisonAppointmentRepository.findByVideoBooking(persistedBooking).single()) {
+      prisonCode() isEqualTo PENTONVILLE
+      prisonerNumber isEqualTo pentonvillePrisoner.number
+      appointmentType isEqualTo AppointmentType.VLB_COURT_MAIN.name
+      appointmentDate isEqualTo tomorrow()
+      prisonLocationId isEqualTo pentonvilleLocation.id
+      startTime isEqualTo LocalTime.of(12, 0)
+      endTime isEqualTo LocalTime.of(12, 30)
+    }
+
+    // There should be 3 notifications, 1 user email and 2 prison emails
+    val notifications = notificationRepository.findAll().also { it hasSize 3 }
+
+    notifications.isPresent("p@p.com", RescheduledCourtBookingPrisonCourtEmail::class, persistedBooking)
+    notifications.isPresent("g@g.com", RescheduledCourtBookingPrisonCourtEmail::class, persistedBooking)
+    notifications.isPresent(COURT_USER.email!!, RescheduledCourtBookingUserEmail::class, persistedBooking)
+  }
+
+  @Test
+  fun `should reschedule a Derby court booking and emails sent to Pentonville prison when post is removed`() {
+    videoBookingRepository.findAll() hasSize 0
+    notificationRepository.findAll() hasSize 0
+
+    prisonSearchApi().stubGetPrisoner("123456", PENTONVILLE)
+
+    val courtBookingRequest = CreateCourtBookingRequestBuilder.builder {
+      court(DERBY_JUSTICE_CENTRE)
+      prisoner(pentonvillePrisoner)
+      post(pentonvilleLocation)
+      main(pentonvilleLocation, tomorrow(), LocalTime.of(12, 0), LocalTime.of(12, 30))
+    }.build()
+
+    val bookingId = webTestClient.createBooking(courtBookingRequest, COURT_USER)
+
+    val amendBookingRequest = AmendCourtBookingRequestBuilder.builder {
+      prisoner(pentonvillePrisoner)
+      main(pentonvilleLocation, tomorrow(), LocalTime.of(12, 0), LocalTime.of(12, 30))
+    }.build()
+
+    notificationRepository.deleteAll()
+    webTestClient.amendBooking(bookingId, amendBookingRequest, COURT_USER)
+
+    val persistedBooking = videoBookingRepository.findById(bookingId).orElseThrow()
+
+    with(prisonAppointmentRepository.findByVideoBooking(persistedBooking).single()) {
+      prisonCode() isEqualTo PENTONVILLE
+      prisonerNumber isEqualTo pentonvillePrisoner.number
+      appointmentType isEqualTo AppointmentType.VLB_COURT_MAIN.name
+      appointmentDate isEqualTo tomorrow()
+      prisonLocationId isEqualTo pentonvilleLocation.id
+      startTime isEqualTo LocalTime.of(12, 0)
+      endTime isEqualTo LocalTime.of(12, 30)
+    }
+
+    // There should be 3 notifications, 1 user email and 2 prison emails
+    val notifications = notificationRepository.findAll().also { it hasSize 3 }
+
+    notifications.isPresent("p@p.com", RescheduledCourtBookingPrisonCourtEmail::class, persistedBooking)
+    notifications.isPresent("g@g.com", RescheduledCourtBookingPrisonCourtEmail::class, persistedBooking)
+    notifications.isPresent(COURT_USER.email!!, RescheduledCourtBookingUserEmail::class, persistedBooking)
+  }
+
+  @Test
+  fun `should reschedule a Derby court booking and emails sent to Pentonville prison when pre is added`() {
+    videoBookingRepository.findAll() hasSize 0
+    notificationRepository.findAll() hasSize 0
+
+    prisonSearchApi().stubGetPrisoner("123456", PENTONVILLE)
+
+    val courtBookingRequest = CreateCourtBookingRequestBuilder.builder {
+      court(DERBY_JUSTICE_CENTRE)
+      prisoner(pentonvillePrisoner)
+      main(pentonvilleLocation, tomorrow(), LocalTime.of(12, 0), LocalTime.of(12, 30))
+    }.build()
+
+    val bookingId = webTestClient.createBooking(courtBookingRequest, COURT_USER)
+
+    val amendBookingRequest = AmendCourtBookingRequestBuilder.builder {
+      prisoner(pentonvillePrisoner)
+      pre(pentonvilleLocation)
+      main(pentonvilleLocation, tomorrow(), LocalTime.of(12, 0), LocalTime.of(12, 30))
+    }.build()
+
+    notificationRepository.deleteAll()
+    webTestClient.amendBooking(bookingId, amendBookingRequest, COURT_USER)
+
+    val persistedBooking = videoBookingRepository.findById(bookingId).orElseThrow()
+    val persistedAppointments = prisonAppointmentRepository.findByVideoBooking(persistedBooking).also { it hasSize 2 }
+
+    with(persistedAppointments.single { it.appointmentType == AppointmentType.VLB_COURT_PRE.name }) {
+      prisonCode() isEqualTo PENTONVILLE
+      prisonerNumber isEqualTo pentonvillePrisoner.number
+      appointmentDate isEqualTo tomorrow()
+      prisonLocationId isEqualTo pentonvilleLocation.id
+      startTime isEqualTo LocalTime.of(11, 45)
+      endTime isEqualTo LocalTime.of(12, 0)
+    }
+
+    with(persistedAppointments.single { it.appointmentType == AppointmentType.VLB_COURT_MAIN.name }) {
+      prisonCode() isEqualTo PENTONVILLE
+      prisonerNumber isEqualTo pentonvillePrisoner.number
+      appointmentDate isEqualTo tomorrow()
+      prisonLocationId isEqualTo pentonvilleLocation.id
+      startTime isEqualTo LocalTime.of(12, 0)
+      endTime isEqualTo LocalTime.of(12, 30)
     }
 
     // There should be 3 notifications, 1 user email and 2 prison emails

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/RescheduledCourtEmailFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/court/RescheduledCourtEmailFactoryTest.kt
@@ -1,0 +1,203 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.court
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toMediumFormatStyle
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ContactType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.bookingContact
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntriesExactlyInAnyOrder
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isInstanceOf
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisoner
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withMainCourtPrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withPreMainCourtPrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.LocationsService
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
+import java.time.LocalDate
+import java.time.LocalTime
+
+class RescheduledCourtEmailFactoryTest {
+  private val locationService: LocationsService = mock()
+  private val factory = RescheduledCourtEmailFactory(locationService)
+  private val old = bookingWithPreAndMain(
+    date = tomorrow(),
+    startTime = LocalTime.of(10, 0),
+    endTime = LocalTime.of(11, 0),
+    birminghamLocation,
+  ).toModel(setOf(birminghamLocation.toModel()))
+  private val amended = bookingWithMainOnly(
+    date = tomorrow(),
+    startTime = LocalTime.of(10, 0),
+    endTime = LocalTime.of(11, 0),
+    birminghamLocation,
+  )
+
+  @BeforeEach
+  fun before() {
+    whenever(locationService.getLocationById(birminghamLocation.id)) doReturn birminghamLocation.toModel()
+    whenever(locationService.getLocationByKey(birminghamLocation.key)) doReturn birminghamLocation.toModel()
+  }
+
+  @Test
+  fun `should create a user email`() {
+    val email = factory.user(
+      oldBooking = old,
+      amendedBooking = amended,
+      prison = prison(prisonCode = BIRMINGHAM),
+      prisoner = prisoner(prisonCode = BIRMINGHAM, prisonerNumber = "123456"),
+      userContact = bookingContact(contactType = ContactType.USER, email = "user@email.com"),
+    )
+
+    email isInstanceOf RescheduledCourtBookingUserEmail::class.java
+    email.address isEqualTo "user@email.com"
+    email.personalisation() containsEntriesExactlyInAnyOrder mapOf(
+      "comments" to "None entered",
+      "court" to "DRBYMC",
+      "courtHearingLink" to "https://court.hearing.link",
+      "date" to amended.startDateTime()!!.toLocalDate().toMediumFormatStyle(),
+      "mainAppointmentInfo" to "Birmingham room - 10:00 to 11:00",
+      "offenderNo" to "123456",
+      "oldAppointmentDate" to old.startDateTime().toLocalDate().toMediumFormatStyle(),
+      "oldMainAppointmentInfo" to "Birmingham Room - 10:00 to 11:00",
+      "oldPostAppointmentInfo" to "Not required",
+      "oldPreAppointmentInfo" to "Birmingham Room - 09:45 to 10:45",
+      "postAppointmentInfo" to "Not required",
+      "postPrisonVideoUrl" to "",
+      "preAppointmentInfo" to "Not required",
+      "prePrisonVideoUrl" to "",
+      "prison" to "Birmingham",
+      "prisonerName" to "Fred Bloggs",
+      "userName" to "Book Video",
+    )
+  }
+
+  @Test
+  fun `should create a court email`() {
+    val email = factory.court(
+      oldBooking = old,
+      amendedBooking = amended,
+      prison = prison(prisonCode = BIRMINGHAM),
+      prisoner = prisoner(prisonCode = BIRMINGHAM, prisonerNumber = "123456"),
+      courtContact = bookingContact(contactType = ContactType.COURT, email = "court@email.com"),
+    )
+
+    email isInstanceOf RescheduledCourtBookingCourtEmail::class.java
+    email.address isEqualTo "court@email.com"
+    email.personalisation() containsEntriesExactlyInAnyOrder mapOf(
+      "comments" to "None entered",
+      "court" to "DRBYMC",
+      "courtHearingLink" to "https://court.hearing.link",
+      "date" to amended.startDateTime()!!.toLocalDate().toMediumFormatStyle(),
+      "mainAppointmentInfo" to "Birmingham room - 10:00 to 11:00",
+      "offenderNo" to "123456",
+      "oldAppointmentDate" to old.startDateTime().toLocalDate().toMediumFormatStyle(),
+      "oldMainAppointmentInfo" to "Birmingham Room - 10:00 to 11:00",
+      "oldPostAppointmentInfo" to "Not required",
+      "oldPreAppointmentInfo" to "Birmingham Room - 09:45 to 10:45",
+      "postAppointmentInfo" to "Not required",
+      "postPrisonVideoUrl" to "",
+      "preAppointmentInfo" to "Not required",
+      "prePrisonVideoUrl" to "",
+      "prison" to "Birmingham",
+      "prisonerName" to "Fred Bloggs",
+    )
+  }
+
+  @Test
+  fun `should create a prison email, no court contact`() {
+    val email = factory.prison(
+      oldBooking = old,
+      amendedBooking = amended,
+      prison = prison(prisonCode = BIRMINGHAM),
+      prisoner = prisoner(prisonCode = BIRMINGHAM, prisonerNumber = "123456"),
+      prisonContact = bookingContact(contactType = ContactType.PRISON, email = "prison@email.com"),
+      contacts = emptyList(),
+    )
+
+    email isInstanceOf RescheduledCourtBookingPrisonNoCourtEmail::class.java
+    email.address isEqualTo "prison@email.com"
+    email.personalisation() containsEntriesExactlyInAnyOrder mapOf(
+      "comments" to "None entered",
+      "court" to "DRBYMC",
+      "courtHearingLink" to "https://court.hearing.link",
+      "date" to amended.startDateTime()!!.toLocalDate().toMediumFormatStyle(),
+      "mainAppointmentInfo" to "Birmingham room - 10:00 to 11:00",
+      "offenderNo" to "123456",
+      "oldAppointmentDate" to old.startDateTime().toLocalDate().toMediumFormatStyle(),
+      "oldMainAppointmentInfo" to "Birmingham Room - 10:00 to 11:00",
+      "oldPostAppointmentInfo" to "Not required",
+      "oldPreAppointmentInfo" to "Birmingham Room - 09:45 to 10:45",
+      "postAppointmentInfo" to "Not required",
+      "postPrisonVideoUrl" to "",
+      "preAppointmentInfo" to "Not required",
+      "prePrisonVideoUrl" to "",
+      "prison" to "Birmingham",
+      "prisonerName" to "Fred Bloggs",
+    )
+  }
+
+  @Test
+  fun `should create a prison email, with court contact`() {
+    val email = factory.prison(
+      oldBooking = old,
+      amendedBooking = amended,
+      prison = prison(prisonCode = BIRMINGHAM),
+      prisoner = prisoner(prisonCode = BIRMINGHAM, prisonerNumber = "123456"),
+      prisonContact = bookingContact(contactType = ContactType.PRISON, email = "prison@email.com"),
+      contacts = listOf(bookingContact(contactType = ContactType.COURT, email = "court@email.com")),
+    )
+
+    email isInstanceOf RescheduledCourtBookingPrisonCourtEmail::class.java
+    email.address isEqualTo "prison@email.com"
+    email.personalisation() containsEntriesExactlyInAnyOrder mapOf(
+      "comments" to "None entered",
+      "court" to "DRBYMC",
+      "courtEmailAddress" to "court@email.com",
+      "courtHearingLink" to "https://court.hearing.link",
+      "date" to amended.startDateTime()!!.toLocalDate().toMediumFormatStyle(),
+      "mainAppointmentInfo" to "Birmingham room - 10:00 to 11:00",
+      "offenderNo" to "123456",
+      "oldAppointmentDate" to old.startDateTime().toLocalDate().toMediumFormatStyle(),
+      "oldMainAppointmentInfo" to "Birmingham Room - 10:00 to 11:00",
+      "oldPostAppointmentInfo" to "Not required",
+      "oldPreAppointmentInfo" to "Birmingham Room - 09:45 to 10:45",
+      "postAppointmentInfo" to "Not required",
+      "postPrisonVideoUrl" to "",
+      "preAppointmentInfo" to "Not required",
+      "prePrisonVideoUrl" to "",
+      "prison" to "Birmingham",
+      "prisonerName" to "Fred Bloggs",
+    )
+  }
+
+  private fun bookingWithPreAndMain(date: LocalDate, startTime: LocalTime, endTime: LocalTime, location: Location) = run {
+    courtBooking().withPreMainCourtPrisonAppointment(
+      date = date,
+      startTime = startTime,
+      endTime = endTime,
+      location = location,
+      prisonCode = BIRMINGHAM,
+      prisonerNumber = "123456",
+    )
+  }
+
+  private fun bookingWithMainOnly(date: LocalDate, startTime: LocalTime, endTime: LocalTime, location: Location) = run {
+    courtBooking().withMainCourtPrisonAppointment(
+      date = date,
+      startTime = startTime,
+      endTime = endTime,
+      location = location,
+      prisonCode = BIRMINGHAM,
+      prisonerNumber = "123456",
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/RescheduledProbationEmailFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/emails/probation/RescheduledProbationEmailFactoryTest.kt
@@ -1,0 +1,192 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.emails.probation
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.toMediumFormatStyle
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ContactType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.bookingContact
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsEntriesExactlyInAnyOrder
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isInstanceOf
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prisoner
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withProbationPrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.AdditionalBookingDetailRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.LocationsService
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
+import java.time.LocalDate
+import java.time.LocalTime
+
+class RescheduledProbationEmailFactoryTest {
+  private val locationService: LocationsService = mock()
+  private val additionalBookingDetailRepository: AdditionalBookingDetailRepository = mock()
+  private val factory = RescheduledProbationEmailFactory(locationService, additionalBookingDetailRepository)
+  private val old = oldBooking(
+    date = tomorrow(),
+    startTime = LocalTime.of(10, 0),
+    endTime = LocalTime.of(11, 0),
+    birminghamLocation,
+  ).toModel(setOf(birminghamLocation.toModel()))
+  private val amended = amendedBooking(
+    date = tomorrow(),
+    startTime = LocalTime.of(11, 0),
+    endTime = LocalTime.of(12, 0),
+    birminghamLocation,
+  )
+
+  @BeforeEach
+  fun before() {
+    whenever(locationService.getLocationById(birminghamLocation.id)) doReturn birminghamLocation.toModel()
+    whenever(locationService.getLocationByKey(birminghamLocation.key)) doReturn birminghamLocation.toModel()
+  }
+
+  @Test
+  fun `should create a user email`() {
+    val email = factory.user(
+      oldBooking = old,
+      amendedBooking = amended,
+      prison = prison(prisonCode = BIRMINGHAM),
+      prisoner = prisoner(prisonCode = BIRMINGHAM, prisonerNumber = "123456"),
+      contact = bookingContact(contactType = ContactType.USER, email = "user@email.com"),
+    )
+
+    email isInstanceOf RescheduledProbationBookingUserEmail::class.java
+    email.address isEqualTo "user@email.com"
+    email.personalisation() containsEntriesExactlyInAnyOrder mapOf(
+      "comments" to "None entered",
+      "probationTeam" to "probation team description",
+      "date" to amended.startDateTime()!!.toLocalDate().toMediumFormatStyle(),
+      "appointmentInfo" to "Birmingham room - 11:00 to 12:00",
+      "offenderNo" to "123456",
+      "oldAppointmentDate" to old.startDateTime().toLocalDate().toMediumFormatStyle(),
+      "oldAppointmentInfo" to "Birmingham Room - 10:00 to 11:00",
+      "prison" to "Birmingham",
+      "prisonerName" to "Fred Bloggs",
+      "prisonVideoUrl" to "Not yet known",
+      "probationOfficerEmailAddress" to "Not yet known",
+      "probationOfficerContactNumber" to "Not yet known",
+      "probationOfficerName" to "Not yet known",
+      "userName" to "Book Video",
+    )
+  }
+
+  @Test
+  fun `should create a probation email`() {
+    val email = factory.probation(
+      oldBooking = old,
+      amendedBooking = amended,
+      prison = prison(prisonCode = BIRMINGHAM),
+      prisoner = prisoner(prisonCode = BIRMINGHAM, prisonerNumber = "123456"),
+      contact = bookingContact(contactType = ContactType.PROBATION, email = "probation@email.com"),
+    )
+
+    email isInstanceOf RescheduledProbationBookingProbationEmail::class.java
+    email.address isEqualTo "probation@email.com"
+    email.personalisation() containsEntriesExactlyInAnyOrder mapOf(
+      "comments" to "None entered",
+      "probationTeam" to "probation team description",
+      "date" to amended.startDateTime()!!.toLocalDate().toMediumFormatStyle(),
+      "appointmentInfo" to "Birmingham room - 11:00 to 12:00",
+      "offenderNo" to "123456",
+      "oldAppointmentDate" to old.startDateTime().toLocalDate().toMediumFormatStyle(),
+      "oldAppointmentInfo" to "Birmingham Room - 10:00 to 11:00",
+      "prison" to "Birmingham",
+      "prisonVideoUrl" to "Not yet known",
+      "prisonerName" to "Fred Bloggs",
+      "probationOfficerName" to "Not yet known",
+      "probationOfficerEmailAddress" to "Not yet known",
+      "probationOfficerContactNumber" to "Not yet known",
+    )
+  }
+
+  @Test
+  fun `should create a prison email, no probation contact`() {
+    val email = factory.prison(
+      oldBooking = old,
+      amendedBooking = amended,
+      prison = prison(prisonCode = BIRMINGHAM),
+      prisoner = prisoner(prisonCode = BIRMINGHAM, prisonerNumber = "123456"),
+      contact = bookingContact(contactType = ContactType.PRISON, email = "prison@email.com"),
+      contacts = emptyList(),
+    )
+
+    email isInstanceOf RescheduledProbationBookingPrisonNoProbationEmail::class.java
+    email.address isEqualTo "prison@email.com"
+    email.personalisation() containsEntriesExactlyInAnyOrder mapOf(
+      "comments" to "None entered",
+      "probationTeam" to "probation team description",
+      "date" to amended.startDateTime()!!.toLocalDate().toMediumFormatStyle(),
+      "appointmentInfo" to "Birmingham room - 11:00 to 12:00",
+      "offenderNo" to "123456",
+      "oldAppointmentDate" to old.startDateTime().toLocalDate().toMediumFormatStyle(),
+      "oldAppointmentInfo" to "Birmingham Room - 10:00 to 11:00",
+      "prison" to "Birmingham",
+      "prisonVideoUrl" to "Not yet known",
+      "prisonerName" to "Fred Bloggs",
+      "probationOfficerName" to "Not yet known",
+      "probationOfficerEmailAddress" to "Not yet known",
+      "probationOfficerContactNumber" to "Not yet known",
+    )
+  }
+
+  @Test
+  fun `should create a prison email, with probation contact`() {
+    val email = factory.prison(
+      oldBooking = old,
+      amendedBooking = amended,
+      prison = prison(prisonCode = BIRMINGHAM),
+      prisoner = prisoner(prisonCode = BIRMINGHAM, prisonerNumber = "123456"),
+      contact = bookingContact(contactType = ContactType.PRISON, email = "prison@email.com"),
+      contacts = listOf(bookingContact(contactType = ContactType.PROBATION, email = "probation@email.com")),
+    )
+
+    email isInstanceOf RescheduledProbationBookingPrisonProbationEmail::class.java
+    email.address isEqualTo "prison@email.com"
+    email.personalisation() containsEntriesExactlyInAnyOrder mapOf(
+      "comments" to "None entered",
+      "probationTeam" to "probation team description",
+      "date" to amended.startDateTime()!!.toLocalDate().toMediumFormatStyle(),
+      "appointmentInfo" to "Birmingham room - 11:00 to 12:00",
+      "offenderNo" to "123456",
+      "oldAppointmentDate" to old.startDateTime().toLocalDate().toMediumFormatStyle(),
+      "oldAppointmentInfo" to "Birmingham Room - 10:00 to 11:00",
+      "prison" to "Birmingham",
+      "prisonVideoUrl" to "Not yet known",
+      "prisonerName" to "Fred Bloggs",
+      "probationEmailAddress" to "probation@email.com",
+      "probationOfficerName" to "Not yet known",
+      "probationOfficerEmailAddress" to "Not yet known",
+      "probationOfficerContactNumber" to "Not yet known",
+    )
+  }
+
+  private fun oldBooking(date: LocalDate, startTime: LocalTime, endTime: LocalTime, location: Location) = run {
+    probationBooking().withProbationPrisonAppointment(
+      date = date,
+      startTime = startTime,
+      endTime = endTime,
+      location = location,
+      prisonCode = BIRMINGHAM,
+      prisonerNumber = "123456",
+    )
+  }
+
+  private fun amendedBooking(date: LocalDate, startTime: LocalTime, endTime: LocalTime, location: Location) = run {
+    probationBooking().withProbationPrisonAppointment(
+      date = date,
+      startTime = startTime,
+      endTime = endTime,
+      location = location,
+      prisonCode = BIRMINGHAM,
+      prisonerNumber = "123456",
+    )
+  }
+}


### PR DESCRIPTION
It has been decided any change to the start and/or end time of bookings then bookings are to be considered rescheduled.

This means if pre or post meetings are added or removed then the meeting time has change and so rescheduled.

Ultimately anything that impacts the date, start time or end time of a booking then that booking is considered rescheduled.