### PR TITLE
BAVL-1399 add blocking from and to times to the request and response model objects to help define the initial contract.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationsInsidePrisonClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/locationsinsideprison/LocationsInsidePrisonClient.kt
@@ -36,6 +36,7 @@ class LocationsInsidePrisonClient(private val locationsInsidePrisonApiWebClient:
     .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
     .block()
 
+  @Deprecated("Use getLocationsById instead")
   @Cacheable(CacheConfiguration.LOCATION_BY_KEY_CACHE_NAME)
   fun getLocationByKey(key: String): Location? = locationsInsidePrisonApiWebClient.get()
     .uri("/locations/key/{key}", key)
@@ -45,6 +46,7 @@ class LocationsInsidePrisonClient(private val locationsInsidePrisonApiWebClient:
     .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
     .block()
 
+  @Deprecated("Use getLocationsById instead")
   fun getLocationsByKeys(keys: Set<String>): List<Location> = locationsInsidePrisonApiWebClient.post()
     .uri("/locations/keys")
     .bodyValue(keys)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttribute.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/entity/LocationAttribute.kt
@@ -150,7 +150,6 @@ class LocationAttribute private constructor(
     when (locationUsage) {
       LocationUsage.SHARED -> AvailabilityStatus.SHARED
       LocationUsage.PROBATION -> when {
-        // TODO need to add check here for the court or sentence attribute
         allowedParties.isNullOrBlank() -> AvailabilityStatus.PROBATION_ANY
         isPartyAllowed(probationTeam.code) -> AvailabilityStatus.PROBATION_ROOM
         else -> AvailabilityStatus.NONE

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/Location.kt
@@ -51,11 +51,19 @@ data class RoomAttributes(
 
   val schedule: List<RoomSchedule> = emptyList(),
 
-  @Schema(description = "The start date which a room is blocked from. Only applies to temporarily blocked rooms.")
+  @Schema(description = "The start date which a room is blocked from. Only applies to temporarily blocked rooms.", example = "2028-07-05")
   val blockedFrom: LocalDate? = null,
 
-  @Schema(description = "The end date which a room is blocked to. Only applies to temporarily blocked rooms.")
+  @Schema(description = "The end date which a room is blocked to. Only applies to temporarily blocked rooms.", example = "2028-07-06")
   val blockedTo: LocalDate? = null,
+
+  @Schema(description = "The start time which a location is blocked from. Only applies to temporarily blocked locations.", example = "10:00")
+  @JsonFormat(pattern = "HH:mm")
+  val blockedFromTime: LocalTime? = null,
+
+  @Schema(description = "The end time which a location is blocked to, must be on or after the blocked from date. Only applies to temporarily blocked locations.", example = "15:00")
+  @JsonFormat(pattern = "HH:mm")
+  val blockedToTime: LocalTime? = null,
 )
 
 @Schema(description = "The additional schedule of usage for a video room")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AmendDecoratedRoomRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/AmendDecoratedRoomRequest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.GroupSequence
@@ -9,6 +10,7 @@ import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationUsage
 import java.time.LocalDate
+import java.time.LocalTime
 
 @GroupSequence(AmendDecoratedRoomRequest::class, BlockedDateValidationExtension::class)
 data class AmendDecoratedRoomRequest(
@@ -29,12 +31,20 @@ data class AmendDecoratedRoomRequest(
   @Schema(description = "Optional comments for the decorated location, can be null", example = "Temporarily unavailable due to ongoing work", required = false)
   val comments: String? = null,
 
-  @Schema(description = "The start date which a location is blocked from. Only applies to temporarily blocked locations.", required = false)
+  @Schema(description = "The start date which a location is blocked from. Only applies to temporarily blocked locations.", example = "2028-07-05", required = false)
   val blockedFrom: LocalDate? = null,
 
   @field:FutureOrPresent(message = "The blocked to date must be in the future or present")
-  @Schema(description = "The end date which a location is blocked to, must be on or after the blocked from date. Only applies to temporarily blocked locations.", required = false)
+  @Schema(description = "The end date which a location is blocked to, must be on or after the blocked from date. Only applies to temporarily blocked locations.", example = "2028-07-06", required = false)
   val blockedTo: LocalDate? = null,
+
+  @Schema(description = "The start time which a location is blocked from. Only applies to temporarily blocked locations.", example = "10:00", required = false)
+  @JsonFormat(pattern = "HH:mm")
+  val blockedFromTime: LocalTime? = null,
+
+  @Schema(description = "The end time which a location is blocked to, must be on or after the blocked from date. Only applies to temporarily blocked locations.", example = "15:00", required = false)
+  @JsonFormat(pattern = "HH:mm")
+  val blockedToTime: LocalTime? = null,
 ) {
   @JsonIgnore
   @AssertTrue(message = "The blocked to must be on or after the blocked from date", groups = [BlockedDateValidationExtension::class])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateDecoratedRoomRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/model/request/CreateDecoratedRoomRequest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.request
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.GroupSequence
@@ -9,6 +10,7 @@ import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationStatus
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.model.LocationUsage
 import java.time.LocalDate
+import java.time.LocalTime
 
 @GroupSequence(CreateDecoratedRoomRequest::class, BlockedDateValidationExtension::class)
 data class CreateDecoratedRoomRequest(
@@ -29,12 +31,20 @@ data class CreateDecoratedRoomRequest(
   @Schema(description = "Optional comments for the decorated location, can be null", example = "Temporarily unavailable due to ongoing work", required = false)
   val comments: String? = null,
 
-  @Schema(description = "The start date which a location is blocked from. Only applies to temporarily blocked locations.", required = false)
+  @Schema(description = "The start date which a location is blocked from. Only applies to temporarily blocked locations.", example = "2028-07-05", required = false)
   val blockedFrom: LocalDate? = null,
 
   @field:FutureOrPresent(message = "The blocked to date must be in the future or present")
-  @Schema(description = "The end date which a location is blocked to, must be on or after the blocked from date. Only applies to temporarily blocked locations.", required = false)
+  @Schema(description = "The end date which a location is blocked to, must be on or after the blocked from date. Only applies to temporarily blocked locations.", example = "2028-07-06", required = false)
   val blockedTo: LocalDate? = null,
+
+  @Schema(description = "The start time which a location is blocked from. Only applies to temporarily blocked locations.", example = "10:00", required = false)
+  @JsonFormat(pattern = "HH:mm")
+  val blockedFromTime: LocalTime? = null,
+
+  @Schema(description = "The end time which a location is blocked to, must be on or after the blocked from date. Only applies to temporarily blocked locations.", example = "15:00", required = false)
+  @JsonFormat(pattern = "HH:mm")
+  val blockedToTime: LocalTime? = null,
 ) {
   @JsonIgnore
   @AssertTrue(message = "The blocked to must be on or after the blocked from date", groups = [BlockedDateValidationExtension::class])


### PR DESCRIPTION
This PR adds the blocking from and to times to aid define initial contract for any callers.

Note the values are not persisted at this point.