### PR TITLE
BAVL-1384 new dev only migration script for new probation meeting type and a new job to merge exising meetings to the new type where applicable.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,7 +99,6 @@ val configValues = mapOf(
   "dateLibrary" to "java8-localdatetime",
   "serializationLibrary" to "jackson",
   "enumPropertyNaming" to "original",
-  "useSpringBoot3" to "true",
 )
 
 val buildDirectory: Directory = layout.buildDirectory.get()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
@@ -161,7 +161,7 @@ enum class ProbationMeetingType(val description: String) {
   ROTL("ROTL (release on temporary licence)"),
   RR("Recall report (PRARR - parts B or C)"),
   RTSCR("Response to supervision (court report)"),
-  RECALL("Recall (PRARR part B or C and FTR56)"),
+  RECALL("Recall (PRARR part B, part C or FTR56)"),
   UNKNOWN("Unknown"),
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
@@ -161,6 +161,7 @@ enum class ProbationMeetingType(val description: String) {
   ROTL("ROTL (release on temporary licence)"),
   RR("Recall report (PRARR - parts B or C)"),
   RTSCR("Response to supervision (court report)"),
+  RECALL("Recall (PRARR part B or C and FTR56)"),
   UNKNOWN("Unknown"),
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/VideoBookingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/VideoBookingRepository.kt
@@ -25,7 +25,9 @@ interface VideoBookingRepository : JpaRepository<VideoBooking, Long> {
       SELECT v
       FROM VideoBooking v
       JOIN VideoAppointment va on va.videoBookingId = v.videoBookingId
-      WHERE va.appointmentDate >= :date AND v.probationMeetingType IN :probationMeetingTypes
+      WHERE va.appointmentDate >= :date
+        AND v.probationMeetingType IN :probationMeetingTypes
+        AND v.bookingType = 'PROBATION'
     """,
   )
   fun findByProbationMeetingTypesOnOrAfterDate(probationMeetingTypes: List<String>, date: LocalDate): List<VideoBooking>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/VideoBookingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/repository/VideoBookingRepository.kt
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import java.time.LocalDate
 
 @Repository
 interface VideoBookingRepository : JpaRepository<VideoBooking, Long> {
@@ -18,4 +19,14 @@ interface VideoBookingRepository : JpaRepository<VideoBooking, Long> {
     """,
   )
   fun countDistinctByPrisonerNumber(prisonerNumber: String): Long
+
+  @Query(
+    value = """
+      SELECT v
+      FROM VideoBooking v
+      JOIN VideoAppointment va on va.videoBookingId = v.videoBookingId
+      WHERE va.appointmentDate >= :date AND v.probationMeetingType IN :probationMeetingTypes
+    """,
+  )
+  fun findByProbationMeetingTypesOnOrAfterDate(probationMeetingTypes: List<String>, date: LocalDate): List<VideoBooking>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/JobTriggerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/JobTriggerService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.jobs
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.jobs.JobType.COURT_HEARING_LINK_REMINDER
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.jobs.JobType.MERGE_PROBATION_RECALL_MEETING_TYPES
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.jobs.JobType.NEW_PRISON_VIDEO_ROOM
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.jobs.JobType.PROBATION_OFFICER_DETAILS_REMINDER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.jobs.JobType.REACTIVATE_BLOCKED_LOCATIONS
@@ -15,11 +16,13 @@ class JobTriggerService(
   private val probationOfficerDetailsReminderJob: ProbationOfficerDetailsReminderJob,
   private val newPrisonVideoRoomsJob: NewPrisonVideoRoomsJob,
   private val reactivateBlockedLocationsJob: ReactivateBlockedLocationsJob,
+  private val mergeProbationRecallMeetingTypesJob: MergeProbationRecallMeetingTypesJob,
 ) {
   fun run(job: JobType) = when (job) {
     COURT_HEARING_LINK_REMINDER -> jobRunner.runJob(courtHearingLinkReminderJob)
     PROBATION_OFFICER_DETAILS_REMINDER -> jobRunner.runJob(probationOfficerDetailsReminderJob)
     NEW_PRISON_VIDEO_ROOM -> jobRunner.runJob(newPrisonVideoRoomsJob)
     REACTIVATE_BLOCKED_LOCATIONS -> jobRunner.runJob(reactivateBlockedLocationsJob)
+    MERGE_PROBATION_RECALL_MEETING_TYPES -> jobRunner.runJob(mergeProbationRecallMeetingTypesJob)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/Jobs.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/Jobs.kt
@@ -5,6 +5,7 @@ enum class JobType(val resultMessage: String) {
   PROBATION_OFFICER_DETAILS_REMINDER("Probation officer details reminder job triggered"),
   NEW_PRISON_VIDEO_ROOM("New prison video room job triggered"),
   REACTIVATE_BLOCKED_LOCATIONS("Reactivate blocked rooms job triggered"),
+  MERGE_PROBATION_RECALL_MEETING_TYPES("Merge probation recall meeting types job triggered"),
 }
 
 abstract class JobDefinition(val jobType: JobType, private val block: () -> Unit) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/MergeProbationRecallMeetingTypesJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/MergeProbationRecallMeetingTypesJob.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.jobs
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.TimeSource
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingHistoryService
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.UserService
+
+/**
+ * Technically, this job is short-lived. It should only really need to be run once (possibly more due to timings).
+ *
+ * Its purpose is to merge any future probation meeting types FTR56 and RR to one single meeting type RECALL.
+ *
+ * Audit records of any merged meeting types will be kept. Only future meetings are merged, historic ones are ignored.
+ */
+@Component
+class MergeProbationRecallMeetingTypesJob(
+  private val videoBookingRepository: VideoBookingRepository,
+  private val bookingHistoryService: BookingHistoryService,
+  private val timeSource: TimeSource,
+) : JobDefinition(
+  JobType.MERGE_PROBATION_RECALL_MEETING_TYPES,
+  block = {
+    val now = timeSource.now()
+    var anyMeetingTypesMerged = false
+    val legacyRecallMeetingTypes = listOf(ProbationMeetingType.FTR56.name, ProbationMeetingType.RR.name)
+
+    val bookings = videoBookingRepository
+      .findByProbationMeetingTypesOnOrAfterDate(legacyRecallMeetingTypes, now.toLocalDate())
+      .filter { probationMeeting -> probationMeeting.overallStartDateTime()?.isAfter(now) == true }
+      .onEach { probationMeeting ->
+        probationMeeting.apply {
+          probationMeetingType = ProbationMeetingType.RECALL.name
+          amendedBy = UserService.getServiceAsUser().username
+          amendedTime = now
+        }
+
+        anyMeetingTypesMerged = true
+      }
+
+    if (anyMeetingTypesMerged) {
+      videoBookingRepository.saveAllAndFlush(bookings)
+      bookings.forEach { booking -> bookingHistoryService.createBookingHistory(HistoryType.AMEND, booking) }
+
+      log.info("Migrated recall meeting type for booking IDs ${bookings.map { it.videoBookingId }}")
+    } else {
+      log.info("No bookings were migrated for recall meeting type.")
+    }
+  },
+) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+}

--- a/src/main/resources/migrations/dev/V2026.06.19__probation_meeting_type_reference_data.sql
+++ b/src/main/resources/migrations/dev/V2026.06.19__probation_meeting_type_reference_data.sql
@@ -1,0 +1,20 @@
+delete from reference_code where group_code = 'PROBATION_MEETING_TYPE';
+
+insert into reference_code (group_code, code, description,created_by, created_time, enabled, display_sequence)
+values
+  ('PROBATION_MEETING_TYPE', 'PSR', 'Pre-sentence report (PSR)', 'MATT', current_timestamp, true, 1),
+  ('PROBATION_MEETING_TYPE', 'RECALL', 'Recall (PRARR part B or C and FTR56)', 'MATT', current_timestamp, true, 2),
+  ('PROBATION_MEETING_TYPE', 'FTR56', '56-day fixed term recall (FTR56)', 'MATT', current_timestamp, false, 99),
+  ('PROBATION_MEETING_TYPE', 'RR', 'Recall report (PRARR - parts B or C)', 'MATT', current_timestamp, false, 99),
+  ('PROBATION_MEETING_TYPE', 'PR', 'Parole Report (PAROM)', 'MATT', current_timestamp, true, 4),
+  ('PROBATION_MEETING_TYPE', 'HDC', 'HDC (home detention curfew)', 'MATT', current_timestamp, true, 5),
+  ('PROBATION_MEETING_TYPE', 'OASYS', 'OASys', 'MATT', current_timestamp, true, 6),
+  ('PROBATION_MEETING_TYPE', 'MALRAP', 'Multi-agency lifer risk assessment panel (MALRAP)', 'MATT', current_timestamp, true, 7),
+  ('PROBATION_MEETING_TYPE', 'PRP', 'Pre-release planning', 'MATT', current_timestamp, true, 8),
+  ('PROBATION_MEETING_TYPE', 'IOM', 'Integrated offender management (IOM)', 'MATT', current_timestamp, true, 9),
+  ('PROBATION_MEETING_TYPE', 'RTSCR', 'Response to supervision (court report)', 'MATT', current_timestamp, true, 10),
+  ('PROBATION_MEETING_TYPE', 'BR', 'Bail report', 'MATT', current_timestamp, true, 11),
+  ('PROBATION_MEETING_TYPE', 'RCAT', 'R-CAT (recategorisation) assessments', 'MATT', current_timestamp, true, 12),
+  ('PROBATION_MEETING_TYPE', 'ROTL', 'ROTL (release on temporary licence)', 'MATT', current_timestamp, true, 13),
+  ('PROBATION_MEETING_TYPE', 'OTHER', 'Other', 'MATT', current_timestamp, true, 14),
+  ('PROBATION_MEETING_TYPE', 'UNKNOWN', 'Unknown', 'MATT', current_timestamp, true, 15);

--- a/src/main/resources/migrations/dev/V2026.06.19__probation_meeting_type_reference_data.sql
+++ b/src/main/resources/migrations/dev/V2026.06.19__probation_meeting_type_reference_data.sql
@@ -1,20 +1,7 @@
-delete from reference_code where group_code = 'PROBATION_MEETING_TYPE';
+update reference_code
+   set enabled = false, display_sequence = 99
+ where group_code = 'PROBATION_MEETING_TYPE' and code in ('FTR56', 'RR');
 
 insert into reference_code (group_code, code, description,created_by, created_time, enabled, display_sequence)
-values
-  ('PROBATION_MEETING_TYPE', 'PSR', 'Pre-sentence report (PSR)', 'MATT', current_timestamp, true, 1),
-  ('PROBATION_MEETING_TYPE', 'RECALL', 'Recall (PRARR part B or C and FTR56)', 'MATT', current_timestamp, true, 2),
-  ('PROBATION_MEETING_TYPE', 'FTR56', '56-day fixed term recall (FTR56)', 'MATT', current_timestamp, false, 99),
-  ('PROBATION_MEETING_TYPE', 'RR', 'Recall report (PRARR - parts B or C)', 'MATT', current_timestamp, false, 99),
-  ('PROBATION_MEETING_TYPE', 'PR', 'Parole Report (PAROM)', 'MATT', current_timestamp, true, 4),
-  ('PROBATION_MEETING_TYPE', 'HDC', 'HDC (home detention curfew)', 'MATT', current_timestamp, true, 5),
-  ('PROBATION_MEETING_TYPE', 'OASYS', 'OASys', 'MATT', current_timestamp, true, 6),
-  ('PROBATION_MEETING_TYPE', 'MALRAP', 'Multi-agency lifer risk assessment panel (MALRAP)', 'MATT', current_timestamp, true, 7),
-  ('PROBATION_MEETING_TYPE', 'PRP', 'Pre-release planning', 'MATT', current_timestamp, true, 8),
-  ('PROBATION_MEETING_TYPE', 'IOM', 'Integrated offender management (IOM)', 'MATT', current_timestamp, true, 9),
-  ('PROBATION_MEETING_TYPE', 'RTSCR', 'Response to supervision (court report)', 'MATT', current_timestamp, true, 10),
-  ('PROBATION_MEETING_TYPE', 'BR', 'Bail report', 'MATT', current_timestamp, true, 11),
-  ('PROBATION_MEETING_TYPE', 'RCAT', 'R-CAT (recategorisation) assessments', 'MATT', current_timestamp, true, 12),
-  ('PROBATION_MEETING_TYPE', 'ROTL', 'ROTL (release on temporary licence)', 'MATT', current_timestamp, true, 13),
-  ('PROBATION_MEETING_TYPE', 'OTHER', 'Other', 'MATT', current_timestamp, true, 14),
-  ('PROBATION_MEETING_TYPE', 'UNKNOWN', 'Unknown', 'MATT', current_timestamp, true, 15);
+values ('PROBATION_MEETING_TYPE', 'RECALL', 'Recall (PRARR part B, part C or FTR56)', 'MATT', current_timestamp, true, 2)
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/JobTriggerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/JobTriggerIntegrationTest.kt
@@ -13,6 +13,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.nomismapping.NomisMappingClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.Email
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.TestEmailConfiguration
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.LocationStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.Notification
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
@@ -34,6 +35,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.risleyLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.today
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.BookingHistoryRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.LocationAttributeRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.NotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.PrisonRepository
@@ -340,6 +342,51 @@ class JobTriggerIntegrationTest : IntegrationTestBase() {
       locationAttributeRepository.findByDpsLocationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))!!.locationStatus isEqualTo LocationStatus.TEMPORARILY_BLOCKED
       locationAttributeRepository.findByDpsLocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))!!.locationStatus isEqualTo LocationStatus.ACTIVE
     }
+  }
+
+  @Nested
+  @DisplayName("Merge probation recall meeting type")
+  inner class MergeProbationRecallMeetingType {
+
+    @Autowired
+    private lateinit var videoBookingRepository: VideoBookingRepository
+
+    @Autowired
+    private lateinit var bookingHistoryRepository: BookingHistoryRepository
+
+    @Sql("classpath:integration-test-data/seed-historic-and-future-probation-recall-meetings.sql")
+    @Test
+    fun `should merge future RR and FTR56 probation meetings to RECALL but not touch historic meetings`() {
+      // Historic bookings before merge
+      probationMeeting(-3000).probationMeetingType isEqualTo "RR"
+      bookingHistory(-3000).single { it.historyType == HistoryType.CREATE }.probationMeetingType isEqualTo "RR"
+      probationMeeting(-3100).probationMeetingType isEqualTo "FTR56"
+      bookingHistory(-3100).single { it.historyType == HistoryType.CREATE }.probationMeetingType isEqualTo "FTR56"
+
+      // Future bookings before merge
+      probationMeeting(-4000).probationMeetingType isEqualTo "RR"
+      bookingHistory(-4000).single { it.historyType == HistoryType.CREATE }.probationMeetingType isEqualTo "RR"
+      probationMeeting(-4100).probationMeetingType isEqualTo "FTR56"
+      bookingHistory(-4100).single { it.historyType == HistoryType.CREATE }.probationMeetingType isEqualTo "FTR56"
+
+      webTestClient.triggerJob(JobType.MERGE_PROBATION_RECALL_MEETING_TYPES)
+
+      // Historic bookings after merge (should be untouched)
+      probationMeeting(-3000).probationMeetingType isEqualTo "RR"
+      bookingHistory(-3000).single().probationMeetingType isEqualTo "RR"
+      probationMeeting(-3100).probationMeetingType isEqualTo "FTR56"
+      bookingHistory(-3100).single().probationMeetingType isEqualTo "FTR56"
+
+      // Future bookings after merge (should be merge)
+      probationMeeting(-4000).probationMeetingType isEqualTo "RECALL"
+      bookingHistory(-4000).single { it.historyType == HistoryType.AMEND }.probationMeetingType isEqualTo "RECALL"
+      probationMeeting(-4100).probationMeetingType isEqualTo "RECALL"
+      bookingHistory(-4100).single { it.historyType == HistoryType.AMEND }.probationMeetingType isEqualTo "RECALL"
+    }
+
+    private fun probationMeeting(id: Long) = videoBookingRepository.findById(id).orElseThrow()
+
+    private fun bookingHistory(id: Long) = bookingHistoryRepository.findAllByVideoBookingIdOrderByCreatedTime(id)
   }
 
   private fun <T : Email> Collection<Notification>.isPresent(email: String, template: KClass<T>, booking: VideoBooking? = null) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ReferenceCodesResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ReferenceCodesResourceIntegrationTest.kt
@@ -39,14 +39,13 @@ class ReferenceCodesResourceIntegrationTest : IntegrationTestBase() {
   @Test
   fun `should return a list of ordered probation meeting type reference codes`() {
     val groupCode = "PROBATION_MEETING_TYPE"
-    referenceCodeRepository.findAllByGroupCodeEquals(groupCode) hasSize 15
+    referenceCodeRepository.findAllByGroupCodeEquals(groupCode) hasSize 16
 
     val enabledOnlyProbationMeetingTypes = webTestClient.getReferenceCodes(groupCode)
 
     assertThat(enabledOnlyProbationMeetingTypes).extracting("code").containsExactly(
       "PSR",
-      "FTR56",
-      "RR",
+      "RECALL",
       "PR",
       "HDC",
       "OASYS",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/JobTriggerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/JobTriggerServiceTest.kt
@@ -15,7 +15,15 @@ class JobTriggerServiceTest {
   private val probationOfficerDetailsReminderJob: ProbationOfficerDetailsReminderJob = mock()
   private val newPrisonVideoRoomsJob: NewPrisonVideoRoomsJob = mock()
   private val reactivateBlockedLocationsJob: ReactivateBlockedLocationsJob = mock()
-  private val jobTriggerService: JobTriggerService = JobTriggerService(jobRunner, courtHearingLinkReminderJob, probationOfficerDetailsReminderJob, newPrisonVideoRoomsJob, reactivateBlockedLocationsJob)
+  private val mergeProbationRecallMeetingTypesJob: MergeProbationRecallMeetingTypesJob = mock()
+  private val jobTriggerService: JobTriggerService = JobTriggerService(
+    jobRunner,
+    courtHearingLinkReminderJob,
+    probationOfficerDetailsReminderJob,
+    newPrisonVideoRoomsJob,
+    reactivateBlockedLocationsJob,
+    mergeProbationRecallMeetingTypesJob,
+  )
 
   @Test
   fun `should run court hearing link reminder job when job type is COURT_HEARING_LINK_REMINDER`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/MergeProbationRecallMeetingTypesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/MergeProbationRecallMeetingTypesJobTest.kt
@@ -1,0 +1,106 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.jobs
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.TimeSource
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsExactlyInAnyOrder
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withProbationPrisonAppointment
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingHistoryService
+import java.time.LocalDateTime
+
+class MergeProbationRecallMeetingTypesJobTest {
+  private val videoBookingRepository: VideoBookingRepository = mock()
+  private val bookingHistoryService: BookingHistoryService = mock()
+  private val now = LocalDateTime.now()
+  private val timeSource = TimeSource { now }
+  private val job = MergeProbationRecallMeetingTypesJob(videoBookingRepository, bookingHistoryService, timeSource)
+  private val captor = argumentCaptor<List<VideoBooking>>()
+
+  @Test
+  fun `should merge FTR56 meeting type to RECALL`() {
+    val booking = probationBooking(meetingType = ProbationMeetingType.FTR56).withProbationPrisonAppointment()
+
+    whenever { videoBookingRepository.findByProbationMeetingTypesOnOrAfterDate(listOf("FTR56", "RR"), now.toLocalDate()) } doReturn listOf(booking)
+
+    job.runJob()
+
+    booking.probationMeetingType isEqualTo "RECALL"
+    booking.amendedBy isEqualTo "BOOK_A_VIDEO_LINK_SERVICE"
+    booking.amendedTime isEqualTo now
+
+    inOrder(videoBookingRepository, bookingHistoryService) {
+      verify(videoBookingRepository).saveAllAndFlush(captor.capture())
+      captor.firstValue containsExactlyInAnyOrder listOf(booking)
+      verify(bookingHistoryService).createBookingHistory(HistoryType.AMEND, booking)
+    }
+  }
+
+  @Test
+  fun `should merge RR meeting type to RECALL`() {
+    val booking = probationBooking(meetingType = ProbationMeetingType.RR).withProbationPrisonAppointment()
+
+    whenever { videoBookingRepository.findByProbationMeetingTypesOnOrAfterDate(listOf("FTR56", "RR"), now.toLocalDate()) } doReturn listOf(booking)
+
+    job.runJob()
+
+    booking.probationMeetingType isEqualTo "RECALL"
+    booking.amendedBy isEqualTo "BOOK_A_VIDEO_LINK_SERVICE"
+    booking.amendedTime isEqualTo now
+
+    inOrder(videoBookingRepository, bookingHistoryService) {
+      verify(videoBookingRepository).saveAllAndFlush(captor.capture())
+      captor.firstValue containsExactlyInAnyOrder listOf(booking)
+      verify(bookingHistoryService).createBookingHistory(HistoryType.AMEND, booking)
+    }
+  }
+
+  @Test
+  fun `should merge multiple bookings`() {
+    val ftr56Booking = probationBooking(meetingType = ProbationMeetingType.FTR56).withProbationPrisonAppointment()
+    val rrBooking = probationBooking(meetingType = ProbationMeetingType.RR).withProbationPrisonAppointment()
+
+    whenever { videoBookingRepository.findByProbationMeetingTypesOnOrAfterDate(listOf("FTR56", "RR"), now.toLocalDate()) } doReturn listOf(ftr56Booking, rrBooking)
+
+    job.runJob()
+
+    ftr56Booking.probationMeetingType isEqualTo "RECALL"
+    ftr56Booking.amendedBy isEqualTo "BOOK_A_VIDEO_LINK_SERVICE"
+    ftr56Booking.amendedTime isEqualTo now
+
+    rrBooking.probationMeetingType isEqualTo "RECALL"
+    rrBooking.amendedBy isEqualTo "BOOK_A_VIDEO_LINK_SERVICE"
+    rrBooking.amendedTime isEqualTo now
+
+    inOrder(videoBookingRepository, bookingHistoryService) {
+      verify(videoBookingRepository).saveAllAndFlush(captor.capture())
+      captor.firstValue containsExactlyInAnyOrder listOf(ftr56Booking, rrBooking)
+      verify(bookingHistoryService, times(2)).createBookingHistory(eq(HistoryType.AMEND), any())
+    }
+  }
+
+  @Test
+  fun `should handle no bookings to merge`() {
+    whenever { videoBookingRepository.findByProbationMeetingTypesOnOrAfterDate(listOf("FTR56", "RR"), now.toLocalDate()) } doReturn emptyList()
+
+    job.runJob()
+
+    verify(videoBookingRepository, never()).saveAllAndFlush(any<List<VideoBooking>>())
+    verifyNoInteractions(bookingHistoryService)
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -45,7 +45,7 @@ hmpps:
   sar:
     tests:
       attachments-expected: false
-      expected-flyway-schema-version: 2026.05.12
+      expected-flyway-schema-version: 2026.06.19
       expected-jpa-entity-schema:
         path: /sar/entity-schema.json
       expected-api-response:

--- a/src/test/resources/integration-test-data/seed-historic-and-future-probation-recall-meetings.sql
+++ b/src/test/resources/integration-test-data/seed-historic-and-future-probation-recall-meetings.sql
@@ -1,0 +1,39 @@
+-- Historic RR meeting
+insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time)
+values (-3000, 'PROBATION', 'ACTIVE', 1, 'RR', 'comments about the meeting', 'probation_user', '2024-01-01T01:00:00');
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
+values (-3000, 1, 'ABCDEF', 'VLB_PROBATION', 'comments about the meeting', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, current_date - 2, '16:00', '17:00');
+insert into booking_history(booking_history_id, video_booking_id, history_type, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time)
+values (-3000, -3000, 'CREATE', 1, 'RR','comments about the meeting', 'probation_user', '2024-01-01T01:00:00');
+insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)
+values (-3000, 'PVI', 'ABCDEF', current_date - 2, 'VLB_PROBATION', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '16:00', '17:00');
+
+-- Historic FTR56 meeting
+insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time)
+values (-3100, 'PROBATION', 'ACTIVE', 1, 'FTR56', 'comments about the meeting', 'probation_user', '2024-01-01T01:00:00');
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
+values (-3100, 1, 'ABCDEF', 'VLB_PROBATION', 'comments about the meeting', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, current_date - 1, '16:00', '17:00');
+insert into booking_history(booking_history_id, video_booking_id, history_type, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time)
+values (-3100, -3100, 'CREATE', 1, 'FTR56','comments about the meeting', 'probation_user', '2024-01-01T01:00:00');
+insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)
+values (-3100, 'PVI', 'ABCDEF', current_date - 1, 'VLB_PROBATION', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '16:00', '17:00');
+
+-- Future RR meeting
+insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time)
+values (-4000, 'PROBATION', 'ACTIVE', 1, 'RR', 'comments about the meeting', 'probation_user', '2024-01-01T01:00:00');
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
+values (-4000, 1, 'ABCDEF', 'VLB_PROBATION', 'comments about the meeting', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '2099-01-25', '16:00', '17:00');
+insert into booking_history(booking_history_id, video_booking_id, history_type, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time)
+values (-4000, -4000, 'CREATE', 1, 'RR','comments about the meeting', 'probation_user', '2024-01-01T01:00:00');
+insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)
+values (-4000, 'PVI', 'ABCDEF', '2099-01-25', 'VLB_PROBATION', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '16:00', '17:00');
+
+-- Future FTR56 meeting
+insert into video_booking (video_booking_id, booking_type, status_code, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time, migrated_description)
+values (-4100, 'PROBATION', 'ACTIVE', 28, 'FTR56', 'comments about the meeting', 'probation_user', '2024-01-01T01:00:00', 'Free text probation team name');
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
+values (-4100, 1, 'DEFGHI', 'VLB_PROBATION', 'comments about the meeting', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '2099-01-25', '16:00', '17:00');
+insert into booking_history(booking_history_id, video_booking_id, history_type, probation_team_id, probation_meeting_type, notes_for_staff, created_by, created_time)
+values (-4100, -4100, 'CREATE', 28, 'FTR56','comments about the meeting', 'probation_user', '2024-01-01T01:00:00');
+insert into booking_history_appointment (booking_history_id, prison_code, prisoner_number, appointment_date, appointment_type, prison_location_id, start_time, end_time)
+values (-4100, 'PVI', 'ABCDEF', '2099-01-25', 'VLB_PROBATION', '926d8f38-7149-4fda-b51f-85abcbcb0d00'::uuid, '16:00', '17:00');


### PR DESCRIPTION
This PR introduces a new probation RECALL meeting type and disables two older ones.

There is also a new  job to help migrate any future meetings with the old disabled types to the new single meeting type. For any meetings migrated corresponding amend audit records will also be created.

We may also need to regenerate the UI types to pick up the new meeting type (I am hoping not).

**_Note: The migration script to disable the old and add the new type is for DEV only.  When we want this in production we will have to create a dedicated prod script as well._**