### PR TITLE
BVLS-1345 resolve issue where exisiting slot not included for timeslot service availability checks.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/TimeSlotAvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/TimeSlotAvailabilityService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.availability
 
+import jakarta.persistence.EntityNotFoundException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -7,6 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.isOnOrBefore
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.PrisonRegime
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.AvailabilityStatus
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationUsage
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
@@ -14,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.TimeSlo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AvailableLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AvailableLocationsResponse
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.slot
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.LocationsService
 import java.time.LocalTime
 
@@ -29,6 +32,7 @@ import java.time.LocalTime
 @Transactional(readOnly = true)
 class TimeSlotAvailabilityService(
   locationsService: LocationsService,
+  private val prisonAppointmentRepository: PrisonAppointmentRepository,
   private val bookedLocationsService: BookedLocationsService,
   private val prisonRegime: PrisonRegime,
   private val timeSource: TimeSource,
@@ -41,6 +45,7 @@ class TimeSlotAvailabilityService(
   override fun findAvailable(request: TimeSlotAvailabilityRequest): AvailableLocationsResponse {
     val (startOfDay, endOfDay) = getStartAndEndOfDay(request)
     val prisonVideoLinkLocations = getVideoLinkLocationsAt(request.prisonCode!!)
+    val mayBeExistingAppointment = request.vlbIdToExclude?.let { prisonAppointmentRepository.findById(it).orElseThrow { EntityNotFoundException("Prison appointment with ID $it not found.") } }
     val bookedLocations = bookedLocationsService.findBooked(BookedLookup(request.prisonCode, request.date!!, prisonVideoLinkLocations, request.vlbIdToExclude))
     val meetingDuration = request.bookingDuration!!.toLong()
 
@@ -51,19 +56,36 @@ class TimeSlotAvailabilityService(
         var meetingEndTime = meetingStartTime.plusMinutes(meetingDuration)
 
         while (meetingEndTime.isOnOrBefore(endOfDay)) {
-          if (!bookedLocations.isBooked(location, meetingStartTime, meetingEndTime) && request.fallsWithinSlotTime(meetingStartTime)) {
+          if (mayBeExistingAppointment?.let { isTheSame(it, location, request, meetingStartTime, meetingEndTime) } == true) {
             add(
-              availabilityStatus = location.allowsByAnyRuleOrSchedule(request, meetingStartTime),
+              availabilityStatus = AvailabilityStatus.SHARED,
               availableLocation = AvailableLocation(
                 name = location.description ?: location.key,
                 startTime = meetingStartTime,
                 endTime = meetingEndTime,
                 dpsLocationId = location.dpsLocationId,
                 dpsLocationKey = location.key,
-                usage = location.extraAttributes?.locationUsage?.let { LocationUsage.valueOf(it.name) } ?: LocationUsage.SHARED,
+                usage = location.extraAttributes?.locationUsage?.let { LocationUsage.valueOf(it.name) }
+                  ?: LocationUsage.SHARED,
                 timeSlot = slot(meetingStartTime),
               ),
             )
+          } else {
+            if (!bookedLocations.isBooked(location, meetingStartTime, meetingEndTime) && request.fallsWithinSlotTime(meetingStartTime)) {
+              add(
+                availabilityStatus = location.allowsByAnyRuleOrSchedule(request, meetingStartTime),
+                availableLocation = AvailableLocation(
+                  name = location.description ?: location.key,
+                  startTime = meetingStartTime,
+                  endTime = meetingEndTime,
+                  dpsLocationId = location.dpsLocationId,
+                  dpsLocationKey = location.key,
+                  usage = location.extraAttributes?.locationUsage?.let { LocationUsage.valueOf(it.name) }
+                    ?: LocationUsage.SHARED,
+                  timeSlot = slot(meetingStartTime),
+                ),
+              )
+            }
           }
 
           meetingStartTime = meetingStartTime.plusMinutes(15)
@@ -77,6 +99,15 @@ class TimeSlotAvailabilityService(
         .build()
         .also { log.info("TIME SLOT AVAILABLE LOCATIONS: found ${it.size} available locations matching request $request") },
     )
+  }
+
+  private fun isTheSame(existingAppointment: PrisonAppointment, location: Location, request: TimeSlotAvailabilityRequest, start: LocalTime, end: LocalTime) = run {
+    existingAppointment.prisonLocationId == location.dpsLocationId &&
+      request.date == existingAppointment.appointmentDate &&
+      request.timeSlots == null ||
+      request.timeSlots!!.contains(slot(existingAppointment.startTime)) &&
+      start == existingAppointment.startTime &&
+      end == existingAppointment.endTime
   }
 
   private fun getStartAndEndOfDay(request: TimeSlotAvailabilityRequest): Pair<LocalTime, LocalTime> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/TimeSlotAvailabilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/TimeSlotAvailabilityServiceTest.kt
@@ -16,10 +16,13 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsExactly
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationTeam
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.risleyLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation2
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withProbationPrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationUsage
@@ -29,13 +32,16 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Booking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.TimeSlotAvailabilityRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AvailableLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.slot
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.LocationsService
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.util.Optional
 
 class TimeSlotAvailabilityServiceTest {
   private val locationsService: LocationsService = mock()
+  private val prisonAppointmentRepository: PrisonAppointmentRepository = mock()
   private val bookedLocationsService: BookedLocationsService = mock()
   private val prisonRegime: PrisonRegime = mock()
   private val locationAttributesService: LocationAttributesAvailableService = mock()
@@ -542,8 +548,68 @@ class TimeSlotAvailabilityServiceTest {
     }
   }
 
+  @Nested
+  inner class AmendmentRequests {
+    private val decoratedLocation = wandsworthLocation.toModel().copy(
+      description = "b - decorated probation room",
+      extraAttributes = RoomAttributes(
+        attributeId = 1,
+        locationStatus = LocationStatus.ACTIVE,
+        locationUsage = LocationUsage.PROBATION,
+        allowedParties = emptyList(),
+        prisonVideoUrl = null,
+        notes = null,
+      ),
+    )
+
+    @BeforeEach
+    fun before() {
+      whenever(prisonRegime.startOfDay(WANDSWORTH)) doReturn LocalTime.of(9, 0)
+      whenever(prisonRegime.endOfDay(WANDSWORTH)) doReturn LocalTime.of(10, 0)
+    }
+
+    @Test
+    fun `should include existing booking for amend booking request when time slot is the same`() {
+      val probationTeam = probationTeam()
+      val booking = probationBooking(probationTeam).withProbationPrisonAppointment(
+        date = tomorrow(),
+        startTime = LocalTime.of(9, 0),
+        endTime = LocalTime.of(9, 30),
+        prisonCode = WANDSWORTH,
+        location = wandsworthLocation,
+      )
+
+      whenever(prisonAppointmentRepository.findById(booking.videoBookingId)) doReturn Optional.of(booking.appointments().single())
+      whenever(locationsService.getVideoLinkLocationsAtPrison(WANDSWORTH, true)) doReturn listOf(decoratedLocation)
+      whenever(bookedLocationsService.findBooked(BookedLookup(WANDSWORTH, tomorrow(), listOf(decoratedLocation), booking.videoBookingId))) doReturn BookedLocations(emptyList())
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, probationTeam.code, tomorrow(), LocalTime.of(9, 0), LocalTime.of(9, 30)))) doReturn AvailabilityStatus.NONE
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, probationTeam.code, tomorrow(), LocalTime.of(9, 15), LocalTime.of(9, 45)))) doReturn AvailabilityStatus.NONE
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, probationTeam.code, tomorrow(), LocalTime.of(9, 30), LocalTime.of(10, 0)))) doReturn AvailabilityStatus.PROBATION_ANY
+      whenever(locationAttributesService.isLocationAvailableFor(LocationAvailableRequest.probation(1, probationTeam.code, tomorrow(), LocalTime.of(9, 45), LocalTime.of(10, 15)))) doReturn AvailabilityStatus.NONE
+
+      val response = service { tomorrow().atStartOfDay() }.findAvailable(
+        TimeSlotAvailabilityRequest(
+          prisonCode = WANDSWORTH,
+          bookingType = BookingType.PROBATION,
+          probationTeamCode = BLACKPOOL_MC_PPOC,
+          date = tomorrow(),
+          bookingDuration = 30,
+          timeSlots = listOf(TimeSlot.AM),
+          vlbIdToExclude = booking.videoBookingId,
+        ),
+      )
+
+      response.locations containsExactly listOf(
+        // Existing booking is still available
+        availableLocation(decoratedLocation, time(9, 0), time(9, 30), LocationUsage.PROBATION),
+        availableLocation(decoratedLocation, time(9, 30), time(10, 0), LocationUsage.PROBATION),
+      )
+    }
+  }
+
   private fun service(timeSource: TimeSource = TimeSource { LocalDateTime.now() }) = TimeSlotAvailabilityService(
     locationsService,
+    prisonAppointmentRepository,
     bookedLocationsService,
     prisonRegime,
     timeSource,


### PR DESCRIPTION
This change should resolve an issue whereby existing probation bookings during availability checking were being excluded.

It is similar in some ways to the date time checking service however we only have a date and slot to work with from the amend request.  To work with this we check the slot is the same and then the existing booking is also the same, if so we include it.