### PR TITLE
BAVL-1345 ignore overlapping appointment check if probation date, time and location has not changed on amend journey.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendProbationBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendProbationBookingService.kt
@@ -57,8 +57,7 @@ class AmendProbationBookingService(
       notesForPrisoners = request.notesForPrisoners,
       amendedBy = amendedBy,
     )
-      .also { thisBooking -> thisBooking.removeAllAppointments() }
-      .also { thisBooking -> appointmentsService.createAppointmentForProbation(thisBooking, request.prisoner(), amendedBy) }
+      .also { thisBooking -> appointmentsService.amendAppointmentForProbation(thisBooking, request.prisoner(), amendedBy) }
       .also { thisBooking -> videoBookingRepository.saveAndFlush(thisBooking) }
       .also { thisBooking -> request.saveAdditionalDetailsFor(thisBooking) }
       .also { thisBooking -> bookingHistoryService.createBookingHistory(HistoryType.AMEND, thisBooking) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AppointmentsService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsid
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.common.isTimesOverlap
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Prison
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.PrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Appointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
@@ -82,7 +83,19 @@ class AppointmentsService(
   private fun Appointment.isBefore(other: Appointment): Boolean = this.date!! <= other.date && this.endTime!! <= other.startTime
 
   fun createAppointmentForProbation(videoBooking: VideoBooking, prisoner: PrisonerDetails, user: User) {
-    checkProbationAppointments(prisoner.appointments, prisoner.prisonCode!!, user)
+    createProbationAppointment(videoBooking, prisoner, user)
+  }
+
+  fun amendAppointmentForProbation(videoBooking: VideoBooking, prisoner: PrisonerDetails, user: User) {
+    val originalAppointment = videoBooking.probationMeeting()
+
+    videoBooking.removeAllAppointments()
+
+    createProbationAppointment(videoBooking, prisoner, user, originalAppointment)
+  }
+
+  private fun createProbationAppointment(videoBooking: VideoBooking, prisoner: PrisonerDetails, user: User, originalAppointment: PrisonAppointment? = null) {
+    checkProbationAppointments(prisoner.appointments.single(), prisoner.prisonCode!!, user, originalAppointment)
 
     // We don't need to do a check for non-prison users as this is covered by the overlapping appointment check.
     if (user is PrisonUser) {
@@ -112,8 +125,8 @@ class AppointmentsService(
     if (user !is PrisonUser) require(enabled) { "Prison with code $code is not enabled for self service" }
   }
 
-  private fun checkProbationAppointments(appointments: List<Appointment>, prisonCode: String, user: User) {
-    with(appointments.single()) {
+  private fun checkProbationAppointments(appointment: Appointment, prisonCode: String, user: User, originalAppointment: PrisonAppointment? = null) {
+    with(appointment) {
       require(type!!.isProbation) {
         "Appointment type $type is not valid for probation appointments"
       }
@@ -122,9 +135,21 @@ class AppointmentsService(
 
       // Prison users can have overlapping appointments
       if (user !is PrisonUser) {
-        checkExistingProbationAppointmentDateAndTimesDoNotOverlap(prisonCode, location)
+        // We only carry out this check if the original appointment is null, or it has changed
+        if (originalAppointment == null || appointmentHasChanged(originalAppointment, this)) {
+          checkExistingProbationAppointmentDateAndTimesDoNotOverlap(prisonCode, location)
+        }
       }
     }
+  }
+
+  private fun appointmentHasChanged(originalAppointment: PrisonAppointment, updatedAppointment: Appointment) = run {
+    (
+      originalAppointment.appointmentDate == updatedAppointment.date &&
+        originalAppointment.startTime == updatedAppointment.startTime &&
+        originalAppointment.endTime == updatedAppointment.endTime &&
+        originalAppointment.prisonLocationId == locationsInsidePrisonClient.getLocationByKey(updatedAppointment.locationKey!!)?.id
+      ).not()
   }
 
   private fun PrisonerDetails.checkForDuplicateAppointment(appointmentType: AppointmentType) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/TimeSlotAvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/TimeSlotAvailabilityService.kt
@@ -110,20 +110,13 @@ class TimeSlotAvailabilityService(
     val existingStartTime = existingAppointment.startTime
     val existingEndTime = existingAppointment.endTime
 
-    log.info("isTheSame:start")
-    log.info("location =  $existingLocationId -> ${location.dpsLocationId}")
-    log.info("date =      ${request.date} -> $existingAppointmentDate")
-    log.info("timeSlot =  ${request.timeSlots} -> ${slot(existingStartTime)}")
-    log.info("startTime = $start -> $existingStartTime")
-    log.info("endTime =   $end -> $existingEndTime")
-
     (
       existingLocationId == location.dpsLocationId &&
         request.date == existingAppointmentDate &&
         request.timeSlots?.contains(slot(existingStartTime)) == true &&
         start == existingStartTime &&
         end == existingEndTime
-      ).also { log.info("isTheSame:$it:end") }
+      )
   }
 
   private fun getStartAndEndOfDay(request: TimeSlotAvailabilityRequest): Pair<LocalTime, LocalTime> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationBookingIntegrationTest.kt
@@ -21,8 +21,10 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BIRMINGHAM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.BLACKPOOL_MC_PPOC
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_BIRMINGHAM
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PRISON_USER_WANDSWORTH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.TEAM_NOT_LISTED
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.WANDSWORTH
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.amendProbationBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.birminghamLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasAmendedBy
@@ -47,6 +49,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasStartTime
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AdditionalBookingDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AppointmentType
@@ -540,6 +543,60 @@ class ProbationBookingIntegrationTest : SqsIntegrationTestBase() {
       .also { it.contactName isEqualTo "tnl probation contact" }
       .also { it.contactEmail isEqualTo "tnl_probation_contact@email.com" }
       .also { it.contactNumber isEqualTo null }
+  }
+
+  @Test
+  fun `should amend existing probation booking notes as probation user`() {
+    prisonSearchApi().stubGetPrisoner("123456", WANDSWORTH)
+
+    val probationBookingRequest = probationBookingRequest(
+      probationTeamCode = BLACKPOOL_MC_PPOC,
+      probationMeetingType = ProbationMeetingType.PSR,
+      prisonCode = WANDSWORTH,
+      prisonerNumber = "123456",
+      startTime = LocalTime.of(9, 0),
+      endTime = LocalTime.of(9, 30),
+      appointmentType = AppointmentType.VLB_PROBATION,
+      location = wandsworthLocation,
+      notesForStaff = "integration test probation staff notes created",
+    )
+
+    val videoBookingId = webTestClient.createBooking(probationBookingRequest, PROBATION_USER)
+
+    val prisonProbationBookingRequest = probationBookingRequest(
+      probationTeamCode = BLACKPOOL_MC_PPOC,
+      probationMeetingType = ProbationMeetingType.PSR,
+      prisonCode = WANDSWORTH,
+      prisonerNumber = "123456",
+      startTime = LocalTime.of(9, 15),
+      endTime = LocalTime.of(9, 45),
+      appointmentType = AppointmentType.VLB_PROBATION,
+      location = wandsworthLocation,
+    )
+
+    webTestClient.createBooking(prisonProbationBookingRequest, PRISON_USER_WANDSWORTH)
+
+    webTestClient.amendBooking(
+      videoBookingId,
+      amendProbationBookingRequest(
+        prisonCode = WANDSWORTH,
+        prisonerNumber = "123456",
+        probationMeetingType = ProbationMeetingType.PSR,
+        location = wandsworthLocation,
+        appointmentDate = tomorrow(),
+        startTime = probationBookingRequest.prisoners.single().appointments.single().startTime!!,
+        endTime = probationBookingRequest.prisoners.single().appointments.single().endTime!!,
+        notesForStaff = "integration test probation staff notes amended",
+        additionalBookingDetails = null,
+      ),
+      PROBATION_USER,
+    )
+
+    val amendedBooking = videoBookingRepository.findById(videoBookingId).orElseThrow()
+    amendedBooking.hasAmendedBy(PROBATION_USER)
+
+    val amendedAppointment = prisonAppointmentRepository.findByVideoBooking(amendedBooking).single()
+    amendedAppointment.hasNotesForStaff("integration test probation staff notes amended")
   }
 
   private fun appointmentSearchResult(date: LocalDate, startTime: LocalTime, endTime: LocalTime, prisonCode: String, prisonerNumber: String, locationId: Long, appointmentType: SupportedAppointmentTypes.Type) = run {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendProbationBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendProbationBookingServiceTest.kt
@@ -143,8 +143,8 @@ class AmendProbationBookingServiceTest {
     inOrder(
       videoBookingRepository,
       prisonerSearchClient,
-      locationValidator,
       appointmentsService,
+      locationValidator,
       videoBookingRepository,
       additionalBookingDetailRepository,
       additionalBookingDetailRepository,
@@ -152,6 +152,7 @@ class AmendProbationBookingServiceTest {
     ) {
       verify(videoBookingRepository).findById(2)
       verify(prisonerSearchClient).getPrisoner(prisonerNumber)
+      verify(appointmentsService).amendAppointmentForProbation(probationBooking, probationBookingRequest.prisoners.single(), PROBATION_USER)
       verify(locationValidator).validatePrisonLocation(BIRMINGHAM, birminghamLocation.key)
       verify(videoBookingRepository).saveAndFlush(probationBooking)
       verify(additionalBookingDetailRepository).findByVideoBooking(probationBooking)


### PR DESCRIPTION
This change fixes an issue whereby you were not able to update a probation booking when the date, time and location had not changed but something else has e.g. notes.