### PR TITLE
BAVL-1346 enable rescheduled emails feature in production.

### DIFF
--- a/helm_deploy/hmpps-book-a-video-link-api/values.yaml
+++ b/helm_deploy/hmpps-book-a-video-link-api/values.yaml
@@ -42,7 +42,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     DB_SSL_MODE: "verify-full"
     HMPPS_SQS_USE_WEB_TOKEN: true
-    FEATURE_SEND_RESCHEDULED_EMAILS: false
+    FEATURE_SEND_RESCHEDULED_EMAILS: true
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:


### PR DESCRIPTION
The changes turns on the rescheduled emails feature on in production.

Once live (for a while) we can remove the old redundant code and toggle.