### PR TITLE
BAVL-1309 reworking the search endpoint to support search by both location ID or location key.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/VideoBookingSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/VideoBookingSearchRequest.kt
@@ -1,11 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.NotBlank
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.response.BookingStatus
 import java.time.LocalDate
 import java.time.LocalTime
+import java.util.UUID
 
 @Schema(
   description =
@@ -21,9 +24,16 @@ data class VideoBookingSearchRequest(
   @Schema(description = "The prisoner number (NOMIS ID)", example = "A1234AA")
   val prisonerNumber: String,
 
-  @field:NotBlank(message = "The location key is mandatory")
+  // TODO this is going to replace the location key
+  @Schema(
+    description = "The unique UUID for the location where the appointment takes place. The id field from the locations-inside-prison service.",
+    example = "a4fe3fef-34fd-4354fde-a12efe",
+  )
+  val dpsLocationId: UUID?,
+
+  @Deprecated(message = "Use dpsLocationId instead")
   @Schema(description = "The location key for the appointment", example = "PVI-A-1-001")
-  val locationKey: String,
+  val locationKey: String?,
 
   @Schema(description = "The date for which the appointment starts", example = "2022-12-23")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "uuuu-MM-dd")
@@ -39,4 +49,8 @@ data class VideoBookingSearchRequest(
 
   @Schema(description = "The status of the booking to match, defaults to ACTIVE", example = "ACTIVE")
   val statusCode: BookingStatus? = BookingStatus.ACTIVE,
-)
+) {
+  @JsonIgnore
+  @AssertTrue(message = "You must provide either a location id or a location key for search")
+  private fun isInvalidLocation() = locationKey != null || dpsLocationId != null
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsService.kt
@@ -58,22 +58,27 @@ class VideoLinkBookingsService(
   }
 
   fun findMatchingVideoLinkBooking(searchRequest: VideoBookingSearchRequest, user: User): VideoLinkBooking {
-    val location = locationsService.getLocationByKey(searchRequest.locationKey)
-      ?: throw EntityNotFoundException("Location with key ${searchRequest.locationKey} not found")
+    // TODO when UI's moved over to location ID can remove the location key.
+    val locationId = when {
+      searchRequest.dpsLocationId != null -> locationsService.getLocationById(searchRequest.dpsLocationId)?.dpsLocationId
+        ?: throw EntityNotFoundException("Location with ID ${searchRequest.dpsLocationId} not found")
+      else -> locationsService.getLocationByKey(searchRequest.locationKey!!)?.dpsLocationId
+        ?: throw EntityNotFoundException("Location with key ${searchRequest.locationKey} not found")
+    }
 
     val matchingAppointment = when (searchRequest.statusCode) {
       BookingStatus.ACTIVE ->
         videoAppointmentRepository.findActiveVideoAppointment(
           prisonerNumber = searchRequest.prisonerNumber,
           appointmentDate = searchRequest.date,
-          prisonLocationId = location.dpsLocationId,
+          prisonLocationId = locationId,
           startTime = searchRequest.startTime,
           endTime = searchRequest.endTime,
         )
       BookingStatus.CANCELLED -> videoAppointmentRepository.findLatestCancelledVideoAppointment(
         prisonerNumber = searchRequest.prisonerNumber,
         appointmentDate = searchRequest.date,
-        prisonLocationId = location.dpsLocationId,
+        prisonLocationId = locationId,
         startTime = searchRequest.startTime,
         endTime = searchRequest.endTime,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoLinkBookingIntegrationTest.kt
@@ -1781,7 +1781,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
 
   @Test
   @Sql("classpath:integration-test-data/seed-search-for-booking.sql")
-  fun `should find matching court video link bookings`() {
+  fun `should find matching court video link bookings using location key`() {
     val location1 = pentonvilleLocation.copy(id = UUID.fromString("b13f9018-f22d-456f-a690-d80e3d0feb5f"))
     locationsInsidePrisonApi().stubGetLocationByKey(location1)
     locationsInsidePrisonApi().stubGetLocationById(location1)
@@ -1793,6 +1793,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
         date = today(),
         startTime = LocalTime.of(12, 0),
         endTime = LocalTime.of(13, 0),
+        dpsLocationId = null,
       ),
       COURT_USER,
     ).videoLinkBookingId isEqualTo 1000
@@ -1808,6 +1809,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
         date = tomorrow(),
         startTime = LocalTime.of(9, 0),
         endTime = LocalTime.of(10, 0),
+        dpsLocationId = null,
       ),
       COURT_USER,
     ).videoLinkBookingId isEqualTo 3000
@@ -1815,7 +1817,7 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
 
   @Test
   @Sql("classpath:integration-test-data/seed-search-for-booking.sql")
-  fun `should find matching CANCELLED court video link bookings`() {
+  fun `should find matching CANCELLED court video link bookings using location key`() {
     val location = pentonvilleLocation.copy(id = UUID.fromString("ba0df03b-7864-47d5-9729-0301b74ecbe2"), key = "PVI-78910")
     locationsInsidePrisonApi().stubGetLocationByKey(location)
     locationsInsidePrisonApi().stubGetLocationById(location)
@@ -1828,9 +1830,67 @@ class VideoLinkBookingIntegrationTest : SqsIntegrationTestBase() {
         startTime = LocalTime.of(9, 0),
         endTime = LocalTime.of(10, 0),
         statusCode = BookingStatus.CANCELLED,
+        dpsLocationId = null,
       ),
       COURT_USER,
     ).videoLinkBookingId isEqualTo 4000
+  }
+
+  @Test
+  @Sql("classpath:integration-test-data/seed-search-for-booking-by-location_id.sql")
+  fun `should find matching court video link bookings using location id`() {
+    val location1 = pentonvilleLocation.copy(id = UUID.fromString("b13f9018-f22d-456f-a690-d80e3d0feb5f"))
+    locationsInsidePrisonApi().stubGetLocationByKey(location1)
+    locationsInsidePrisonApi().stubGetLocationById(location1)
+
+    webTestClient.searchForBooking(
+      VideoBookingSearchRequest(
+        prisonerNumber = "123456",
+        locationKey = location1.key,
+        date = today(),
+        startTime = LocalTime.of(12, 0),
+        endTime = LocalTime.of(13, 0),
+        dpsLocationId = null,
+      ),
+      COURT_USER,
+    ).videoLinkBookingId isEqualTo -1000
+
+    val location2 = pentonvilleLocation.copy(id = UUID.fromString("ba0df03b-7864-47d5-9729-0301b74ecbe2"), key = "PVI-78910")
+    locationsInsidePrisonApi().stubGetLocationByKey(location2)
+    locationsInsidePrisonApi().stubGetLocationById(location2)
+
+    webTestClient.searchForBooking(
+      VideoBookingSearchRequest(
+        prisonerNumber = "78910",
+        locationKey = null,
+        date = tomorrow().plusDays(1),
+        startTime = LocalTime.of(9, 0),
+        endTime = LocalTime.of(10, 0),
+        dpsLocationId = location2.id,
+      ),
+      COURT_USER,
+    ).videoLinkBookingId isEqualTo -3000
+  }
+
+  @Test
+  @Sql("classpath:integration-test-data/seed-search-for-booking-by-location_id.sql")
+  fun `should find matching CANCELLED court video link bookings using location id`() {
+    val location = pentonvilleLocation.copy(id = UUID.fromString("ba0df03b-7864-47d5-9729-0301b74ecbe2"), key = "PVI-78910")
+    locationsInsidePrisonApi().stubGetLocationByKey(location)
+    locationsInsidePrisonApi().stubGetLocationById(location)
+
+    webTestClient.searchForBooking(
+      VideoBookingSearchRequest(
+        prisonerNumber = "78910",
+        locationKey = null,
+        date = tomorrow().plusDays(1),
+        startTime = LocalTime.of(9, 0),
+        endTime = LocalTime.of(10, 0),
+        statusCode = BookingStatus.CANCELLED,
+        dpsLocationId = location.id,
+      ),
+      COURT_USER,
+    ).videoLinkBookingId isEqualTo -4000
   }
 
   private fun WebTestClient.createBookingFails(request: CreateVideoBookingRequest, user: User) = this

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/VideoBookingSearchRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/VideoBookingSearchRequestTest.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.tomorrow
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.wandsworthLocation
+import java.time.LocalTime
+
+class VideoBookingSearchRequestTest : ValidatorBase<VideoBookingSearchRequest>() {
+  private val request = VideoBookingSearchRequest(
+    prisonerNumber = "123456",
+    locationKey = wandsworthLocation.key,
+    date = tomorrow(),
+    startTime = LocalTime.of(12, 0),
+    endTime = LocalTime.of(13, 0),
+    dpsLocationId = wandsworthLocation.id,
+  )
+
+  @Test
+  fun `should be no errors for valid requests`() {
+    assertNoErrors(request)
+    assertNoErrors(request.copy(locationKey = null))
+    assertNoErrors(request.copy(dpsLocationId = null))
+  }
+
+  @Test
+  fun `should fail when location id and key are missing`() {
+    request.copy(dpsLocationId = null, locationKey = null) failsWithSingle ModelError("invalidLocation", "You must provide either a location id or a location key for search")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoLinkBookingsServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service
 
 import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -10,6 +11,8 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.COURT_USER
@@ -237,8 +240,8 @@ class VideoLinkBookingsServiceTest {
   }
 
   @Nested
-  @DisplayName("Tests for findMatchingVideoLinkBooking")
-  inner class FindMatchingBookings {
+  @DisplayName("Tests for findMatchingVideoLinkBooking by location key")
+  inner class FindMatchingBookingsByKey {
 
     @Test
     fun `should find a matching court video link booking for court user`() {
@@ -248,6 +251,7 @@ class VideoLinkBookingsServiceTest {
         date = tomorrow(),
         startTime = LocalTime.of(12, 0),
         endTime = LocalTime.of(13, 0),
+        dpsLocationId = null,
       )
 
       val booking = courtBooking()
@@ -297,6 +301,7 @@ class VideoLinkBookingsServiceTest {
         startTime = LocalTime.of(12, 0),
         endTime = LocalTime.of(13, 0),
         statusCode = BookingStatus.CANCELLED,
+        dpsLocationId = null,
       )
 
       val booking = courtBooking()
@@ -337,6 +342,7 @@ class VideoLinkBookingsServiceTest {
         date = tomorrow(),
         startTime = LocalTime.of(12, 0),
         endTime = LocalTime.of(13, 0),
+        dpsLocationId = null,
       )
 
       val booking = courtBooking()
@@ -382,6 +388,180 @@ class VideoLinkBookingsServiceTest {
         date = tomorrow(),
         startTime = LocalTime.of(12, 0),
         endTime = LocalTime.of(13, 0),
+        dpsLocationId = null,
+      )
+
+      whenever(
+        videoAppointmentRepository.findActiveVideoAppointment(
+          any(),
+          any(),
+          any(),
+          any(),
+          any(),
+        ),
+      ) doReturn null
+
+      val error = assertThrows<EntityNotFoundException> { service.findMatchingVideoLinkBooking(searchRequest, COURT_USER) }
+
+      error.message isEqualTo "Video booking not found matching search criteria $searchRequest"
+    }
+  }
+
+  @Nested
+  @DisplayName("Tests for findMatchingVideoLinkBooking by location ID")
+  inner class FindMatchingBookingsById {
+
+    @AfterEach
+    fun verifyNoCallsToLocationsServiceByKey() {
+      verify(locationsService, never()).getLocationByKey(any())
+    }
+
+    @Test
+    fun `should find a matching court video link booking for court user`() {
+      val searchRequest = VideoBookingSearchRequest(
+        prisonerNumber = "123456",
+        locationKey = null,
+        date = tomorrow(),
+        startTime = LocalTime.of(12, 0),
+        endTime = LocalTime.of(13, 0),
+        dpsLocationId = wandsworthLocation.id,
+      )
+
+      val booking = courtBooking()
+        .addAppointment(
+          prison = prison(prisonCode = WANDSWORTH),
+          prisonerNumber = searchRequest.prisonerNumber,
+          appointmentType = AppointmentType.VLB_COURT_PRE.name,
+          date = searchRequest.date,
+          startTime = LocalTime.of(11, 0),
+          endTime = LocalTime.of(12, 0),
+          locationId = wandsworthLocation.id,
+        )
+        .addAppointment(
+          prison = prison(prisonCode = WANDSWORTH),
+          prisonerNumber = searchRequest.prisonerNumber,
+          appointmentType = AppointmentType.VLB_COURT_MAIN.name,
+          date = searchRequest.date,
+          startTime = searchRequest.startTime,
+          endTime = searchRequest.endTime,
+          locationId = wandsworthLocation.id,
+        )
+
+      whenever(
+        videoAppointmentRepository.findActiveVideoAppointment(
+          prisonerNumber = "123456",
+          appointmentDate = tomorrow(),
+          prisonLocationId = wandsworthLocation.id,
+          startTime = LocalTime.of(12, 0),
+          endTime = LocalTime.of(13, 0),
+        ),
+      ) doReturn videoAppointment(booking, booking.appointments().second())
+
+      whenever(videoBookingRepository.findById(booking.videoBookingId)) doReturn Optional.of(booking)
+
+      service.findMatchingVideoLinkBooking(searchRequest, COURT_USER) isEqualTo booking.toModel(
+        locations = setOf(wandsworthLocation.toModel()),
+        courtHearingTypeDescription = "Tribunal",
+      )
+    }
+
+    @Test
+    fun `should match with the latest lastUpdated CANCELLED court video link booking`() {
+      val searchRequest = VideoBookingSearchRequest(
+        prisonerNumber = "123456",
+        locationKey = null,
+        date = tomorrow(),
+        startTime = LocalTime.of(12, 0),
+        endTime = LocalTime.of(13, 0),
+        statusCode = BookingStatus.CANCELLED,
+        dpsLocationId = wandsworthLocation.id,
+      )
+
+      val booking = courtBooking()
+        .addAppointment(
+          prison = prison(prisonCode = WANDSWORTH),
+          prisonerNumber = searchRequest.prisonerNumber,
+          appointmentType = AppointmentType.VLB_COURT_MAIN.name,
+          date = searchRequest.date,
+          startTime = searchRequest.startTime,
+          endTime = searchRequest.endTime,
+          locationId = wandsworthLocation.id,
+        )
+        .apply { cancel(COURT_USER) }
+
+      whenever(
+        videoAppointmentRepository.findLatestCancelledVideoAppointment(
+          prisonerNumber = "123456",
+          appointmentDate = tomorrow(),
+          prisonLocationId = wandsworthLocation.id,
+          startTime = LocalTime.of(12, 0),
+          endTime = LocalTime.of(13, 0),
+        ),
+      ) doReturn videoAppointment(booking, booking.appointments().first())
+
+      whenever(videoBookingRepository.findById(booking.videoBookingId)) doReturn Optional.of(booking)
+
+      service.findMatchingVideoLinkBooking(searchRequest, COURT_USER) isEqualTo booking.toModel(
+        locations = setOf(wandsworthLocation.toModel()),
+        courtHearingTypeDescription = "Tribunal",
+      )
+    }
+
+    @Test
+    fun `should fail to find a matching Wandsworth video link booking for Risley prison user`() {
+      val searchRequest = VideoBookingSearchRequest(
+        prisonerNumber = "123456",
+        locationKey = null,
+        date = tomorrow(),
+        startTime = LocalTime.of(12, 0),
+        endTime = LocalTime.of(13, 0),
+        dpsLocationId = wandsworthLocation.id,
+      )
+
+      val booking = courtBooking()
+        .addAppointment(
+          prison = prison(prisonCode = WANDSWORTH),
+          prisonerNumber = searchRequest.prisonerNumber,
+          appointmentType = AppointmentType.VLB_COURT_PRE.name,
+          date = searchRequest.date,
+          startTime = LocalTime.of(11, 0),
+          endTime = LocalTime.of(12, 0),
+          locationId = wandsworthLocation.id,
+        )
+        .addAppointment(
+          prison = prison(prisonCode = WANDSWORTH),
+          prisonerNumber = searchRequest.prisonerNumber,
+          appointmentType = AppointmentType.VLB_COURT_MAIN.name,
+          date = searchRequest.date,
+          startTime = searchRequest.startTime,
+          endTime = searchRequest.endTime,
+          locationId = wandsworthLocation.id,
+        )
+
+      whenever(
+        videoAppointmentRepository.findActiveVideoAppointment(
+          prisonerNumber = "123456",
+          appointmentDate = tomorrow(),
+          prisonLocationId = wandsworthLocation.id,
+          startTime = LocalTime.of(12, 0),
+          endTime = LocalTime.of(13, 0),
+        ),
+      ) doReturn videoAppointment(booking, booking.appointments().second())
+
+      whenever(videoBookingRepository.findById(booking.videoBookingId)) doReturn Optional.of(booking)
+
+      assertThrows<CaseloadAccessException> { service.findMatchingVideoLinkBooking(searchRequest, PRISON_USER_RISLEY) }
+    }
+
+    @Test
+    fun `should throw entity not found when no matching video link booking`() {
+      val searchRequest = VideoBookingSearchRequest(
+        prisonerNumber = "123456",
+        locationKey = null,
+        date = tomorrow(),
+        startTime = LocalTime.of(12, 0),
+        endTime = LocalTime.of(13, 0),
+        dpsLocationId = wandsworthLocation.id,
       )
 
       whenever(

--- a/src/test/resources/integration-test-data/seed-search-for-booking-by-location_id.sql
+++ b/src/test/resources/integration-test-data/seed-search-for-booking-by-location_id.sql
@@ -1,0 +1,19 @@
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
+values (-1000, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
+values (-1000, 17, '123456', 'VLB_COURT_MAIN', 'comments about the hearing', 'b13f9018-f22d-456f-a690-d80e3d0feb5f'::uuid, current_date, '12:00', '13:00');
+
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
+values (-2000, 'COURT', 'CANCELLED', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp - interval '1 second');
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
+values (-2000, 17, '78910', 'VLB_COURT_MAIN', 'comments about the hearing', 'ba0df03b-7864-47d5-9729-0301b74ecbe2'::uuid, current_date + 2, '9:00', '10:00');
+
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
+values (-3000, 'COURT', 'ACTIVE', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
+values (-3000, 17, '78910', 'VLB_COURT_MAIN', 'comments about the hearing', 'ba0df03b-7864-47d5-9729-0301b74ecbe2'::uuid, current_date + 2, '9:00', '10:00');
+
+insert into video_booking (video_booking_id, booking_type, status_code, court_id, hearing_type, notes_for_staff, created_by, created_time)
+values (-4000, 'COURT', 'CANCELLED', 1, 'TRIBUNAL', 'comments about the hearing', 'test_user', current_timestamp);
+insert into prison_appointment (video_booking_id, prison_id, prisoner_number, appointment_type, notes_for_staff, prison_location_id, appointment_date,  start_time, end_time)
+values (-4000, 17, '78910', 'VLB_COURT_MAIN', 'comments about the hearing', 'ba0df03b-7864-47d5-9729-0301b74ecbe2'::uuid, current_date + 2, '9:00', '10:00');


### PR DESCRIPTION
This change prepares the search endpoint predominantly used by external UI services e.g. A&A to allow searching by location ID instead of location key.

When all calling services are migrated to using the ID then the key can be removed from the API endpoint.
