### PR TITLE
BAVL-1384 can only merge future meetings that are active. Cancelled bookings cannot be amended.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/MergeProbationRecallMeetingTypesJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/MergeProbationRecallMeetingTypesJob.kt
@@ -4,6 +4,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.StatusCode
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request.ProbationMeetingType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.repository.VideoBookingRepository
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.BookingHistoryService
@@ -30,7 +31,7 @@ class MergeProbationRecallMeetingTypesJob(
 
     val bookings = videoBookingRepository
       .findByProbationMeetingTypesOnOrAfterDate(legacyRecallMeetingTypes, now.toLocalDate())
-      .filter { probationMeeting -> probationMeeting.overallStartDateTime()?.isAfter(now) == true }
+      .filter { probationMeeting -> probationMeeting.isStatus(StatusCode.ACTIVE) && probationMeeting.overallStartDateTime()?.isAfter(now) == true }
       .onEach { probationMeeting ->
         probationMeeting.apply {
           probationMeetingType = ProbationMeetingType.RECALL.name

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/MergeProbationRecallMeetingTypesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/jobs/MergeProbationRecallMeetingTypesJobTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.service.jobs
 
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyList
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
@@ -15,7 +16,9 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.config.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.HistoryType
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.entity.VideoBooking
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PROBATION_USER
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.containsExactlyInAnyOrder
+import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.probationBooking
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.withProbationPrisonAppointment
@@ -101,6 +104,40 @@ class MergeProbationRecallMeetingTypesJobTest {
     job.runJob()
 
     verify(videoBookingRepository, never()).saveAllAndFlush(any<List<VideoBooking>>())
+    verifyNoInteractions(bookingHistoryService)
+  }
+
+  @Test
+  fun `should not merge inactive booking with FTR56 meeting type to RECALL`() {
+    val booking = probationBooking(meetingType = ProbationMeetingType.FTR56).withProbationPrisonAppointment().cancel(PROBATION_USER)
+
+    whenever { videoBookingRepository.findByProbationMeetingTypesOnOrAfterDate(listOf("FTR56", "RR"), now.toLocalDate()) } doReturn listOf(booking)
+
+    job.runJob()
+
+    booking.probationMeetingType isEqualTo "FTR56"
+    booking.amendedBy isEqualTo PROBATION_USER.username
+    // Note this is the cancellation time
+    booking.amendedTime isCloseTo now
+
+    verify(videoBookingRepository, never()).saveAllAndFlush(anyList<VideoBooking>())
+    verifyNoInteractions(bookingHistoryService)
+  }
+
+  @Test
+  fun `should not merge inactive booking with RR meeting type to RECALL`() {
+    val booking = probationBooking(meetingType = ProbationMeetingType.RR).withProbationPrisonAppointment().cancel(PROBATION_USER)
+
+    whenever { videoBookingRepository.findByProbationMeetingTypesOnOrAfterDate(listOf("FTR56", "RR"), now.toLocalDate()) } doReturn listOf(booking)
+
+    job.runJob()
+
+    booking.probationMeetingType isEqualTo "RR"
+    booking.amendedBy isEqualTo PROBATION_USER.username
+    // Note this is the cancellation time
+    booking.amendedTime isCloseTo now
+
+    verify(videoBookingRepository, never()).saveAllAndFlush(anyList<VideoBooking>())
     verifyNoInteractions(bookingHistoryService)
   }
 }


### PR DESCRIPTION
You can only merge active probation bookings via the booking history service.  You cannot amend inactive (cancelled) bookings.