### PR TITLE
BAVL-1309 partial step towards using DPS location ID instead of location key. Should be a non breaking change so safe to release.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AvailabilityRequest.kt
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.NotBlank
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
+import java.util.UUID
 import kotlin.reflect.KClass
 
 @Schema(description = "The request object sent to the availability check endpoint")
@@ -76,14 +77,19 @@ data class AvailabilityRequest(
 
 @Schema(description = "The prison location key and start/end interval for an appointment slot")
 data class LocationAndInterval(
+  @Schema(
+    description = "The unique UUID for the location where the appointment takes place. The id field from the locations-inside-prison service.",
+    example = "a4fe3fef-34fd-4354fde-a12efe",
+  )
+  val dpsLocationId: UUID?,
 
-  @field:NotBlank(message = "The prison location key must be present")
+  @Deprecated(message = "Do not use, use dpsLocationId instead")
   @Schema(
     description = "The location of the appointment at the prison",
     example = "VCC-ROOM-1",
     requiredMode = RequiredMode.REQUIRED,
   )
-  val prisonLocKey: String,
+  val prisonLocKey: String?,
 
   @Schema(
     description = "The start and end time of a prison appointment to define the interval",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequest.kt
@@ -14,6 +14,7 @@ import jakarta.validation.constraints.Size
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.util.UUID
 
 @Schema(
   description =
@@ -197,7 +198,14 @@ data class Appointment(
   @Schema(description = "The appointment type", example = "VLB_COURT_MAIN")
   val type: AppointmentType,
 
-  @field:NotBlank(message = "The location key for the appointment is mandatory")
+  // TODO this is going to replace the location key
+  @Schema(
+    description = "The unique UUID for the location where the appointment takes place. The id field from the locations-inside-prison service.",
+    example = "a4fe3fef-34fd-4354fde-a12efe",
+  )
+  val dpsLocationId: UUID?,
+
+  @Deprecated(message = "Use dpsLocationId instead")
   @field:Size(max = 160, message = "The location key should not exceed {max} characters")
   @Schema(description = "The location key for the appointment", example = "PVI-A-1-001")
   val locationKey: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/AvailabilityResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/AvailabilityResponse.kt
@@ -48,13 +48,13 @@ data class BookingOption(
     // Converts the availability check request into a booking option
     fun from(request: AvailabilityRequest) = BookingOption(
       pre = request.preAppointment?.let {
-        LocationAndInterval(prisonLocKey = it.prisonLocKey, interval = it.interval)
+        LocationAndInterval(dpsLocationId = it.dpsLocationId, prisonLocKey = it.prisonLocKey, interval = it.interval)
       },
       main = request.mainAppointment.let {
-        LocationAndInterval(prisonLocKey = it.prisonLocKey, interval = it.interval)
+        LocationAndInterval(dpsLocationId = it.dpsLocationId, prisonLocKey = it.prisonLocKey, interval = it.interval)
       },
       post = request.postAppointment?.let {
-        LocationAndInterval(prisonLocKey = it.prisonLocKey, interval = it.interval)
+        LocationAndInterval(dpsLocationId = it.dpsLocationId, prisonLocKey = it.prisonLocKey, interval = it.interval)
       },
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/PrisonAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/response/PrisonAppointment.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.slot
 import java.time.LocalDate
 import java.time.LocalTime
+import java.util.UUID
 
 @Schema(description = "A representation of a prison appointment")
 data class PrisonAppointment(
@@ -23,8 +24,15 @@ data class PrisonAppointment(
   @Schema(description = "The appointment type", example = "VLB_COURT_MAIN")
   val appointmentType: String,
 
+  @Deprecated(message = "Use dpsLocationId instead")
   @Schema(description = "The location of the appointment at the prison", example = "VCC-ROOM-1")
   val prisonLocKey: String,
+
+  @Schema(
+    description = "The unique UUID for the location where the appointment takes place. The id field from the locations-inside-prison service.",
+    example = "a4fe3fef-34fd-4354fde-a12efe",
+  )
+  val dpsLocationId: UUID,
 
   @Schema(description = "The date of the appointment", example = "2024-04-05")
   val appointmentDate: LocalDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/AvailabilityFinderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/AvailabilityFinderService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.Availa
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingOption
 import java.time.LocalTime
 import java.util.TreeMap
+import java.util.UUID
 
 @Service
 class AvailabilityFinderService(
@@ -21,22 +22,39 @@ class AvailabilityFinderService(
 
   fun getOptions(request: AvailabilityRequest, appointments: List<AppointmentSlot>, locations: List<Location>): AvailabilityResponse {
     // Create a Map of <PrisonLocKey, Timeline> from the existing appointments - so we can check and find gaps
-    val timelinesByLocation = timelinesByLocationKey(appointments, locations)
+    val timelinesByLocationKey = timelinesByLocationKey(appointments, locations)
+    val timelinesByLocationId = timelinesByLocationId(appointments, locations)
 
     // Convert the requested times into a booking option object
     val preferredOption = BookingOption.from(request)
 
-    // If the preferred option (requested times) is available, return ok with no alternatives
-    if (optionIsBookable(preferredOption, timelinesByLocation)) {
-      return AvailabilityResponse(availabilityOk = true, alternatives = emptyList())
-    }
+    var alternatives: Sequence<BookingOption>
 
-    // Find upto the maximum number of alternative booking times for these rooms
-    val alternatives = availabilityOptionsGenerator
-      .getOptionsInPreferredOrder(preferredOption)
-      .filter { optionIsBookable(it, timelinesByLocation) }
-      .take(maxAlternatives)
-      .sortedBy { it.main.interval.start }
+    if (request.mainAppointment.dpsLocationId != null) {
+      // If the preferred option (requested times) is available, return ok with no alternatives
+      if (optionIsBookableById(preferredOption, timelinesByLocationId)) {
+        return AvailabilityResponse(availabilityOk = true, alternatives = emptyList())
+      }
+
+      // Find upto the maximum number of alternative booking times for these rooms
+      alternatives = availabilityOptionsGenerator
+        .getOptionsInPreferredOrder(preferredOption)
+        .filter { optionIsBookableById(it, timelinesByLocationId) }
+        .take(maxAlternatives)
+        .sortedBy { it.main.interval.start }
+    } else {
+      // If the preferred option (requested times) is available, return ok with no alternatives
+      if (optionIsBookableByKey(preferredOption, timelinesByLocationKey)) {
+        return AvailabilityResponse(availabilityOk = true, alternatives = emptyList())
+      }
+
+      // Find upto the maximum number of alternative booking times for these rooms
+      alternatives = availabilityOptionsGenerator
+        .getOptionsInPreferredOrder(preferredOption)
+        .filter { optionIsBookableByKey(it, timelinesByLocationKey) }
+        .take(maxAlternatives)
+        .sortedBy { it.main.interval.start }
+    }
 
     // Return the alternatives
     return AvailabilityResponse(availabilityOk = false, alternatives = alternatives.toList())
@@ -44,12 +62,23 @@ class AvailabilityFinderService(
 
   companion object {
 
-    fun optionIsBookable(option: BookingOption, timelinesByLocationId: Map<String, Timeline>) = option
+    @Deprecated(message = "Use timelinesByLocationId instead", replaceWith = ReplaceWith("timelinesByLocationId(slots, locations)"))
+    fun optionIsBookableByKey(option: BookingOption, timelinesByLocationId: Map<String, Timeline>) = option
       .toLocationsAndIntervals()
       .all { timelinesByLocationId[it.prisonLocKey]?.isFreeForInterval(it.interval) ?: true }
 
+    fun optionIsBookableById(option: BookingOption, timelinesByLocationId: Map<UUID, Timeline>) = option
+      .toLocationsAndIntervals()
+      .all { timelinesByLocationId[it.dpsLocationId]?.isFreeForInterval(it.interval) ?: true }
+
+    @Deprecated(message = "Use timelinesByLocationId instead", replaceWith = ReplaceWith("timelinesByLocationId(slots, locations)"))
     fun timelinesByLocationKey(slots: List<AppointmentSlot>, locations: List<Location>): Map<String, Timeline> = slots
       .groupBy { a -> locations.single { it.id == a.prisonLocationId }.key }
+      .mapValues { (_, appointments) -> appointments.flatMap(Companion::toEvents) }
+      .mapValues { Timeline(it.value) }
+
+    fun timelinesByLocationId(slots: List<AppointmentSlot>, locations: List<Location>): Map<UUID, Timeline> = slots
+      .groupBy { a -> locations.single { it.id == a.prisonLocationId }.id }
       .mapValues { (_, appointments) -> appointments.flatMap(Companion::toEvents) }
       .mapValues { Timeline(it.value) }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/AvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/AvailabilityService.kt
@@ -53,7 +53,7 @@ class AvailabilityService(
   ).availabilityOk
 
   private fun CreateVideoBookingRequest.appointment(type: AppointmentType) = prisoners.single().appointments.singleOrNull { it.type == type }
-    ?.let { LocationAndInterval(it.locationKey!!, Interval(it.startTime, it.endTime)) }
+    ?.let { LocationAndInterval(it.dpsLocationId, it.locationKey, Interval(it.startTime, it.endTime)) }
 
   fun isAvailable(videoBookingId: Long, request: AmendVideoBookingRequest): Boolean {
     val existingBooking = videoBookingRepository.findById(videoBookingId).orElseThrow()
@@ -73,7 +73,7 @@ class AvailabilityService(
     ).availabilityOk
   }
 
-  private fun AmendVideoBookingRequest.appointment(type: AppointmentType) = prisoners.single().appointments.singleOrNull { it.type == type }?.let { LocationAndInterval(it.locationKey!!, Interval(it.startTime, it.endTime)) }
+  private fun AmendVideoBookingRequest.appointment(type: AppointmentType) = prisoners.single().appointments.singleOrNull { it.type == type }?.let { LocationAndInterval(it.dpsLocationId, it.locationKey, Interval(it.startTime, it.endTime)) }
 
   /**
    * Assumptions:
@@ -89,16 +89,27 @@ class AvailabilityService(
   fun checkAvailability(request: AvailabilityRequest): AvailabilityResponse {
     log.info("AVAILABILITY CHECK: looking at BVLS and other non-VLB appointment types")
 
-    // Gather the distinct list of locations from the request
-    val locationKeys = setOfNotNull(
-      request.preAppointment?.prisonLocKey,
-      request.postAppointment?.prisonLocKey,
-      request.mainAppointment.prisonLocKey,
-    )
+    val requestedLocations = run {
+      // We should be using location IDs where possible going forwards. Usage of location keys is being phased out as they cannot be relied on.
+      if (request.mainAppointment.dpsLocationId != null) {
+        log.info("AVAILABILITY CHECK: by location ID")
+        setOfNotNull(
+          request.preAppointment?.dpsLocationId,
+          request.postAppointment?.dpsLocationId,
+          request.mainAppointment.dpsLocationId,
+        ).let { getLocationsByIds(it) }
+      } else {
+        // We still need this until all UI's have been updated to use location IDs
+        log.info("AVAILABILITY CHECK: by location key")
+        setOfNotNull(
+          request.preAppointment?.prisonLocKey,
+          request.postAppointment?.prisonLocKey,
+          request.mainAppointment.prisonLocKey,
+        ).let { locationsInsidePrisonClient.getLocationsByKeys(it) }
+      }
+    }
 
-    log.info("AVAILABILITY CHECK: for the following location keys $locationKeys")
-
-    val requestedLocations = locationsInsidePrisonClient.getLocationsByKeys(locationKeys).associateBy { it.key }
+    log.info("AVAILABILITY CHECK: for the following locations ${requestedLocations.map { it.key }}")
 
     if (request.isForAnExistingBooking() && request.dateTimeAndLocationIsTheSame(requestedLocations)) {
       return AvailabilityResponse(true)
@@ -108,12 +119,12 @@ class AvailabilityService(
     val (bvlsAppointmentSlotsToInclude: List<AppointmentSlot>, appointmentsToExclude: List<AppointmentSlot>) = videoAppointmentRepository.findVideoAppointmentsAtPrison(
       forDate = request.date,
       forPrison = request.prisonCode,
-      forLocationIds = requestedLocations.values.map { it.id },
+      forLocationIds = requestedLocations.map { it.id },
     ).partition { vlb -> vlb.videoBookingId != request.vlbIdToExclude }
 
     // Build list of AppointmentSlot for all external non-VLB appointments from NOMIS in these locations on this date
     val externalAppointmentSlotsToInclude: List<AppointmentSlot> =
-      requestedLocations.values
+      requestedLocations
         .flatMap { externalAppointmentsService.getAppointmentSlots(request.prisonCode, request.date, it.id) }
         .filterNot { external ->
           // We can only match on these values, there is no direct match between a BVLS appointment and what is in NOMIS
@@ -130,12 +141,14 @@ class AvailabilityService(
     }
 
     // Check if the requested times are free, and offer alternatives if not
-    return availabilityFinderService.getOptions(request, slotsToCheck, requestedLocations.values.toList())
+    return availabilityFinderService.getOptions(request, slotsToCheck, requestedLocations)
   }
+
+  private fun getLocationsByIds(ids: Set<UUID>): List<Location> = ids.mapNotNull { locationsInsidePrisonClient.getLocationById(it) }
 
   private fun AvailabilityRequest.isForAnExistingBooking() = vlbIdToExclude != null
 
-  private fun AvailabilityRequest.dateTimeAndLocationIsTheSame(requestedLocations: Map<String, Location>): Boolean {
+  private fun AvailabilityRequest.dateTimeAndLocationIsTheSame(requestedLocations: List<Location>): Boolean {
     val mayBeExistingBooking = videoBookingRepository.findById(vlbIdToExclude!!).getOrNull()
 
     if (mayBeExistingBooking != null) {
@@ -143,12 +156,12 @@ class AvailabilityService(
         return mayBeExistingBooking.probationMeeting()!!.dateTimeAndLocationIsTheSame(
           date,
           mainAppointment.interval,
-          requestedLocations[mainAppointment.prisonLocKey]!!,
+          requestedLocations.single { it.id == mainAppointment.dpsLocationId || it.key == mainAppointment.prisonLocKey },
         )
       } else {
-        val preLocation = preAppointment?.prisonLocKey?.let { requestedLocations[it] }
-        val mainLocation = requestedLocations[mainAppointment.prisonLocKey]!!
-        val postLocation = postAppointment?.prisonLocKey?.let { requestedLocations[it] }
+        val preLocation = preAppointment?.let { requestedLocations.singleOrNull { it.id == preAppointment.dpsLocationId || it.key == preAppointment.prisonLocKey } }
+        val mainLocation = requestedLocations.single { it.id == mainAppointment.dpsLocationId || it.key == mainAppointment.prisonLocKey }
+        val postLocation = postAppointment?.let { requestedLocations.singleOrNull { it.id == postAppointment.dpsLocationId || it.key == postAppointment.prisonLocKey } }
 
         val preHearingIsTheSame = (mayBeExistingBooking.preHearing() == null && preLocation == null) ||
           mayBeExistingBooking.preHearing() != null &&

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/PrisonAppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/mapping/PrisonAppointmentMappers.kt
@@ -15,6 +15,7 @@ fun PrisonAppointmentEntity.toModel(locations: Set<Location>) = PrisonAppointmen
   endTime = endTime,
   notesForPrisoners = notesForPrisoners,
   notesForStaff = notesForStaff,
+  dpsLocationId = this.prisonLocationId,
 )
 
 fun List<PrisonAppointmentEntity>.toModel(locations: Set<Location>) = map { it.toModel(locations) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/ModelFactory.kt
@@ -16,6 +16,8 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Appoint
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CourtHearingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateVideoBookingRequest
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Interval
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.LocationAndInterval
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.PrisonerDetails
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.RequestVideoBookingRequest
@@ -62,6 +64,12 @@ fun location(prisonCode: String, locationKeySuffix: String, active: Boolean = tr
   leafLevel = true,
   status = if (active) Location.Status.ACTIVE else Location.Status.INACTIVE,
   locked = false,
+)
+
+fun locationAndInterval(location: Location, start: LocalTime, end: LocalTime) = LocationAndInterval(
+  dpsLocationId = location.id,
+  prisonLocKey = location.key,
+  interval = Interval(start = start, end = end),
 )
 
 fun locationAttributes() = RoomAttributes(
@@ -176,6 +184,7 @@ fun courtBookingRequest(
           date = date,
           startTime = startTime,
           endTime = endTime,
+          dpsLocationId = location?.id,
         ),
       )
     },
@@ -251,6 +260,7 @@ fun probationBookingRequest(
     date = appointmentDate,
     startTime = startTime,
     endTime = endTime,
+    dpsLocationId = location?.id,
   )
 
   val prisoner = PrisonerDetails(
@@ -341,6 +351,7 @@ fun amendCourtBookingRequest(
           date = appointmentDate,
           startTime = startTime,
           endTime = endTime,
+          dpsLocationId = location?.id,
         ),
       )
     },
@@ -377,6 +388,7 @@ fun amendProbationBookingRequest(
     date = appointmentDate,
     startTime = startTime,
     endTime = endTime,
+    dpsLocationId = location?.id,
   )
 
   val prisoner = PrisonerDetails(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/RequestBuilders.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/helper/RequestBuilders.kt
@@ -48,6 +48,7 @@ class CreateCourtBookingRequestBuilder {
       date = date,
       startTime = startTime,
       endTime = endTime,
+      dpsLocationId = location.id,
     )
   }
 
@@ -71,6 +72,7 @@ class CreateCourtBookingRequestBuilder {
                 date = main.date,
                 startTime = main.startTime.minusMinutes(15),
                 endTime = main.startTime,
+                dpsLocationId = it.id,
               )
             },
             main,
@@ -81,6 +83,7 @@ class CreateCourtBookingRequestBuilder {
                 date = main.date,
                 startTime = main.endTime,
                 endTime = main.endTime.plusMinutes(15),
+                dpsLocationId = it.id,
               )
             },
           ),
@@ -129,6 +132,7 @@ class AmendCourtBookingRequestBuilder {
       date = date,
       startTime = startTime,
       endTime = endTime,
+      dpsLocationId = location.id,
     )
   }
 
@@ -151,6 +155,7 @@ class AmendCourtBookingRequestBuilder {
                 date = main.date,
                 startTime = main.startTime.minusMinutes(15),
                 endTime = main.startTime,
+                dpsLocationId = it.id,
               )
             },
             main,
@@ -161,6 +166,7 @@ class AmendCourtBookingRequestBuilder {
                 date = main.date,
                 startTime = main.endTime,
                 endTime = main.endTime.plusMinutes(15),
+                dpsLocationId = it.id,
               )
             },
           ),
@@ -203,6 +209,7 @@ class CreateProbationBookingRequestBuilder {
       date = date,
       startTime = startTime,
       endTime = endTime,
+      dpsLocationId = location.id,
     )
   }
 
@@ -251,6 +258,7 @@ class AmendProbationBookingRequestBuilder {
       date = date,
       startTime = startTime,
       endTime = endTime,
+      dpsLocationId = location.id,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/AvailabilityResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/AvailabilityResourceIntegrationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
@@ -14,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.RISLEY
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.locationAndInterval
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.pentonvilleLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBookingRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.risleyLocation
@@ -28,8 +30,6 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Availab
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.CreateDecoratedRoomRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.DateTimeAvailabilityRequest
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Interval
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.LocationAndInterval
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.TimeSlotAvailabilityRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.AvailabilityResponse
@@ -39,6 +39,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.ExternalUser
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.mapping.toModel
 import java.time.LocalDate
 import java.time.LocalTime
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.locationsinsideprison.model.Location as ApiLocation
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationStatus as ModelLocationStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationUsage as ModelLocationUsage
 
@@ -46,344 +47,634 @@ class AvailabilityResourceIntegrationTest : IntegrationTestBase() {
   @Autowired
   private lateinit var videoBookingRepository: VideoBookingRepository
 
-  @Test
-  fun `should confirm availability for a court booking when the prison room is free`() {
-    videoBookingRepository.findAll() hasSize 0
+  @Nested
+  inner class AvailabilityCheckByDpsLocationID {
+    @Test
+    fun `should offer alternatives for a court booking when the prison room is already occupied`() {
+      videoBookingRepository.findAll() hasSize 0
 
-    // With no bookings present, the availability check should succeed
-    val availabilityRequest = AvailabilityRequest(
-      bookingType = BookingType.COURT,
-      courtOrProbationCode = "DRBYMC",
-      prisonCode = PENTONVILLE,
-      date = LocalDate.now().plusDays(1),
-      mainAppointment = LocationAndInterval(
-        pentonvilleLocation.key,
-        Interval(
-          start = LocalTime.of(12, 0),
-          end = LocalTime.of(12, 30),
-        ),
-      ),
-    )
+      prisonSearchApi().stubGetPrisoner("A1111AA", PENTONVILLE)
 
-    val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
+      val courtBookingRequest = courtBookingRequest(
+        courtCode = "DRBYMC",
+        prisonerNumber = "A1111AA",
+        prisonCode = PENTONVILLE,
+        location = pentonvilleLocation,
+        startTime = LocalTime.of(12, 0),
+        endTime = LocalTime.of(12, 30),
+      )
 
-    assertThat(availabilityResponse).isNotNull
-    with(availabilityResponse) {
-      assertThat(availabilityOk).isTrue()
-      assertThat(alternatives).isEmpty()
-    }
-  }
+      webTestClient.createBooking(courtBookingRequest, COURT_USER)
 
-  @Test
-  fun `should offer alternatives for a court booking when the prison room is already occupied`() {
-    videoBookingRepository.findAll() hasSize 0
-
-    prisonSearchApi().stubGetPrisoner("A1111AA", PENTONVILLE)
-
-    val courtBookingRequest = courtBookingRequest(
-      courtCode = "DRBYMC",
-      prisonerNumber = "A1111AA",
-      prisonCode = PENTONVILLE,
-      location = pentonvilleLocation,
-      startTime = LocalTime.of(12, 0),
-      endTime = LocalTime.of(12, 30),
-    )
-
-    webTestClient.createBooking(courtBookingRequest, COURT_USER)
-
-    // Do the availability check for a booking at the same time as the existing booking above
-    val availabilityRequest = AvailabilityRequest(
-      bookingType = BookingType.COURT,
-      courtOrProbationCode = "DRBYMC",
-      prisonCode = PENTONVILLE,
-      date = LocalDate.now().plusDays(1),
-      mainAppointment = LocationAndInterval(
-        pentonvilleLocation.key,
-        Interval(
-          start = LocalTime.of(12, 0),
-          end = LocalTime.of(12, 30),
-        ),
-      ),
-    )
-
-    val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
-
-    assertThat(availabilityResponse).isNotNull
-    with(availabilityResponse) {
-      assertThat(availabilityOk).isFalse()
-      assertThat(alternatives).hasSize(3)
-    }
-  }
-
-  @Test
-  fun `should exclude specific booking when checking for availability`() {
-    videoBookingRepository.findAll() hasSize 0
-
-    prisonSearchApi().stubGetPrisoner("A1111AA", PENTONVILLE)
-
-    val courtBookingRequest = courtBookingRequest(
-      courtCode = "DRBYMC",
-      prisonerNumber = "A1111AA",
-      prisonCode = PENTONVILLE,
-      location = pentonvilleLocation,
-      startTime = LocalTime.of(12, 0),
-      endTime = LocalTime.of(12, 30),
-    )
-
-    val id = webTestClient.createBooking(courtBookingRequest, COURT_USER)
-
-    // Do the availability check for a booking at the same time as the existing booking above
-    val availabilityRequest = AvailabilityRequest(
-      bookingType = BookingType.COURT,
-      courtOrProbationCode = "DRBYMC",
-      prisonCode = PENTONVILLE,
-      date = LocalDate.now().plusDays(1),
-      mainAppointment = LocationAndInterval(
-        pentonvilleLocation.key,
-        Interval(
-          start = LocalTime.of(12, 0),
-          end = LocalTime.of(12, 30),
-        ),
-      ),
-      vlbIdToExclude = id,
-    )
-
-    val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
-
-    assertThat(availabilityResponse).isNotNull
-    with(availabilityResponse) {
-      assertThat(availabilityOk).isTrue()
-      assertThat(alternatives).hasSize(0)
-    }
-  }
-
-  @Test
-  fun `should confirm availability for a probation booking when the prison room is free`() {
-    videoBookingRepository.findAll() hasSize 0
-
-    val availabilityRequest = AvailabilityRequest(
-      bookingType = BookingType.PROBATION,
-      courtOrProbationCode = "BLKPPP",
-      prisonCode = PENTONVILLE,
-      date = LocalDate.now().plusDays(1),
-      mainAppointment = LocationAndInterval(
-        pentonvilleLocation.key,
-        Interval(
-          start = LocalTime.of(12, 0),
-          end = LocalTime.of(12, 30),
-        ),
-      ),
-    )
-
-    val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
-
-    assertThat(availabilityResponse).isNotNull
-    with(availabilityResponse) {
-      assertThat(availabilityOk).isTrue()
-      assertThat(alternatives).isEmpty()
-    }
-  }
-
-  @Test
-  fun `should return alternatives for a probation booking when the prison room is already occupied`() {
-    videoBookingRepository.findAll() hasSize 0
-
-    prisonSearchApi().stubGetPrisoner("A1111AA", PENTONVILLE)
-
-    val probationBookingRequest = probationBookingRequest(
-      probationTeamCode = "BLKPPP",
-      probationMeetingType = ProbationMeetingType.PSR,
-      prisonCode = PENTONVILLE,
-      prisonerNumber = "A1111AA",
-      appointmentDate = tomorrow(),
-      startTime = LocalTime.of(9, 0),
-      endTime = LocalTime.of(9, 30),
-      appointmentType = AppointmentType.VLB_PROBATION,
-      location = pentonvilleLocation,
-    )
-
-    webTestClient.createBooking(probationBookingRequest, PROBATION_USER)
-
-    videoBookingRepository.findAll() hasSize 1
-
-    // Check for availability of the times just created i.e. an overlapping appointment
-    val availabilityRequest = AvailabilityRequest(
-      bookingType = BookingType.PROBATION,
-      courtOrProbationCode = "BLKPPP",
-      prisonCode = PENTONVILLE,
-      date = tomorrow(),
-      mainAppointment = LocationAndInterval(
-        pentonvilleLocation.key,
-        Interval(
-          start = LocalTime.of(9, 0),
-          end = LocalTime.of(9, 30),
-        ),
-      ),
-    )
-
-    val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
-
-    assertThat(availabilityResponse).isNotNull
-    with(availabilityResponse) {
-      assertThat(availabilityOk).isFalse()
-      assertThat(alternatives).hasSize(3)
-    }
-  }
-
-  @Test
-  fun `should find 16 available times in the morning for room 1 by time slot when nothing booked tomorrow`() {
-    activitiesAppointmentsApi().stubGetRolledOutPrison(RISLEY, true)
-    locationsInsidePrisonApi().stubVideoLinkLocationsAtPrison(RISLEY, risleyLocation)
-
-    // A room must be decorated in availability checks - the default for undecorated rooms is AvailabilityStatus.NONE.
-    webTestClient.createDecoratedRoom(
-      CreateDecoratedRoomRequest(
-        locationUsage = ModelLocationUsage.SHARED,
-        locationStatus = ModelLocationStatus.ACTIVE,
-      ),
-      risleyLocation.toModel(),
-      PROBATION_USER,
-    )
-
-    val response = webTestClient.findByTimeSlot(
-      TimeSlotAvailabilityRequest(
-        prisonCode = RISLEY,
-        bookingType = BookingType.PROBATION,
-        probationTeamCode = BLACKPOOL_MC_PPOC,
-        date = tomorrow(),
-        timeSlots = listOf(TimeSlot.AM),
-        courtCode = null,
-        bookingDuration = 30,
-        vlbIdToExclude = null,
-      ),
-    )
-
-    response.locations hasSize 16
-    response.locations.all { it.name == risleyLocation.localName } isBool true
-  }
-
-  @Test
-  fun `should find no available times in the morning if room is blocked`() {
-    activitiesAppointmentsApi().stubGetRolledOutPrison(RISLEY, true)
-    locationsInsidePrisonApi().stubVideoLinkLocationsAtPrison(RISLEY, risleyLocation)
-    locationsInsidePrisonApi().stubGetLocationById(risleyLocation)
-
-    webTestClient.createDecoratedRoom(
-      CreateDecoratedRoomRequest(
-        locationUsage = ModelLocationUsage.PROBATION,
-        locationStatus = ModelLocationStatus.TEMPORARILY_BLOCKED,
-        blockedFrom = today(),
-        blockedTo = tomorrow(),
-      ),
-      risleyLocation.toModel(),
-      PROBATION_USER,
-    )
-
-    val response = webTestClient.findByTimeSlot(
-      TimeSlotAvailabilityRequest(
-        prisonCode = RISLEY,
-        bookingType = BookingType.PROBATION,
-        probationTeamCode = BLACKPOOL_MC_PPOC,
-        date = tomorrow(),
-        timeSlots = listOf(TimeSlot.AM),
-        courtCode = null,
-        bookingDuration = 30,
-        vlbIdToExclude = null,
-      ),
-    )
-
-    response.locations hasSize 0
-  }
-
-  @Test
-  fun `should find two available room by date and time when nothing booked tomorrow`() {
-    activitiesAppointmentsApi().stubGetRolledOutPrison(RISLEY, true)
-    locationsInsidePrisonApi().stubVideoLinkLocationsAtPrison(RISLEY, risleyLocation, risleyLocation2)
-    locationsInsidePrisonApi().stubGetLocationById(risleyLocation)
-    locationsInsidePrisonApi().stubGetLocationById(risleyLocation2)
-
-    // A room must be decorated in availability checks - the default for undecorated rooms is AvailabilityStatus.NONE.
-    webTestClient.createDecoratedRoom(
-      CreateDecoratedRoomRequest(
-        locationUsage = ModelLocationUsage.SHARED,
-        locationStatus = ModelLocationStatus.ACTIVE,
-      ),
-      risleyLocation.toModel(),
-      COURT_USER,
-    )
-
-    // A room must be decorated in availability checks - the default for undecorated rooms is AvailabilityStatus.NONE.
-    webTestClient.createDecoratedRoom(
-      CreateDecoratedRoomRequest(
-        locationUsage = ModelLocationUsage.SHARED,
-        locationStatus = ModelLocationStatus.ACTIVE,
-      ),
-      risleyLocation2.toModel(),
-      COURT_USER,
-    )
-
-    val response = webTestClient.findByDateAndTime(
-      DateTimeAvailabilityRequest(
-        prisonCode = RISLEY,
+      // Do the availability check for a booking at the same time as the existing booking above
+      val availabilityRequest = AvailabilityRequest(
         bookingType = BookingType.COURT,
-        courtCode = DERBY_JUSTICE_CENTRE,
-        date = tomorrow(),
+        courtOrProbationCode = "DRBYMC",
+        prisonCode = PENTONVILLE,
+        date = LocalDate.now().plusDays(1),
+        mainAppointment = locationAndIntervalById(pentonvilleLocation, start = LocalTime.of(12, 0), end = LocalTime.of(12, 30)),
+      )
+
+      val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
+
+      assertThat(availabilityResponse).isNotNull
+      with(availabilityResponse) {
+        assertThat(availabilityOk).isFalse()
+        assertThat(alternatives).hasSize(3)
+      }
+    }
+
+    @Test
+    fun `should confirm availability for a court booking when the prison room is free`() {
+      videoBookingRepository.findAll() hasSize 0
+
+      // With no bookings present, the availability check should succeed
+      val availabilityRequest = AvailabilityRequest(
+        bookingType = BookingType.COURT,
+        courtOrProbationCode = "DRBYMC",
+        prisonCode = PENTONVILLE,
+        date = LocalDate.now().plusDays(1),
+        mainAppointment = locationAndIntervalById(pentonvilleLocation, start = LocalTime.of(12, 0), end = LocalTime.of(12, 30)),
+      )
+
+      val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
+
+      assertThat(availabilityResponse).isNotNull
+      with(availabilityResponse) {
+        assertThat(availabilityOk).isTrue()
+        assertThat(alternatives).isEmpty()
+      }
+    }
+
+    @Test
+    fun `should exclude specific booking when checking for availability`() {
+      videoBookingRepository.findAll() hasSize 0
+
+      prisonSearchApi().stubGetPrisoner("A1111AA", PENTONVILLE)
+
+      val courtBookingRequest = courtBookingRequest(
+        courtCode = "DRBYMC",
+        prisonerNumber = "A1111AA",
+        prisonCode = PENTONVILLE,
+        location = pentonvilleLocation,
+        startTime = LocalTime.of(12, 0),
+        endTime = LocalTime.of(12, 30),
+      )
+
+      val id = webTestClient.createBooking(courtBookingRequest, COURT_USER)
+
+      // Do the availability check for a booking at the same time as the existing booking above
+      val availabilityRequest = AvailabilityRequest(
+        bookingType = BookingType.COURT,
+        courtOrProbationCode = "DRBYMC",
+        prisonCode = PENTONVILLE,
+        date = LocalDate.now().plusDays(1),
+        mainAppointment = locationAndIntervalById(pentonvilleLocation, start = LocalTime.of(12, 0), end = LocalTime.of(12, 30)),
+        vlbIdToExclude = id,
+      )
+
+      val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
+
+      assertThat(availabilityResponse).isNotNull
+      with(availabilityResponse) {
+        assertThat(availabilityOk).isTrue()
+        assertThat(alternatives).hasSize(0)
+      }
+    }
+
+    @Test
+    fun `should confirm availability for a probation booking when the prison room is free`() {
+      videoBookingRepository.findAll() hasSize 0
+
+      val availabilityRequest = AvailabilityRequest(
+        bookingType = BookingType.PROBATION,
+        courtOrProbationCode = "BLKPPP",
+        prisonCode = PENTONVILLE,
+        date = LocalDate.now().plusDays(1),
+        mainAppointment = locationAndIntervalById(pentonvilleLocation, start = LocalTime.of(12, 0), end = LocalTime.of(12, 30)),
+      )
+
+      val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
+
+      assertThat(availabilityResponse).isNotNull
+      with(availabilityResponse) {
+        assertThat(availabilityOk).isTrue()
+        assertThat(alternatives).isEmpty()
+      }
+    }
+
+    @Test
+    fun `should return alternatives for a probation booking when the prison room is already occupied`() {
+      videoBookingRepository.findAll() hasSize 0
+
+      prisonSearchApi().stubGetPrisoner("A1111AA", PENTONVILLE)
+
+      val probationBookingRequest = probationBookingRequest(
+        probationTeamCode = "BLKPPP",
+        probationMeetingType = ProbationMeetingType.PSR,
+        prisonCode = PENTONVILLE,
+        prisonerNumber = "A1111AA",
+        appointmentDate = tomorrow(),
         startTime = LocalTime.of(9, 0),
         endTime = LocalTime.of(9, 30),
-        probationTeamCode = null,
-        appointmentToExclude = null,
-      ),
-    )
+        appointmentType = AppointmentType.VLB_PROBATION,
+        location = pentonvilleLocation,
+      )
 
-    response.locations hasSize 2
-    response.locations.single { it.name == risleyLocation.localName }
-    response.locations.single { it.name == risleyLocation2.localName }
+      webTestClient.createBooking(probationBookingRequest, PROBATION_USER)
+
+      videoBookingRepository.findAll() hasSize 1
+
+      // Check for availability of the times just created i.e. an overlapping appointment
+      val availabilityRequest = AvailabilityRequest(
+        bookingType = BookingType.PROBATION,
+        courtOrProbationCode = "BLKPPP",
+        prisonCode = PENTONVILLE,
+        date = tomorrow(),
+        mainAppointment = locationAndIntervalById(pentonvilleLocation, start = LocalTime.of(9, 0), end = LocalTime.of(9, 30)),
+      )
+
+      val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
+
+      assertThat(availabilityResponse).isNotNull
+      with(availabilityResponse) {
+        assertThat(availabilityOk).isFalse()
+        assertThat(alternatives).hasSize(3)
+      }
+    }
+
+    @Test
+    fun `should find 16 available times in the morning for room 1 by time slot when nothing booked tomorrow`() {
+      activitiesAppointmentsApi().stubGetRolledOutPrison(RISLEY, true)
+      locationsInsidePrisonApi().stubVideoLinkLocationsAtPrison(RISLEY, risleyLocation)
+
+      // A room must be decorated in availability checks - the default for undecorated rooms is AvailabilityStatus.NONE.
+      webTestClient.createDecoratedRoom(
+        CreateDecoratedRoomRequest(
+          locationUsage = ModelLocationUsage.SHARED,
+          locationStatus = ModelLocationStatus.ACTIVE,
+        ),
+        risleyLocation.toModel(),
+        PROBATION_USER,
+      )
+
+      val response = webTestClient.findByTimeSlot(
+        TimeSlotAvailabilityRequest(
+          prisonCode = RISLEY,
+          bookingType = BookingType.PROBATION,
+          probationTeamCode = BLACKPOOL_MC_PPOC,
+          date = tomorrow(),
+          timeSlots = listOf(TimeSlot.AM),
+          courtCode = null,
+          bookingDuration = 30,
+          vlbIdToExclude = null,
+        ),
+      )
+
+      response.locations hasSize 16
+      response.locations.all { it.name == risleyLocation.localName } isBool true
+    }
+
+    @Test
+    fun `should find no available times in the morning if room is blocked`() {
+      activitiesAppointmentsApi().stubGetRolledOutPrison(RISLEY, true)
+      locationsInsidePrisonApi().stubVideoLinkLocationsAtPrison(RISLEY, risleyLocation)
+      locationsInsidePrisonApi().stubGetLocationById(risleyLocation)
+
+      webTestClient.createDecoratedRoom(
+        CreateDecoratedRoomRequest(
+          locationUsage = ModelLocationUsage.PROBATION,
+          locationStatus = ModelLocationStatus.TEMPORARILY_BLOCKED,
+          blockedFrom = today(),
+          blockedTo = tomorrow(),
+        ),
+        risleyLocation.toModel(),
+        PROBATION_USER,
+      )
+
+      val response = webTestClient.findByTimeSlot(
+        TimeSlotAvailabilityRequest(
+          prisonCode = RISLEY,
+          bookingType = BookingType.PROBATION,
+          probationTeamCode = BLACKPOOL_MC_PPOC,
+          date = tomorrow(),
+          timeSlots = listOf(TimeSlot.AM),
+          courtCode = null,
+          bookingDuration = 30,
+          vlbIdToExclude = null,
+        ),
+      )
+
+      response.locations hasSize 0
+    }
+
+    @Test
+    fun `should find two available room by date and time when nothing booked tomorrow`() {
+      activitiesAppointmentsApi().stubGetRolledOutPrison(RISLEY, true)
+      locationsInsidePrisonApi().stubVideoLinkLocationsAtPrison(RISLEY, risleyLocation, risleyLocation2)
+      locationsInsidePrisonApi().stubGetLocationById(risleyLocation)
+      locationsInsidePrisonApi().stubGetLocationById(risleyLocation2)
+
+      // A room must be decorated in availability checks - the default for undecorated rooms is AvailabilityStatus.NONE.
+      webTestClient.createDecoratedRoom(
+        CreateDecoratedRoomRequest(
+          locationUsage = ModelLocationUsage.SHARED,
+          locationStatus = ModelLocationStatus.ACTIVE,
+        ),
+        risleyLocation.toModel(),
+        COURT_USER,
+      )
+
+      // A room must be decorated in availability checks - the default for undecorated rooms is AvailabilityStatus.NONE.
+      webTestClient.createDecoratedRoom(
+        CreateDecoratedRoomRequest(
+          locationUsage = ModelLocationUsage.SHARED,
+          locationStatus = ModelLocationStatus.ACTIVE,
+        ),
+        risleyLocation2.toModel(),
+        COURT_USER,
+      )
+
+      val response = webTestClient.findByDateAndTime(
+        DateTimeAvailabilityRequest(
+          prisonCode = RISLEY,
+          bookingType = BookingType.COURT,
+          courtCode = DERBY_JUSTICE_CENTRE,
+          date = tomorrow(),
+          startTime = LocalTime.of(9, 0),
+          endTime = LocalTime.of(9, 30),
+          probationTeamCode = null,
+          appointmentToExclude = null,
+        ),
+      )
+
+      response.locations hasSize 2
+      response.locations.single { it.name == risleyLocation.localName }
+      response.locations.single { it.name == risleyLocation2.localName }
+    }
+
+    @Test
+    fun `should find one available room by date and time when one room is blocked and nothing booked tomorrow`() {
+      activitiesAppointmentsApi().stubGetRolledOutPrison(RISLEY, true)
+      locationsInsidePrisonApi().stubVideoLinkLocationsAtPrison(RISLEY, risleyLocation, risleyLocation2)
+      locationsInsidePrisonApi().stubGetLocationById(risleyLocation)
+      locationsInsidePrisonApi().stubGetLocationById(risleyLocation2)
+
+      // Blocked room
+      webTestClient.createDecoratedRoom(
+        CreateDecoratedRoomRequest(
+          locationUsage = ModelLocationUsage.SHARED,
+          locationStatus = ModelLocationStatus.TEMPORARILY_BLOCKED,
+          blockedFrom = today(),
+          blockedTo = tomorrow(),
+        ),
+        risleyLocation.toModel(),
+        COURT_USER,
+      )
+
+      // Free room. A room must be decorated in availability checks - the default for undecorated rooms is AvailabilityStatus.NONE.
+      webTestClient.createDecoratedRoom(
+        CreateDecoratedRoomRequest(
+          locationUsage = ModelLocationUsage.SHARED,
+          locationStatus = ModelLocationStatus.ACTIVE,
+        ),
+        risleyLocation2.toModel(),
+        COURT_USER,
+      )
+
+      val response = webTestClient.findByDateAndTime(
+        DateTimeAvailabilityRequest(
+          prisonCode = RISLEY,
+          bookingType = BookingType.COURT,
+          courtCode = DERBY_JUSTICE_CENTRE,
+          date = tomorrow(),
+          startTime = LocalTime.of(9, 0),
+          endTime = LocalTime.of(9, 30),
+          probationTeamCode = null,
+          appointmentToExclude = null,
+        ),
+      )
+
+      response.locations hasSize 1
+      response.locations.single { it.name == risleyLocation2.localName }
+    }
+
+    private fun locationAndIntervalById(location: ApiLocation, start: LocalTime, end: LocalTime) = locationAndInterval(location, start, end).copy(prisonLocKey = null)
   }
 
-  @Test
-  fun `should find one available room by date and time when one room is blocked and nothing booked tomorrow`() {
-    activitiesAppointmentsApi().stubGetRolledOutPrison(RISLEY, true)
-    locationsInsidePrisonApi().stubVideoLinkLocationsAtPrison(RISLEY, risleyLocation, risleyLocation2)
-    locationsInsidePrisonApi().stubGetLocationById(risleyLocation)
-    locationsInsidePrisonApi().stubGetLocationById(risleyLocation2)
+  @Nested
+  inner class AvailabilityCheckByDpsLocationKey {
+    @Test
+    fun `should offer alternatives for a court booking when the prison room is already occupied`() {
+      videoBookingRepository.findAll() hasSize 0
 
-    // Blocked room
-    webTestClient.createDecoratedRoom(
-      CreateDecoratedRoomRequest(
-        locationUsage = ModelLocationUsage.SHARED,
-        locationStatus = ModelLocationStatus.TEMPORARILY_BLOCKED,
-        blockedFrom = today(),
-        blockedTo = tomorrow(),
-      ),
-      risleyLocation.toModel(),
-      COURT_USER,
-    )
+      prisonSearchApi().stubGetPrisoner("A1111AA", PENTONVILLE)
 
-    // Free room. A room must be decorated in availability checks - the default for undecorated rooms is AvailabilityStatus.NONE.
-    webTestClient.createDecoratedRoom(
-      CreateDecoratedRoomRequest(
-        locationUsage = ModelLocationUsage.SHARED,
-        locationStatus = ModelLocationStatus.ACTIVE,
-      ),
-      risleyLocation2.toModel(),
-      COURT_USER,
-    )
+      val courtBookingRequest = courtBookingRequest(
+        courtCode = "DRBYMC",
+        prisonerNumber = "A1111AA",
+        prisonCode = PENTONVILLE,
+        location = pentonvilleLocation,
+        startTime = LocalTime.of(12, 0),
+        endTime = LocalTime.of(12, 30),
+      )
 
-    val response = webTestClient.findByDateAndTime(
-      DateTimeAvailabilityRequest(
-        prisonCode = RISLEY,
+      webTestClient.createBooking(courtBookingRequest, COURT_USER)
+
+      // Do the availability check for a booking at the same time as the existing booking above
+      val availabilityRequest = AvailabilityRequest(
         bookingType = BookingType.COURT,
-        courtCode = DERBY_JUSTICE_CENTRE,
-        date = tomorrow(),
+        courtOrProbationCode = "DRBYMC",
+        prisonCode = PENTONVILLE,
+        date = LocalDate.now().plusDays(1),
+        mainAppointment = locationAndIntervalByKey(pentonvilleLocation, start = LocalTime.of(12, 0), end = LocalTime.of(12, 30)),
+      )
+
+      val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
+
+      assertThat(availabilityResponse).isNotNull
+      with(availabilityResponse) {
+        assertThat(availabilityOk).isFalse()
+        assertThat(alternatives).hasSize(3)
+      }
+    }
+
+    @Test
+    fun `should confirm availability for a court booking when the prison room is free`() {
+      videoBookingRepository.findAll() hasSize 0
+
+      // With no bookings present, the availability check should succeed
+      val availabilityRequest = AvailabilityRequest(
+        bookingType = BookingType.COURT,
+        courtOrProbationCode = "DRBYMC",
+        prisonCode = PENTONVILLE,
+        date = LocalDate.now().plusDays(1),
+        mainAppointment = locationAndIntervalByKey(pentonvilleLocation, start = LocalTime.of(12, 0), end = LocalTime.of(12, 30)),
+      )
+
+      val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
+
+      assertThat(availabilityResponse).isNotNull
+      with(availabilityResponse) {
+        assertThat(availabilityOk).isTrue()
+        assertThat(alternatives).isEmpty()
+      }
+    }
+
+    @Test
+    fun `should exclude specific booking when checking for availability`() {
+      videoBookingRepository.findAll() hasSize 0
+
+      prisonSearchApi().stubGetPrisoner("A1111AA", PENTONVILLE)
+
+      val courtBookingRequest = courtBookingRequest(
+        courtCode = "DRBYMC",
+        prisonerNumber = "A1111AA",
+        prisonCode = PENTONVILLE,
+        location = pentonvilleLocation,
+        startTime = LocalTime.of(12, 0),
+        endTime = LocalTime.of(12, 30),
+      )
+
+      val id = webTestClient.createBooking(courtBookingRequest, COURT_USER)
+
+      // Do the availability check for a booking at the same time as the existing booking above
+      val availabilityRequest = AvailabilityRequest(
+        bookingType = BookingType.COURT,
+        courtOrProbationCode = "DRBYMC",
+        prisonCode = PENTONVILLE,
+        date = LocalDate.now().plusDays(1),
+        mainAppointment = locationAndIntervalByKey(pentonvilleLocation, start = LocalTime.of(12, 0), end = LocalTime.of(12, 30)),
+        vlbIdToExclude = id,
+      )
+
+      val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
+
+      assertThat(availabilityResponse).isNotNull
+      with(availabilityResponse) {
+        assertThat(availabilityOk).isTrue()
+        assertThat(alternatives).hasSize(0)
+      }
+    }
+
+    @Test
+    fun `should confirm availability for a probation booking when the prison room is free`() {
+      videoBookingRepository.findAll() hasSize 0
+
+      val availabilityRequest = AvailabilityRequest(
+        bookingType = BookingType.PROBATION,
+        courtOrProbationCode = "BLKPPP",
+        prisonCode = PENTONVILLE,
+        date = LocalDate.now().plusDays(1),
+        mainAppointment = locationAndIntervalByKey(pentonvilleLocation, start = LocalTime.of(12, 0), end = LocalTime.of(12, 30)),
+      )
+
+      val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
+
+      assertThat(availabilityResponse).isNotNull
+      with(availabilityResponse) {
+        assertThat(availabilityOk).isTrue()
+        assertThat(alternatives).isEmpty()
+      }
+    }
+
+    @Test
+    fun `should return alternatives for a probation booking when the prison room is already occupied`() {
+      videoBookingRepository.findAll() hasSize 0
+
+      prisonSearchApi().stubGetPrisoner("A1111AA", PENTONVILLE)
+
+      val probationBookingRequest = probationBookingRequest(
+        probationTeamCode = "BLKPPP",
+        probationMeetingType = ProbationMeetingType.PSR,
+        prisonCode = PENTONVILLE,
+        prisonerNumber = "A1111AA",
+        appointmentDate = tomorrow(),
         startTime = LocalTime.of(9, 0),
         endTime = LocalTime.of(9, 30),
-        probationTeamCode = null,
-        appointmentToExclude = null,
-      ),
-    )
+        appointmentType = AppointmentType.VLB_PROBATION,
+        location = pentonvilleLocation,
+      )
 
-    response.locations hasSize 1
-    response.locations.single { it.name == risleyLocation2.localName }
+      webTestClient.createBooking(probationBookingRequest, PROBATION_USER)
+
+      videoBookingRepository.findAll() hasSize 1
+
+      // Check for availability of the times just created i.e. an overlapping appointment
+      val availabilityRequest = AvailabilityRequest(
+        bookingType = BookingType.PROBATION,
+        courtOrProbationCode = "BLKPPP",
+        prisonCode = PENTONVILLE,
+        date = tomorrow(),
+        mainAppointment = locationAndIntervalByKey(pentonvilleLocation, start = LocalTime.of(9, 0), end = LocalTime.of(9, 30)),
+      )
+
+      val availabilityResponse = webTestClient.availabilityCheck(availabilityRequest)
+
+      assertThat(availabilityResponse).isNotNull
+      with(availabilityResponse) {
+        assertThat(availabilityOk).isFalse()
+        assertThat(alternatives).hasSize(3)
+      }
+    }
+
+    @Test
+    fun `should find 16 available times in the morning for room 1 by time slot when nothing booked tomorrow`() {
+      activitiesAppointmentsApi().stubGetRolledOutPrison(RISLEY, true)
+      locationsInsidePrisonApi().stubVideoLinkLocationsAtPrison(RISLEY, risleyLocation)
+
+      // A room must be decorated in availability checks - the default for undecorated rooms is AvailabilityStatus.NONE.
+      webTestClient.createDecoratedRoom(
+        CreateDecoratedRoomRequest(
+          locationUsage = ModelLocationUsage.SHARED,
+          locationStatus = ModelLocationStatus.ACTIVE,
+        ),
+        risleyLocation.toModel(),
+        PROBATION_USER,
+      )
+
+      val response = webTestClient.findByTimeSlot(
+        TimeSlotAvailabilityRequest(
+          prisonCode = RISLEY,
+          bookingType = BookingType.PROBATION,
+          probationTeamCode = BLACKPOOL_MC_PPOC,
+          date = tomorrow(),
+          timeSlots = listOf(TimeSlot.AM),
+          courtCode = null,
+          bookingDuration = 30,
+          vlbIdToExclude = null,
+        ),
+      )
+
+      response.locations hasSize 16
+      response.locations.all { it.name == risleyLocation.localName } isBool true
+    }
+
+    @Test
+    fun `should find no available times in the morning if room is blocked`() {
+      activitiesAppointmentsApi().stubGetRolledOutPrison(RISLEY, true)
+      locationsInsidePrisonApi().stubVideoLinkLocationsAtPrison(RISLEY, risleyLocation)
+      locationsInsidePrisonApi().stubGetLocationById(risleyLocation)
+
+      webTestClient.createDecoratedRoom(
+        CreateDecoratedRoomRequest(
+          locationUsage = ModelLocationUsage.PROBATION,
+          locationStatus = ModelLocationStatus.TEMPORARILY_BLOCKED,
+          blockedFrom = today(),
+          blockedTo = tomorrow(),
+        ),
+        risleyLocation.toModel(),
+        PROBATION_USER,
+      )
+
+      val response = webTestClient.findByTimeSlot(
+        TimeSlotAvailabilityRequest(
+          prisonCode = RISLEY,
+          bookingType = BookingType.PROBATION,
+          probationTeamCode = BLACKPOOL_MC_PPOC,
+          date = tomorrow(),
+          timeSlots = listOf(TimeSlot.AM),
+          courtCode = null,
+          bookingDuration = 30,
+          vlbIdToExclude = null,
+        ),
+      )
+
+      response.locations hasSize 0
+    }
+
+    @Test
+    fun `should find two available room by date and time when nothing booked tomorrow`() {
+      activitiesAppointmentsApi().stubGetRolledOutPrison(RISLEY, true)
+      locationsInsidePrisonApi().stubVideoLinkLocationsAtPrison(RISLEY, risleyLocation, risleyLocation2)
+      locationsInsidePrisonApi().stubGetLocationById(risleyLocation)
+      locationsInsidePrisonApi().stubGetLocationById(risleyLocation2)
+
+      // A room must be decorated in availability checks - the default for undecorated rooms is AvailabilityStatus.NONE.
+      webTestClient.createDecoratedRoom(
+        CreateDecoratedRoomRequest(
+          locationUsage = ModelLocationUsage.SHARED,
+          locationStatus = ModelLocationStatus.ACTIVE,
+        ),
+        risleyLocation.toModel(),
+        COURT_USER,
+      )
+
+      // A room must be decorated in availability checks - the default for undecorated rooms is AvailabilityStatus.NONE.
+      webTestClient.createDecoratedRoom(
+        CreateDecoratedRoomRequest(
+          locationUsage = ModelLocationUsage.SHARED,
+          locationStatus = ModelLocationStatus.ACTIVE,
+        ),
+        risleyLocation2.toModel(),
+        COURT_USER,
+      )
+
+      val response = webTestClient.findByDateAndTime(
+        DateTimeAvailabilityRequest(
+          prisonCode = RISLEY,
+          bookingType = BookingType.COURT,
+          courtCode = DERBY_JUSTICE_CENTRE,
+          date = tomorrow(),
+          startTime = LocalTime.of(9, 0),
+          endTime = LocalTime.of(9, 30),
+          probationTeamCode = null,
+          appointmentToExclude = null,
+        ),
+      )
+
+      response.locations hasSize 2
+      response.locations.single { it.name == risleyLocation.localName }
+      response.locations.single { it.name == risleyLocation2.localName }
+    }
+
+    @Test
+    fun `should find one available room by date and time when one room is blocked and nothing booked tomorrow`() {
+      activitiesAppointmentsApi().stubGetRolledOutPrison(RISLEY, true)
+      locationsInsidePrisonApi().stubVideoLinkLocationsAtPrison(RISLEY, risleyLocation, risleyLocation2)
+      locationsInsidePrisonApi().stubGetLocationById(risleyLocation)
+      locationsInsidePrisonApi().stubGetLocationById(risleyLocation2)
+
+      // Blocked room
+      webTestClient.createDecoratedRoom(
+        CreateDecoratedRoomRequest(
+          locationUsage = ModelLocationUsage.SHARED,
+          locationStatus = ModelLocationStatus.TEMPORARILY_BLOCKED,
+          blockedFrom = today(),
+          blockedTo = tomorrow(),
+        ),
+        risleyLocation.toModel(),
+        COURT_USER,
+      )
+
+      // Free room. A room must be decorated in availability checks - the default for undecorated rooms is AvailabilityStatus.NONE.
+      webTestClient.createDecoratedRoom(
+        CreateDecoratedRoomRequest(
+          locationUsage = ModelLocationUsage.SHARED,
+          locationStatus = ModelLocationStatus.ACTIVE,
+        ),
+        risleyLocation2.toModel(),
+        COURT_USER,
+      )
+
+      val response = webTestClient.findByDateAndTime(
+        DateTimeAvailabilityRequest(
+          prisonCode = RISLEY,
+          bookingType = BookingType.COURT,
+          courtCode = DERBY_JUSTICE_CENTRE,
+          date = tomorrow(),
+          startTime = LocalTime.of(9, 0),
+          endTime = LocalTime.of(9, 30),
+          probationTeamCode = null,
+          appointmentToExclude = null,
+        ),
+      )
+
+      response.locations hasSize 1
+      response.locations.single { it.name == risleyLocation2.localName }
+    }
+
+    private fun locationAndIntervalByKey(location: ApiLocation, start: LocalTime, end: LocalTime) = locationAndInterval(location, start, end).copy(dpsLocationId = null)
   }
 
   private fun WebTestClient.availabilityCheck(request: AvailabilityRequest) = this

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/InboundEventsIntegrationTest.kt
@@ -472,6 +472,7 @@ class InboundEventsIntegrationTest : SqsIntegrationTestBase() {
           date = tomorrow(),
           startTime = LocalTime.of(10, 45),
           endTime = LocalTime.of(11, 0),
+          dpsLocationId = pentonvilleLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_MAIN,
@@ -479,6 +480,7 @@ class InboundEventsIntegrationTest : SqsIntegrationTestBase() {
           date = tomorrow(),
           startTime = LocalTime.of(11, 0),
           endTime = LocalTime.of(11, 30),
+          dpsLocationId = pentonvilleLocation.id,
         ),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AmendVideoBookingRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AmendVideoBookingRequestTest.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.today
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.yesterday
 import java.time.LocalTime
+import java.util.UUID
 
 class AmendVideoBookingRequestTest : ValidatorBase<AmendVideoBookingRequest>() {
 
@@ -14,6 +15,7 @@ class AmendVideoBookingRequestTest : ValidatorBase<AmendVideoBookingRequest>() {
     date = tomorrow(),
     startTime = LocalTime.now(),
     endTime = LocalTime.now().plusHours(1),
+    dpsLocationId = UUID.randomUUID(),
   )
 
   private val prisoner = PrisonerDetails(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateVideoBookingRequestTest.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.today
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.yesterday
 import java.time.LocalTime
+import java.util.UUID
 
 class CreateVideoBookingRequestTest : ValidatorBase<CreateVideoBookingRequest>() {
 
@@ -14,6 +15,7 @@ class CreateVideoBookingRequestTest : ValidatorBase<CreateVideoBookingRequest>()
     date = tomorrow(),
     startTime = LocalTime.now(),
     endTime = LocalTime.now().plusHours(1),
+    dpsLocationId = UUID.randomUUID(),
   )
 
   private val prisoner = PrisonerDetails(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendCourtBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/AmendCourtBookingServiceTest.kt
@@ -93,6 +93,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 0),
           endTime = LocalTime.of(9, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_MAIN,
@@ -100,6 +101,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -107,6 +109,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 0),
           endTime = LocalTime.of(10, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -193,6 +196,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 0),
           endTime = LocalTime.of(9, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_MAIN,
@@ -200,6 +204,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -207,6 +212,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 0),
           endTime = LocalTime.of(10, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -214,6 +220,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 30),
           endTime = LocalTime.of(11, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -240,6 +247,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 0),
           endTime = LocalTime.of(9, 31),
+          dpsLocationId = pentonvilleLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_MAIN,
@@ -247,6 +255,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = pentonvilleLocation.id,
         ),
       ),
     )
@@ -273,6 +282,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 0),
           endTime = LocalTime.of(9, 31),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -280,6 +290,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -306,6 +317,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 0),
           endTime = LocalTime.of(9, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -313,6 +325,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 0),
           endTime = LocalTime.of(10, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -339,6 +352,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 0),
           endTime = LocalTime.of(9, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_PRE,
@@ -346,6 +360,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 0),
           endTime = LocalTime.of(9, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_MAIN,
@@ -353,6 +368,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -379,6 +395,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -386,6 +403,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 0),
           endTime = LocalTime.of(10, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -393,6 +411,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 30),
           endTime = LocalTime.of(11, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -419,6 +438,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -426,6 +446,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 0),
           endTime = LocalTime.of(10, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_PROBATION,
@@ -433,6 +454,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 30),
           endTime = LocalTime.of(11, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -469,6 +491,7 @@ class AmendCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateCourtBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/CreateCourtBookingServiceTest.kt
@@ -89,6 +89,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 0),
           endTime = LocalTime.of(9, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_MAIN,
@@ -96,6 +97,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -103,6 +105,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 0),
           endTime = LocalTime.of(10, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -182,6 +185,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -203,6 +207,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 0),
           endTime = LocalTime.of(9, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_MAIN,
@@ -210,6 +215,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -217,6 +223,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 0),
           endTime = LocalTime.of(10, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -224,6 +231,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 30),
           endTime = LocalTime.of(11, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -253,6 +261,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 0),
           endTime = LocalTime.of(9, 31),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_MAIN,
@@ -260,6 +269,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -289,6 +299,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 0),
           endTime = LocalTime.of(9, 31),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -296,6 +307,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -325,6 +337,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 0),
           endTime = LocalTime.of(9, 30),
+          dpsLocationId = wandsworthLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -332,6 +345,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 0),
           endTime = LocalTime.of(10, 30),
+          dpsLocationId = wandsworthLocation.id,
         ),
       ),
     )
@@ -361,6 +375,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 0),
           endTime = LocalTime.of(9, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_PRE,
@@ -368,6 +383,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 0),
           endTime = LocalTime.of(9, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_MAIN,
@@ -375,6 +391,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -404,6 +421,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -411,6 +429,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 0),
           endTime = LocalTime.of(10, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -418,6 +437,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 30),
           endTime = LocalTime.of(11, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -447,6 +467,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_COURT_POST,
@@ -454,6 +475,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 0),
           endTime = LocalTime.of(10, 30),
+          dpsLocationId = birminghamLocation.id,
         ),
         Appointment(
           type = AppointmentType.VLB_PROBATION,
@@ -461,6 +483,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(10, 30),
           endTime = LocalTime.of(11, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -490,6 +513,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )
@@ -556,6 +580,7 @@ class CreateCourtBookingServiceTest {
           date = tomorrow(),
           startTime = LocalTime.of(9, 30),
           endTime = LocalTime.of(10, 0),
+          dpsLocationId = birminghamLocation.id,
         ),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/AvailabilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/locations/availability/AvailabilityServiceTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.availability
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyList
 import org.mockito.kotlin.any
@@ -18,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.location
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.locationAndInterval
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.prison
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.today
@@ -25,15 +25,9 @@ import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withMainCourtP
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withProbationPrisonAppointment
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.AvailabilityRequest
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.BookingType
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.Interval
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.LocationAndInterval
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.availability.AvailabilityFinderService
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.availability.AvailabilityOptionsGenerator
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.availability.AvailabilityService
-import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.locations.availability.ExternalAppointmentsService
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -91,44 +85,43 @@ class AvailabilityServiceTest {
   private val room2 = location(WANDSWORTH, "VCC-2")
   private val room3 = location(WANDSWORTH, "VCC-3")
 
-  private val videoAppointments = listOf(
+  private val room1VideoAppointments = listOf(
     createVideoAppointment(1L, 1L, room1.id, "VLB_COURT_PRE", LocalTime.of(9, 15), LocalTime.of(9, 30)),
     createVideoAppointment(1L, 2L, room1.id, "VLB_COURT_MAIN", LocalTime.of(9, 30), LocalTime.of(10, 0)),
     createVideoAppointment(2L, 3L, room1.id, "VLB_COURT_MAIN", LocalTime.of(10, 0), LocalTime.of(11, 0)),
     createVideoAppointment(2L, 4L, room1.id, "VLB_COURT_POST", LocalTime.of(11, 0), LocalTime.of(11, 15)),
     createVideoAppointment(3L, 5L, room1.id, "VLB_COURT_MAIN", LocalTime.of(11, 15), LocalTime.of(11, 45)),
+  )
+
+  private val room2VideoAppointments = listOf(
     createVideoAppointment(4L, 6L, room2.id, "VLB_COURT_MAIN", LocalTime.of(9, 30), LocalTime.of(12, 30)),
     createVideoAppointment(5L, 7L, room2.id, "VLB_COURT_MAIN", LocalTime.of(13, 30), LocalTime.of(16, 30)),
+  )
+
+  private val room3VideoAppointments = listOf(
     createVideoAppointment(6L, 8L, room3.id, "VLB_COURT_MAIN", LocalTime.of(9, 0), LocalTime.of(19, 0)),
   )
 
-  @BeforeEach
-  fun setUpMock() {
-    // Mock the view of existing video appointments
+  @Test
+  fun `No options when the requested time is free`() {
     whenever(
       videoAppointmentRepository.findVideoAppointmentsAtPrison(
         forDate = any(),
         forPrison = any(),
         forLocationIds = anyList(),
       ),
-    ).thenReturn(videoAppointments)
-  }
+    ) doReturn room1VideoAppointments
 
-  @Test
-  fun `No options when the requested time is free`() {
     // Request for a time which is currently free
     val request = AvailabilityRequest(
       bookingType = BookingType.COURT,
       courtOrProbationCode = "TESTC",
       prisonCode = WANDSWORTH,
       date = LocalDate.now(),
-      mainAppointment = LocationAndInterval(
-        prisonLocKey = room1.key,
-        interval = Interval(start = LocalTime.of(12, 0), end = LocalTime.of(12, 30)),
-      ),
+      mainAppointment = locationAndInterval(room1, LocalTime.of(12, 0), LocalTime.of(12, 30)),
     )
 
-    whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1, room2, room3)
+    whenever(locationsInsidePrisonClient.getLocationById(room1.id)) doReturn room1
 
     val response = service.checkAvailability(request)
 
@@ -141,19 +134,24 @@ class AvailabilityServiceTest {
 
   @Test
   fun `Options provided when the requested time is not free`() {
+    whenever(
+      videoAppointmentRepository.findVideoAppointmentsAtPrison(
+        forDate = any(),
+        forPrison = any(),
+        forLocationIds = anyList(),
+      ),
+    ) doReturn room1VideoAppointments
+
     // Request for a time already taken
     val request = AvailabilityRequest(
       bookingType = BookingType.COURT,
       courtOrProbationCode = "TESTC",
       prisonCode = WANDSWORTH,
       date = LocalDate.now(),
-      mainAppointment = LocationAndInterval(
-        prisonLocKey = room1.key,
-        interval = Interval(start = LocalTime.of(11, 0), end = LocalTime.of(11, 30)),
-      ),
+      mainAppointment = locationAndInterval(room1, LocalTime.of(11, 0), LocalTime.of(11, 30)),
     )
 
-    whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1, room2, room3)
+    whenever(locationsInsidePrisonClient.getLocationById(room1.id)) doReturn room1
 
     val response = service.checkAvailability(request)
 
@@ -163,18 +161,9 @@ class AvailabilityServiceTest {
       assertThat(alternatives).hasSize(3)
       assertThat(alternatives).extracting("main").containsAll(
         listOf(
-          LocationAndInterval(
-            prisonLocKey = room1.key,
-            interval = Interval(start = LocalTime.of(11, 45), end = LocalTime.of(12, 15)),
-          ),
-          LocationAndInterval(
-            prisonLocKey = room1.key,
-            interval = Interval(start = LocalTime.of(12, 0), end = LocalTime.of(12, 30)),
-          ),
-          LocationAndInterval(
-            prisonLocKey = room1.key,
-            interval = Interval(start = LocalTime.of(12, 15), end = LocalTime.of(12, 45)),
-          ),
+          locationAndInterval(room1, LocalTime.of(11, 45), LocalTime.of(12, 15)),
+          locationAndInterval(room1, LocalTime.of(12, 0), LocalTime.of(12, 30)),
+          locationAndInterval(room1, LocalTime.of(12, 15), LocalTime.of(12, 45)),
         ),
       )
     }
@@ -182,27 +171,27 @@ class AvailabilityServiceTest {
 
   @Test
   fun `Considers all rooms when multiple rooms are requested and one is unavailable`() {
+    whenever(
+      videoAppointmentRepository.findVideoAppointmentsAtPrison(
+        forDate = any(),
+        forPrison = any(),
+        forLocationIds = anyList(),
+      ),
+    ) doReturn room1VideoAppointments.plus(room2VideoAppointments)
+
     // Request for multiple rooms with one of them busy at this time
     val request = AvailabilityRequest(
       bookingType = BookingType.COURT,
       courtOrProbationCode = "TESTC",
       prisonCode = WANDSWORTH,
       date = LocalDate.now(),
-      preAppointment = LocationAndInterval(
-        prisonLocKey = room1.key,
-        interval = Interval(start = LocalTime.of(14, 0), end = LocalTime.of(14, 15)),
-      ),
-      mainAppointment = LocationAndInterval(
-        prisonLocKey = room2.key,
-        interval = Interval(start = LocalTime.of(14, 15), end = LocalTime.of(14, 45)),
-      ),
-      postAppointment = LocationAndInterval(
-        prisonLocKey = room1.key,
-        interval = Interval(start = LocalTime.of(14, 45), end = LocalTime.of(15, 0)),
-      ),
+      preAppointment = locationAndInterval(room1, LocalTime.of(14, 0), LocalTime.of(14, 15)),
+      mainAppointment = locationAndInterval(room2, LocalTime.of(14, 15), LocalTime.of(14, 45)),
+      postAppointment = locationAndInterval(room1, LocalTime.of(14, 45), LocalTime.of(15, 0)),
     )
 
-    whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1, room2, room3)
+    whenever(locationsInsidePrisonClient.getLocationById(room1.id)) doReturn room1
+    whenever(locationsInsidePrisonClient.getLocationById(room2.id)) doReturn room2
 
     val response = service.checkAvailability(request)
 
@@ -212,18 +201,9 @@ class AvailabilityServiceTest {
       assertThat(alternatives).hasSize(3)
       assertThat(alternatives).extracting("main").containsAll(
         listOf(
-          LocationAndInterval(
-            prisonLocKey = room2.key,
-            interval = Interval(start = LocalTime.of(12, 30), end = LocalTime.of(13, 0)),
-          ),
-          LocationAndInterval(
-            prisonLocKey = room2.key,
-            interval = Interval(start = LocalTime.of(12, 45), end = LocalTime.of(13, 15)),
-          ),
-          LocationAndInterval(
-            prisonLocKey = room2.key,
-            interval = Interval(start = LocalTime.of(13, 0), end = LocalTime.of(13, 30)),
-          ),
+          locationAndInterval(room2, start = LocalTime.of(12, 30), end = LocalTime.of(13, 0)),
+          locationAndInterval(room2, start = LocalTime.of(12, 45), end = LocalTime.of(13, 15)),
+          locationAndInterval(room2, start = LocalTime.of(13, 0), end = LocalTime.of(13, 30)),
         ),
       )
     }
@@ -231,19 +211,24 @@ class AvailabilityServiceTest {
 
   @Test
   fun `No options are provided when room is busy and requested times are outside the start and end day times`() {
+    whenever(
+      videoAppointmentRepository.findVideoAppointmentsAtPrison(
+        forDate = any(),
+        forPrison = any(),
+        forLocationIds = anyList(),
+      ),
+    ) doReturn room3VideoAppointments
+
     // Request for a time outside the start/end times of the day
     val request = AvailabilityRequest(
       bookingType = BookingType.COURT,
       courtOrProbationCode = "TESTC",
       prisonCode = WANDSWORTH,
       date = LocalDate.now(),
-      mainAppointment = LocationAndInterval(
-        prisonLocKey = room3.key,
-        interval = Interval(start = LocalTime.of(18, 0), end = LocalTime.of(19, 0)),
-      ),
+      mainAppointment = locationAndInterval(room3, start = LocalTime.of(18, 0), end = LocalTime.of(19, 0)),
     )
 
-    whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1, room2, room3)
+    whenever(locationsInsidePrisonClient.getLocationById(room3.id)) doReturn room3
 
     val response = service.checkAvailability(request)
 
@@ -257,20 +242,25 @@ class AvailabilityServiceTest {
 
   @Test
   fun `Excludes appointments with the same videoBookingId as vlbIdToExclude`() {
+    whenever(
+      videoAppointmentRepository.findVideoAppointmentsAtPrison(
+        forDate = any(),
+        forPrison = any(),
+        forLocationIds = anyList(),
+      ),
+    ) doReturn room1VideoAppointments
+
     // Request to exclude certain videoBookingId
     val request = AvailabilityRequest(
       bookingType = BookingType.COURT,
       courtOrProbationCode = "TESTC",
       prisonCode = WANDSWORTH,
       date = LocalDate.now(),
-      mainAppointment = LocationAndInterval(
-        prisonLocKey = room1.key,
-        interval = Interval(start = LocalTime.of(10, 0), end = LocalTime.of(11, 0)),
-      ),
+      mainAppointment = locationAndInterval(room1, start = LocalTime.of(10, 0), end = LocalTime.of(11, 0)),
       vlbIdToExclude = 2L,
     )
 
-    whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1, room2, room3)
+    whenever(locationsInsidePrisonClient.getLocationById(room1.id)) doReturn room1
 
     val response = service.checkAvailability(request)
 
@@ -284,20 +274,25 @@ class AvailabilityServiceTest {
 
   @Test
   fun `Includes appointments not matching vlbIdToExclude`() {
+    whenever(
+      videoAppointmentRepository.findVideoAppointmentsAtPrison(
+        forDate = any(),
+        forPrison = any(),
+        forLocationIds = anyList(),
+      ),
+    ) doReturn room1VideoAppointments
+
     // Request to exclude certain videoBookingId
     val request = AvailabilityRequest(
       bookingType = BookingType.COURT,
       courtOrProbationCode = "TESTC",
       prisonCode = WANDSWORTH,
       date = LocalDate.now(),
-      mainAppointment = LocationAndInterval(
-        prisonLocKey = room1.key,
-        interval = Interval(start = LocalTime.of(10, 0), end = LocalTime.of(11, 0)),
-      ),
+      mainAppointment = locationAndInterval(room1, start = LocalTime.of(10, 0), end = LocalTime.of(11, 0)),
       vlbIdToExclude = 5L,
     )
 
-    whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1, room2, room3)
+    whenever(locationsInsidePrisonClient.getLocationById(room1.id)) doReturn room1
 
     val response = service.checkAvailability(request)
 
@@ -316,18 +311,9 @@ class AvailabilityServiceTest {
       courtOrProbationCode = "TESTC",
       prisonCode = WANDSWORTH,
       date = today(),
-      preAppointment = LocationAndInterval(
-        prisonLocKey = room1.key,
-        interval = Interval(start = LocalTime.of(9, 0), end = LocalTime.of(10, 0)),
-      ),
-      mainAppointment = LocationAndInterval(
-        prisonLocKey = room1.key,
-        interval = Interval(start = LocalTime.of(10, 0), end = LocalTime.of(11, 0)),
-      ),
-      postAppointment = LocationAndInterval(
-        prisonLocKey = room1.key,
-        interval = Interval(start = LocalTime.of(11, 0), end = LocalTime.of(12, 0)),
-      ),
+      preAppointment = locationAndInterval(room1, start = LocalTime.of(9, 0), end = LocalTime.of(10, 0)),
+      mainAppointment = locationAndInterval(room1, start = LocalTime.of(10, 0), end = LocalTime.of(11, 0)),
+      postAppointment = locationAndInterval(room1, start = LocalTime.of(11, 0), end = LocalTime.of(12, 0)),
       vlbIdToExclude = 2L,
     )
 
@@ -357,7 +343,8 @@ class AvailabilityServiceTest {
         locationId = room1.id,
       ),
     )
-    whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1)
+
+    whenever(locationsInsidePrisonClient.getLocationById(room1.id)) doReturn room1
 
     with(service.checkAvailability(existingCourtBookingRequest)) {
       availabilityOk isBool true
@@ -375,10 +362,7 @@ class AvailabilityServiceTest {
       courtOrProbationCode = "TESTC",
       prisonCode = WANDSWORTH,
       date = today(),
-      mainAppointment = LocationAndInterval(
-        prisonLocKey = room1.key,
-        interval = Interval(start = LocalTime.of(10, 0), end = LocalTime.of(11, 0)),
-      ),
+      mainAppointment = locationAndInterval(room1, start = LocalTime.of(10, 0), end = LocalTime.of(11, 0)),
       vlbIdToExclude = 2L,
     )
 
@@ -391,7 +375,8 @@ class AvailabilityServiceTest {
         endTime = LocalTime.of(11, 0),
       ),
     )
-    whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1)
+
+    whenever(locationsInsidePrisonClient.getLocationById(room1.id)) doReturn room1
 
     with(service.checkAvailability(existingCourtBookingRequest)) {
       availabilityOk isBool true
@@ -409,10 +394,7 @@ class AvailabilityServiceTest {
       courtOrProbationCode = "TESTP",
       prisonCode = WANDSWORTH,
       date = today(),
-      mainAppointment = LocationAndInterval(
-        prisonLocKey = room2.key,
-        interval = Interval(start = LocalTime.of(11, 0), end = LocalTime.of(12, 0)),
-      ),
+      mainAppointment = locationAndInterval(room2, start = LocalTime.of(11, 0), end = LocalTime.of(12, 0)),
       vlbIdToExclude = 3L,
     )
 
@@ -425,7 +407,8 @@ class AvailabilityServiceTest {
         endTime = LocalTime.of(12, 0),
       ),
     )
-    whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room2)
+
+    whenever(locationsInsidePrisonClient.getLocationById(room2.id)) doReturn room2
 
     with(service.checkAvailability(existingProbationBookingRequest)) {
       availabilityOk isBool true
@@ -438,7 +421,7 @@ class AvailabilityServiceTest {
 
   @Test
   fun `is available if request matches existing court booking main hearing booking date, time and location`() {
-    whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room1)
+    whenever(locationsInsidePrisonClient.getLocationById(room1.id)) doReturn room1
 
     val request = amendCourtBookingRequest(
       prisonCode = WANDSWORTH,
@@ -466,7 +449,7 @@ class AvailabilityServiceTest {
 
   @Test
   fun `is available if request matches existing probation booking meeting date, time and location`() {
-    whenever(locationsInsidePrisonClient.getLocationsByKeys(any())) doReturn listOf(room2)
+    whenever(locationsInsidePrisonClient.getLocationById(room2.id)) doReturn room2
 
     val request = amendProbationBookingRequest(
       prisonCode = WANDSWORTH,


### PR DESCRIPTION
The is one of a few PR's moving towards adding the DPS location ID to replace the use of location key.  Other than changes to the availability checker this change is mainly cosmetic.  Underneath only the availability has changed to work with DPS location IDs.

No UI changes should be made until there service works for both the key and ID.