### PR TITLE
BAVL-1425: Adding south central probation teams

### DIFF
--- a/src/main/resources/migrations/common/V2026.08.03__south_central_probation_teams.sql
+++ b/src/main/resources/migrations/common/V2026.08.03__south_central_probation_teams.sql
@@ -1,0 +1,21 @@
+-- South Central probation teams
+insert into probation_team (code, description, enabled, read_only, notes, created_by, created_time, court_team)
+values
+    ('ALDSMC', 'Aldershot Magistrates – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('AMRSCC', 'Amersham Crown – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('AYLSCC', 'Aylesbury Crown – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('BASIMC', 'Basingstoke Magistrates – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('HYWCMC', 'High Wycombe Magistrates – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('IOWGCC', 'Isle of Wight Crown – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('IOWGMC', 'Isle of Wight Magistrates – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('MIKYMC', 'Milton Keynes Magistrates – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('OXFDCC', 'Oxford Crown – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('OXFDMC', 'Oxfordshire Magistrates – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('PORTCC', 'Portsmouth Crown – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('PORTMC', 'Portsmouth Magistrates – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('RDNGCC', 'Reading Crown – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('RDNGMC', 'Reading Magistrates – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('SLGHMC', 'Slough Magistrates – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('SOTMCC', 'Southampton Crown – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('SOTMMC', 'Southampton Magistrates – Probation', true, false, null, 'TIM', current_timestamp, true),
+    ('WNCSCC', 'Winchester Crown – Probation', true, false, null, 'TIM', current_timestamp, true);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationTeamsResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/ProbationTeamsResourceIntegrationTest.kt
@@ -34,17 +34,17 @@ class ProbationTeamsResourceIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:integration-test-data/seed-enabled-probation-team-data.sql")
   @Test
   fun `should return filtered and unfiltered probation teams`() {
-    probationTeamRepository.findAll() hasSize 197 // Including enabled, read ony, and not enabled
+    probationTeamRepository.findAll() hasSize 215 // Including enabled, read ony, and not enabled
 
     val enabledOnlyTeams = webTestClient.getProbationTeams(true)
-    enabledOnlyTeams hasSize 191
+    enabledOnlyTeams hasSize 209
     enabledOnlyTeams.all { it.enabled } isBool true
 
     val allTeams = webTestClient.getProbationTeams(false)
-    allTeams hasSize 193
-    allTeams.count { it.enabled } isEqualTo 191
+    allTeams hasSize 211
+    allTeams.count { it.enabled } isEqualTo 209
     allTeams.count { !it.enabled } isEqualTo 2
-    allTeams.count { it.courtTeam } isEqualTo 8
+    allTeams.count { it.courtTeam } isEqualTo 26
     allTeams.none { it.sentenceManagementTeam } isBool true
   }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -45,7 +45,7 @@ hmpps:
   sar:
     tests:
       attachments-expected: false
-      expected-flyway-schema-version: 2026.07.31
+      expected-flyway-schema-version: 2026.08.03
       expected-jpa-entity-schema:
         path: /sar/entity-schema.json
       expected-api-response:


### PR DESCRIPTION
Adds 18 more probation teams - these are court teams.
Contacts will be added manually in PREPROD and PROD (there is a script to generate these, but they are applied manually so contact details are not in GH).