### PR TITLE
BAVL-1291: New social security tribunal courts added for the North West

### DIFF
--- a/src/main/resources/migrations/common/V2026.05.12__add_social_security_tribunals.sql
+++ b/src/main/resources/migrations/common/V2026.05.12__add_social_security_tribunals.sql
@@ -1,0 +1,12 @@
+insert into court (code, description, enabled, read_only, notes, created_by, created_time)
+values ('CRLSSC', 'Carlisle Social Security and Child Support Tribunal', true, false, 'Not in register', 'TIM', current_timestamp),
+       ('BRWSSC', 'Barrow Social Security and Child Support Tribunal', true, false, 'Not in register', 'TIM', current_timestamp),
+       ('BRKSSC', 'Birkenhead Social Security and Child Support Tribunal', true, false, 'Not in register', 'TIM', current_timestamp),
+       ('CHSSSC', 'Chester Social Security and Child Support Tribunal', true, false, 'Not in register', 'TIM', current_timestamp),
+       ('LANSSC', 'Lancaster Social Security and Child Support Tribunal', true, false, 'Not in register', 'TIM', current_timestamp),
+       ('MANSSC', 'Manchester Social Security and Child Support Tribunal', true, false, 'Not in register', 'TIM', current_timestamp),
+       ('PRSSSC', 'Preston Social Security and Child Support Tribunal', true, false, 'Not in register', 'TIM', current_timestamp),
+       ('SHESSC', 'St Helens Social Security and Child Support Tribunal', true, false, 'Not in register', 'TIM', current_timestamp),
+       ('STKSSC', 'Stockport Social Security and Child Support Tribunal', true, false, 'Not in register', 'TIM', current_timestamp),
+       ('WIGSSC', 'Wigan Social Security and Child Support Tribunal', true, false, 'Not in register', 'TIM', current_timestamp),
+       ('WRKSSC', 'Workington Social Security and Child Support Tribunal', true, false, 'Not in register', 'TIM', current_timestamp);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CourtsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/CourtsResourceIntegrationTest.kt
@@ -34,15 +34,15 @@ class CourtsResourceIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:integration-test-data/seed-enabled-court-data.sql")
   @Test
   fun `should return filtered and unfiltered courts`() {
-    courtRepository.findAll() hasSize 438 // Including 1 read-only court UNKNOWN
+    courtRepository.findAll() hasSize 449 // Including 1 read-only court UNKNOWN
 
     val enabledOnlyCourts = webTestClient.getCourts(true)
-    enabledOnlyCourts hasSize 435
+    enabledOnlyCourts hasSize 446
     enabledOnlyCourts.all { it.enabled } isBool true
 
     val allCourts = webTestClient.getCourts(false)
-    allCourts hasSize 436
-    allCourts.count { it.enabled } isEqualTo 435
+    allCourts hasSize 447
+    allCourts.count { it.enabled } isEqualTo 446
     allCourts.count { !it.enabled } isEqualTo 1
   }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -45,7 +45,7 @@ hmpps:
   sar:
     tests:
       attachments-expected: false
-      expected-flyway-schema-version: 2026.04.28
+      expected-flyway-schema-version: 2026.05.12
       expected-jpa-entity-schema:
         path: /sar/entity-schema.json
       expected-api-response:


### PR DESCRIPTION
This adds 11 new courts for the North West.
Contacts will be added manually to preprod and prod as a follow-on action.