### PR TITLE
BAVL-1431: Removed prisoner number from each report section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ To generate the file, simply run the integration test with the below env variabl
 SAR_GENERATE_ACTUAL=true
 
 e.g.
-SAR_GENERATE_ACTUAL=true ./gradlew integrationTest --tests "uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.sar.SubjectAccessRequestTemplateIntegrationTest"
+SAR_GENERATE_ACTUAL=true ./gradlew integrationTest --tests "uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.integration.sar.SubjectAccessRequestIntegrationTest"
 
 This will output a new file sar-generated-file.html.log into the src/test/resources folder.
+It will also create a SAR API response JSON file to test against.
 Rename this file to remove the .log extension and copy it into the src/test/resources/sar directory to act as the new template for comparison.
 
 [Further info here](https://github.com/ministryofjustice/hmpps-subject-access-request-lib/blob/main/README.md)

--- a/src/main/resources/sar/templates/sar_template.mustache
+++ b/src/main/resources/sar/templates/sar_template.mustache
@@ -14,7 +14,6 @@
     <h3>Video link booking</h3>
     <table class="summary-list">
         <tr><td>Prison name</td><td>{{ getPrisonName prisonCode }}</td></tr>
-        <tr><td>Prisoner number</td><td>{{ optionalString prisonerNumber }}</td></tr>
         <tr><td>Created date</td><td>{{ formatDate createdTime }}</td></tr>
         <tr><td>Booking type</td><td>{{ optionalValue appointmentType }}</td></tr>
         <tr><td>Appointment date</td><td>{{ formatDate appointmentDate }}</td></tr>

--- a/src/test/resources/sar/sar-generated-report.html
+++ b/src/test/resources/sar/sar-generated-report.html
@@ -237,7 +237,6 @@
     <h3>Video link booking</h3>
     <table class="summary-list">
         <tr><td>Prison name</td><td>Moorland (HMP &amp; YOI)</td></tr>
-        <tr><td>Prisoner number</td><td>A4567AZ</td></tr>
         <tr><td>Created date</td><td>01 January 2024, 1:00:00 am</td></tr>
         <tr><td>Booking type</td><td>VLB_PROBATION</td></tr>
         <tr><td>Appointment date</td><td>24 January 2099</td></tr>
@@ -254,7 +253,6 @@
     <h3>Video link booking</h3>
     <table class="summary-list">
         <tr><td>Prison name</td><td>Moorland (HMP &amp; YOI)</td></tr>
-        <tr><td>Prisoner number</td><td>A4567AZ</td></tr>
         <tr><td>Created date</td><td>01 January 2024, 1:00:00 am</td></tr>
         <tr><td>Booking type</td><td>VLB_COURT_MAIN</td></tr>
         <tr><td>Appointment date</td><td>24 January 2099</td></tr>


### PR DESCRIPTION
The prisoner number is provided to each SAR report via the PRN parameter.

OSAR team requested it not also be printed for each report line.
Also noticed README had a slight mistake - wrong test name to generated SAR files.
Updated the SAR HTML file to compare against.