### PR TITLE
BAVL-1426 when querying the A&A API we are only ever interested in appointments out of cell, so exclude them from search.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/client/activitiesappointments/ActivitiesAppointmentsClient.kt
@@ -161,7 +161,7 @@ class ActivitiesAppointmentsClient(private val activitiesAppointmentsApiWebClien
 
   private fun getPrisonAppointments(prisonCode: String, fromDate: LocalDate, toDate: LocalDate? = null) = activitiesAppointmentsApiWebClient.post()
     .uri("/appointments/{prisonCode}/search", prisonCode)
-    .bodyValue(AppointmentSearchRequest(startDate = fromDate, endDate = toDate))
+    .bodyValue(AppointmentSearchRequest(startDate = fromDate, endDate = toDate, inCell = false))
     .retrieve()
     .bodyToMono<List<AppointmentSearchResult>>()
     .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ActivitiesAppointmentsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsbookavideolinkapi/integration/wiremock/ActivitiesAppointmentsApiMockServer.kt
@@ -261,6 +261,7 @@ class ActivitiesAppointmentsApiMockServer : MockServer(8089) {
               AppointmentSearchRequest(
                 startDate = fromDate,
                 endDate = toDate,
+                inCell = false,
               ),
             ),
           ),


### PR DESCRIPTION
When searching for appointments in the A&A API we are not interested in in-cell appointments, this change excludes them from the search results when call the A&A API.