### PR TITLE
BAVL-1426 show all A&A appointments booked into video link rooms instead of just A&A video type appointments.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoEventsByLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoEventsByLocationService.kt
@@ -35,8 +35,6 @@ class VideoEventsByLocationService(
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
-  private val nonBvlsVideoAppointmentTypes = listOf("VLOO", "VLAP", "VLLA", "VLPA")
-
   fun videoEventsByLocation(prisonCode: String, request: VideoEventRequest): VideoEventResponse {
     // Get the video link locations at this prison
     val videoLinkLocations = locationsService.getVideoLinkLocationsAtPrison(prisonCode, enabledOnly = false)
@@ -51,7 +49,7 @@ class VideoEventsByLocationService(
     val videoAppointmentEvents = if (activitiesAppointmentsClient.isAppointmentsRolledOutAt(prisonCode)) {
       activitiesAppointmentsClient
         .getScheduledAppointmentsBetween(prisonCode, request.startDate, request.endDate)
-        .filter { nonBvlsVideoAppointmentTypes.contains(it.appointmentCode()) }
+        .filterOutBvlsAppointmentTypes()
         .map { it.toBookedEvent() }
     } else {
       emptyList()
@@ -85,6 +83,8 @@ class VideoEventsByLocationService(
       },
     )
   }
+
+  private fun List<AppointmentSearchResult>.filterOutBvlsAppointmentTypes() = filterNot { listOf("VLB", "VLPM").contains(it.appointmentCode()) }
 
   fun PrisonAppointment.toBookedEvent() = BookedEvent(
     dpsLocationId = this.prisonLocationId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoEventsByLocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/resource/VideoEventsByLocationIntegrationTest.kt
@@ -96,15 +96,15 @@ class VideoEventsByLocationIntegrationTest : IntegrationTestBase() {
       assertThat(events[0].subTypeDescription).isEqualTo("Pre-sentence report (PSR)")
     }
 
-    // The A&A appointments should be filtered to video and in videoLocation2
+    // The A&A appointments should be filtered to chaplaincy, video and in videoLocation2
     with(videoEvents.locations[1]) {
       assertThat(localName).isEqualTo("Video room 2")
       assertThat(capacity).isNull()
-      assertThat(events).hasSize(2)
+      assertThat(events).hasSize(3)
       assertThat(events).extracting("eventType").containsOnly("APPOINTMENT")
       assertThat(events).extracting("dpsLocationId").containsOnly(videoLocation2.id)
-      assertThat(events).extracting("subType").containsAnyOf("VLOO", "VLLA")
-      assertThat(events).extracting("subTypeDescription").containsAnyOf("Video link - official other", "Video link - legal appointment")
+      assertThat(events).extracting("subType").containsAnyOf("VLOO", "VLLA", "CHAP")
+      assertThat(events).extracting("subTypeDescription").containsAnyOf("Video link - official other", "Video link - legal appointment", "Chaplaincy")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoEventsByLocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/service/VideoEventsByLocationServiceTest.kt
@@ -11,7 +11,6 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
-import org.slf4j.LoggerFactory
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.client.activitiesappointments.ActivitiesAppointmentsClient
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.PENTONVILLE
 import uk.gov.justice.digital.hmpps.hmppsbookavideolinkapi.helper.courtBooking
@@ -36,10 +35,6 @@ import java.time.LocalTime
 import java.util.UUID
 
 class VideoEventsByLocationServiceTest {
-  companion object {
-    private val log = LoggerFactory.getLogger(this::class.java)
-  }
-
   private val locationsService: LocationsService = mock()
   private val activitiesAppointmentsClient: ActivitiesAppointmentsClient = mock()
   private val prisonAppointmentRepository: PrisonAppointmentRepository = mock()
@@ -319,7 +314,7 @@ class VideoEventsByLocationServiceTest {
   }
 
   @Test
-  fun `should filter appointments to uncancelled, undeleted, non-BVLS appointment types only`() {
+  fun `should filter appointments to uncancelled, undeleted, all appointment types except BVLS types`() {
     whenever(activitiesAppointmentsClient.isAppointmentsRolledOutAt(prisonCode)).thenReturn(true)
     whenever(activitiesAppointmentsClient.getScheduledAppointmentsBetween(prisonCode, now(), now())).thenReturn(
       listOf(
@@ -382,7 +377,7 @@ class VideoEventsByLocationServiceTest {
 
     assertThat(response.locations[0].events).isEmpty()
     assertThat(response.locations[1].events).isEmpty()
-    assertThat(response.locations[2].events).hasSize(1)
+    assertThat(response.locations[2].events.map { it.subType }).containsExactlyInAnyOrder("CHAP", "VLPA")
 
     verify(locationsService).getVideoLinkLocationsAtPrison(prisonCode, enabledOnly = false)
     verify(activitiesAppointmentsClient).isAppointmentsRolledOutAt(prisonCode)


### PR DESCRIPTION
Prior to this change we would only see video type appointments from A&A being included as part of the video event results.  

This would not give a true representation of room usage because any A&A appointment can book into a video based room.

With this change we will now see all A&A appointments apart from the BVLS specific types (COURT and PROBATION) as these are mastered in BVLS (but synced to A&A so can be ignored).